### PR TITLE
feat(trade): introduce WalletAddressBadge for trusted Stellar identit…

### DIFF
--- a/frontend/src/components/trade/ContractInfo.tsx
+++ b/frontend/src/components/trade/ContractInfo.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { TradeDetail } from "@/types/trade";
+import { WalletAddressBadge } from "@/components/ui/WalletAddressBadge";
 
 interface ContractInfoProps {
   trade: TradeDetail;
@@ -60,6 +61,29 @@ export function ContractInfo({ trade }: ContractInfoProps) {
             </p>
           </div>
         ))}
+      </div>
+
+      <div className="mb-5 grid grid-cols-1 gap-3">
+        <div>
+          <p className="text-xs text-text-muted mb-1">Buyer Wallet</p>
+          <WalletAddressBadge
+            address={trade.buyer.walletAddress}
+            truncate="middle"
+            showCopy
+            showExplorer
+            className="w-full justify-between"
+          />
+        </div>
+        <div>
+          <p className="text-xs text-text-muted mb-1">Seller Wallet</p>
+          <WalletAddressBadge
+            address={trade.seller.walletAddress}
+            truncate="middle"
+            showCopy
+            showExplorer
+            className="w-full justify-between"
+          />
+        </div>
       </div>
 
       {/* Loss Ratios */}

--- a/frontend/src/components/trade/PartiesPanel.tsx
+++ b/frontend/src/components/trade/PartiesPanel.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { Star } from "lucide-react";
 import type { TradeParty } from "@/types/trade";
+import { WalletAddressBadge } from "@/components/ui/WalletAddressBadge";
 
 interface PartiesPanelProps {
   buyer: TradeParty;
@@ -16,9 +17,6 @@ function PartyCard({
   party: TradeParty;
   role: "BUYER" | "SELLER";
 }) {
-  const truncateWallet = (addr: string) =>
-    addr.length > 12 ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : addr;
-
   return (
     <div className="flex-1 bg-elevated rounded-lg p-4 border border-border-default">
       <p className="text-xs font-semibold tracking-widest text-text-muted mb-3">
@@ -42,9 +40,14 @@ function PartyCard({
           <p className="text-text-primary font-semibold text-sm truncate">
             {party.name}
           </p>
-          <p className="text-text-muted text-xs font-mono mt-0.5">
-            {truncateWallet(party.walletAddress)}
-          </p>
+          <div className="mt-1">
+            <WalletAddressBadge
+              address={party.walletAddress}
+              truncate="middle"
+              showCopy
+              showExplorer
+            />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/ui/WalletAddressBadge.tsx
+++ b/frontend/src/components/ui/WalletAddressBadge.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Clipboard, ExternalLink } from "lucide-react";
+
+export interface WalletAddressBadgeProps {
+  address: string;
+  truncate?: "start" | "middle" | "end";
+  showCopy?: boolean;
+  showExplorer?: boolean;
+  className?: string;
+}
+
+function truncateAddress(
+  address: string,
+  mode: WalletAddressBadgeProps["truncate"],
+): string {
+  if (address.length <= 14) {
+    return address;
+  }
+
+  if (mode === "start") {
+    return `...${address.slice(-10)}`;
+  }
+
+  if (mode === "end") {
+    return `${address.slice(0, 10)}...`;
+  }
+
+  // Figma requirement: first 6 + ... + last 4
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export function WalletAddressBadge({
+  address,
+  truncate = "middle",
+  showCopy = true,
+  showExplorer = false,
+  className,
+}: WalletAddressBadgeProps) {
+  const [copied, setCopied] = useState(false);
+  const displayAddress = useMemo(
+    () => truncateAddress(address, truncate),
+    [address, truncate],
+  );
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div
+      className={`group bg-elevated border border-border-default rounded-md px-2 py-1 font-mono text-sm inline-flex items-center gap-1.5 ${className ?? ""}`}
+    >
+      <span className="text-text-secondary">{displayAddress}</span>
+
+      {showCopy && (
+        <button
+          type="button"
+          onClick={() => void onCopy()}
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-text-primary"
+          aria-label="Copy wallet address"
+          title="Copy wallet address"
+        >
+          {copied ? (
+            <Check className="w-3.5 h-3.5 text-emerald" />
+          ) : (
+            <Clipboard className="w-3.5 h-3.5" />
+          )}
+        </button>
+      )}
+
+      {showExplorer && (
+        <a
+          href={`https://stellar.expert/explorer/public/account/${address}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-text-muted hover:text-gold"
+          aria-label="Open wallet in Stellar Expert"
+          title="Open wallet in Stellar Expert"
+        >
+          <ExternalLink className="w-3.5 h-3.5" />
+        </a>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #33 

…y display

Add a reusable WalletAddressBadge with configurable truncation, hover-revealed copy affordance, and Stellar Expert deep-link support, then integrate it into trade parties and contract details so wallet identity remains compact, verifiable, and actionable across core trade views.

