### PR TITLE
implement FormField component — label, input, hint, and error group

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@stellar/freighter-api": "^6.0.1",
+        "clsx": "^2.1.1",
         "lucide-react": "^1.6.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -2736,6 +2737,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
+    "clsx": "^2.1.1",
     "lucide-react": "^1.6.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/frontend/src/components/ui/FormField.tsx
+++ b/frontend/src/components/ui/FormField.tsx
@@ -11,7 +11,7 @@ export interface FormFieldProps {
   hint?: string;
   error?: string;
   className?: string;
-  children: React.ReactElement;
+  children: React.ReactElement<Record<string, unknown>>;
 }
 
 export function FormField({

--- a/frontend/src/components/ui/FormField.tsx
+++ b/frontend/src/components/ui/FormField.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import { clsx } from "clsx";
+import { Icon } from "./Icon";
+
+export interface FormFieldProps {
+  label: string;
+  name: string;
+  required?: boolean;
+  hint?: string;
+  error?: string;
+  className?: string;
+  children: React.ReactElement;
+}
+
+export function FormField({
+  label,
+  name,
+  required,
+  hint,
+  error,
+  className,
+  children,
+}: FormFieldProps) {
+  const hintId = `${name}-hint`;
+  const errorId = `${name}-error`;
+
+  // When error is present, hint is hidden (InputField L92 pattern).
+  // aria-describedby references only the visible descriptor.
+  const describedBy = error ? errorId : hint ? hintId : undefined;
+
+  // Inject id, aria-describedby, and aria-invalid into the child element
+  const enhanced = React.isValidElement(children)
+    ? React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        id: name,
+        "aria-describedby": describedBy,
+        "aria-invalid": error ? true : undefined,
+      })
+    : children;
+
+  return (
+    <div className={clsx("flex flex-col gap-1.5", className)}>
+      <label
+        htmlFor={name}
+        className="text-text-secondary text-sm font-medium"
+      >
+        {label}
+        {required && <span className="text-gold"> *</span>}
+      </label>
+
+      {enhanced}
+
+      {!error && hint && (
+        <p id={hintId} className="text-text-muted text-xs">
+          {hint}
+        </p>
+      )}
+
+      {error && (
+        <p
+          id={errorId}
+          className="text-status-danger text-xs mt-1 flex items-center gap-1"
+        >
+          <Icon name="alert-circle" size="xs" className="text-status-danger" />
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -2,3 +2,5 @@
 export { Icon } from "./Icon";
 export type { IconProps } from "./Icon";
 export { BentoCard } from "./BentoCard";
+export { FormField } from "./FormField";
+export type { FormFieldProps } from "./FormField";


### PR DESCRIPTION
This PR adds the `FormField` component in `frontend/src/components/ui/FormField.tsx` and re-exports it (along with `FormFieldProps`) from the barrel file `index.ts`. The `FormField` function accepts a label, name, optional hint, optional error, and a single child element, then uses `React.cloneElement` to inject `id`, `aria-describedby`, and `aria-invalid` onto the child so the surrounding label and descriptors are wired up for accessibility without the consumer having to manage those attributes manually. When an error string is present the hint is hidden and a danger-colored error row (with an `alert-circle` Icon) takes its place; when no error exists but a hint is provided, the hint renders beneath the input. The `clsx` package was added as a new dependency to handle conditional className merging inside the wrapper `<div>`.

The design keeps `FormField` intentionally agnostic about which input component it wraps — it only requires a single `React.ReactElement` child, and the child's type is declared as `React.ReactElement<Record<string, unknown>>` to satisfy React 19 / TypeScript strict mode without importing every possible input component type. This means the same `FormField` works around `<InputField>`, a plain `<input>`, or any future select/textarea component with zero coupling. The `aria-describedby` pointer is computed once at the top of the function (`hintId` / `errorId`) and conditionally passed through `cloneElement`, so there is exactly one source of truth for which descriptor element is visible versus referenced.

I verified this locally by running `npm run build` inside `frontend/` to confirm the TypeScript compilation succeeds with the updated `ReactElement` generic, checked that `clsx` resolves correctly in the lockfile, and confirmed no runtime errors when rendering `FormField` with and without the `error` and `hint` props in the dev server.

Closes https://github.com/KingFRANKHOOD/Amana/issues/31