### PR TITLE
fix: clean up .env.example — remove duplicate JWT_SECRET entry

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,6 @@
 PORT=4000
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
-JWT_SECRET=
 
 # Pinata IPFS
 PINATA_API_KEY=
@@ -26,4 +25,3 @@ REDIS_URL=redis://localhost:6379/0
 # SUPABASE_URL=...
 # SUPABASE_ANON_KEY=...
 # STELLAR_RPC_URL=https://soroban-testnet.stellar.org
-


### PR DESCRIPTION
This PR addresses issue #150 by:

- Removing the duplicate empty `JWT_SECRET` entry at the top of the file
- Keeping only the properly documented `JWT_SECRET` with example value

Fixes #150