### PR TITLE
feat: setup  <Divider> component

### DIFF
--- a/frontend/src/components/Divider.tsx
+++ b/frontend/src/components/Divider.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+interface DividerProps {
+  orientation?: "horizontal" | "vertical";
+  label?: string;
+  className?: string;
+}
+
+export default function Divider({
+  orientation = "horizontal",
+  label,
+  className = "",
+}: DividerProps) {
+  if (orientation === "vertical") {
+    return (
+      <div className={`relative flex items-center justify-center w-px h-full bg-border-default ${className}`}>
+        {label && (
+          <span className="absolute bg-bg-primary px-2 text-xs text-text-muted">
+            {label}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`relative flex items-center w-full ${className}`}>
+      <div className="h-px w-full bg-border-default" />
+      {label && (
+        <span className="absolute left-1/2 -translate-x-1/2 bg-bg-primary px-2 text-xs text-text-muted whitespace-nowrap">
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a minimal Divider component with horizontal and vertical orientations.

- Horizontal: h-px w-full bg-border-default
- Vertical: w-px h-full bg-border-default
- Optional label centered over the divider, styled text-text-muted text-xs bg-bg-primary px-2

Closes #28 