### PR TITLE
trade controller prisma implementation

### DIFF
--- a/backend/src/__tests__/dispute.service.test.ts
+++ b/backend/src/__tests__/dispute.service.test.ts
@@ -1,0 +1,104 @@
+import { PrismaClient, TradeStatus, DisputeStatus } from "@prisma/client";
+import { TradeService, DisputeTradeStatusError, TradeAccessDeniedError } from "../services/trade.service";
+import { ContractService } from "../services/contract.service";
+
+function createMockPrisma() {
+    return {
+        trade: {
+            findFirst: jest.fn(),
+            findUnique: jest.fn(),
+        },
+        dispute: {
+            create: jest.fn(),
+        },
+    } as unknown as PrismaClient;
+}
+
+function createMockContractService() {
+    return {
+        buildInitiateDisputeTx: jest.fn(),
+    } as unknown as ContractService;
+}
+
+describe("TradeService - initiateDispute", () => {
+    let prisma: ReturnType<typeof createMockPrisma>;
+    let contractService: ReturnType<typeof createMockContractService>;
+    let service: TradeService;
+
+    beforeEach(() => {
+        prisma = createMockPrisma();
+        contractService = createMockContractService();
+        service = new TradeService(prisma as any, contractService as any);
+    });
+
+    const mockTrade = {
+        id: 1,
+        tradeId: "T123",
+        buyerAddress: "GA_BUYER",
+        sellerAddress: "GA_SELLER",
+        status: TradeStatus.FUNDED,
+        amountUsdc: "100",
+    };
+
+    it("successfully initiates a dispute for a FUNDED trade", async () => {
+        prisma.trade.findFirst = jest.fn().mockResolvedValue(mockTrade);
+        contractService.buildInitiateDisputeTx = jest.fn().mockResolvedValue({ unsignedXdr: "mock-xdr" });
+        prisma.dispute.create = jest.fn().mockResolvedValue({});
+
+        const result = await service.initiateDispute("T123", "GA_BUYER", "Reason string", "Category string");
+
+        expect(result.unsignedXdr).toBe("mock-xdr");
+        expect(contractService.buildInitiateDisputeTx).toHaveBeenCalledWith({
+            tradeId: "T123",
+            initiatorAddress: "GA_BUYER",
+            reasonHash: expect.any(String),
+        });
+        expect(prisma.dispute.create).toHaveBeenCalledWith({
+            data: {
+                tradeId: "T123",
+                initiator: "GA_BUYER",
+                reason: "Reason string",
+                status: DisputeStatus.OPEN,
+            },
+        });
+    });
+
+    it("successfully initiates a dispute for a DELIVERED trade", async () => {
+        prisma.trade.findFirst = jest.fn().mockResolvedValue({
+            ...mockTrade,
+            status: TradeStatus.DELIVERED,
+        });
+        contractService.buildInitiateDisputeTx = jest.fn().mockResolvedValue({ unsignedXdr: "mock-xdr" });
+
+        await service.initiateDispute("T123", "GA_SELLER", "Reason string", "Category string");
+
+        expect(contractService.buildInitiateDisputeTx).toHaveBeenCalled();
+    });
+
+    it("throws DisputeTradeStatusError if trade is in CREATED status", async () => {
+        prisma.trade.findFirst = jest.fn().mockResolvedValue({
+            ...mockTrade,
+            status: TradeStatus.CREATED,
+        });
+
+        await expect(
+            service.initiateDispute("T123", "GA_BUYER", "Reason", "Category")
+        ).rejects.toThrow(DisputeTradeStatusError);
+    });
+
+    it("throws TradeAccessDeniedError if caller is not buyer or seller", async () => {
+        prisma.trade.findFirst = jest.fn().mockResolvedValue(mockTrade);
+
+        await expect(
+            service.initiateDispute("T123", "GA_OTHER", "Reason", "Category")
+        ).rejects.toThrow(TradeAccessDeniedError);
+    });
+
+    it("throws error if trade is not found", async () => {
+        prisma.trade.findFirst = jest.fn().mockResolvedValue(null);
+
+        await expect(
+            service.initiateDispute("T999", "GA_BUYER", "Reason", "Category")
+        ).rejects.toThrow("Trade not found");
+    });
+});

--- a/backend/src/__tests__/trade.service.test.ts
+++ b/backend/src/__tests__/trade.service.test.ts
@@ -18,7 +18,7 @@ describe("TradeService", () => {
 
   beforeEach(() => {
     prisma = createMockPrisma();
-    service = new TradeService(prisma);
+    service = new TradeService(prisma, {} as any);
   });
 
   it("stores a pending trade with PENDING_SIGNATURE status", async () => {
@@ -26,16 +26,16 @@ describe("TradeService", () => {
 
     await service.createPendingTrade({
       tradeId: "4294967297",
-      buyer: "buyer-address",
-      seller: "seller-address",
+      buyerAddress: "buyer-address",
+      sellerAddress: "seller-address",
       amountUsdc: "15.5000000",
     });
 
     expect(prisma.trade.create).toHaveBeenCalledWith({
       data: {
         tradeId: "4294967297",
-        buyer: "buyer-address",
-        seller: "seller-address",
+        buyerAddress: "buyer-address",
+        sellerAddress: "seller-address",
         amountUsdc: "15.5000000",
         status: TradeStatus.PENDING_SIGNATURE,
       },
@@ -47,8 +47,8 @@ describe("TradeService", () => {
       {
         id: 1,
         tradeId: "T1",
-        buyer: "GA_CALLER",
-        seller: "GA_SELLER",
+        buyerAddress: "GA_CALLER",
+        sellerAddress: "GA_SELLER",
         amountUsdc: "100",
         status: TradeStatus.CREATED,
       },
@@ -64,7 +64,7 @@ describe("TradeService", () => {
     expect(prisma.trade.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
-          OR: [{ buyer: "GA_CALLER" }, { seller: "GA_CALLER" }],
+          OR: [{ buyerAddress: "GA_CALLER" }, { sellerAddress: "GA_CALLER" }],
         },
       })
     );
@@ -77,8 +77,8 @@ describe("TradeService", () => {
       {
         id: 2,
         tradeId: "T2",
-        buyer: "GA_CALLER",
-        seller: "GA_S2",
+        buyerAddress: "GA_CALLER",
+        sellerAddress: "GA_S2",
         amountUsdc: "200",
         status: TradeStatus.FUNDED,
       },
@@ -95,7 +95,7 @@ describe("TradeService", () => {
     expect(prisma.trade.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
-          OR: [{ buyer: "GA_CALLER" }, { seller: "GA_CALLER" }],
+          OR: [{ buyerAddress: "GA_CALLER" }, { sellerAddress: "GA_CALLER" }],
           status: TradeStatus.FUNDED,
         },
       })
@@ -106,8 +106,8 @@ describe("TradeService", () => {
     prisma.trade.findFirst = jest.fn().mockResolvedValue({
       id: 10,
       tradeId: "T10",
-      buyer: "GA_A",
-      seller: "GA_B",
+      buyerAddress: "GA_A",
+      sellerAddress: "GA_B",
       amountUsdc: "900",
       status: TradeStatus.CREATED,
     });

--- a/backend/src/controllers/trade.controller.ts
+++ b/backend/src/controllers/trade.controller.ts
@@ -2,13 +2,12 @@ import { TradeStatus } from "@prisma/client";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import type { Request, Response } from "express";
 import { AuthRequest } from "../middleware/auth.middleware";
-import { tradeRepository } from "../repositories/trade.repository";
 import {
   buildConfirmDeliveryTx,
   buildReleaseFundsTx,
   ContractService,
 } from "../services/contract.service";
-import { TradeAccessDeniedError, TradeService } from "../services/trade.service";
+import { TradeAccessDeniedError, TradeService, DisputeTradeStatusError } from "../services/trade.service";
 
 const CALLER_HEADER = "x-stellar-address";
 const AMOUNT_USDC_PATTERN = /^\d+(?:\.\d{1,7})?$/;
@@ -55,89 +54,12 @@ export function isBuyerOrAdmin(
   return tradeBuyer === caller || admins.has(caller);
 }
 
-export async function confirmDeliveryHandler(
-  req: Request,
-  res: Response,
-): Promise<void> {
-  const id = String(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
-  const caller = getCallerStellarAddress(req);
-  if (!caller) {
-    res.status(401).json({ error: "Missing X-Stellar-Address header" });
-    return;
-  }
-
-  const trade = tradeRepository.getById(id);
-  if (!trade) {
-    res.status(404).json({ error: "Trade not found" });
-    return;
-  }
-
-  if (trade.status !== "FUNDED") {
-    res.status(400).json({
-      error: `Trade must be FUNDED to confirm delivery (current: ${trade.status})`,
-    });
-    return;
-  }
-
-  if (!isBuyer(trade.buyerStellarAddress, caller)) {
-    res.status(403).json({ error: "Only the buyer may confirm delivery" });
-    return;
-  }
-
-  try {
-    const unsignedXdr = await buildConfirmDeliveryTx(trade, caller);
-    res.status(200).json({ unsignedXdr });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    res.status(500).json({ error: message });
-  }
-}
-
-export async function releaseFundsHandler(
-  req: Request,
-  res: Response,
-): Promise<void> {
-  const id = String(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
-  const caller = getCallerStellarAddress(req);
-  if (!caller) {
-    res.status(401).json({ error: "Missing X-Stellar-Address header" });
-    return;
-  }
-
-  const trade = tradeRepository.getById(id);
-  if (!trade) {
-    res.status(404).json({ error: "Trade not found" });
-    return;
-  }
-
-  if (trade.status !== "DELIVERED") {
-    res.status(400).json({
-      error: `Trade must be DELIVERED to release funds (current: ${trade.status})`,
-    });
-    return;
-  }
-
-  if (!isBuyerOrAdmin(trade.buyerStellarAddress, caller)) {
-    res
-      .status(403)
-      .json({ error: "Only the buyer or an admin may release funds" });
-    return;
-  }
-
-  try {
-    const unsignedXdr = await buildReleaseFundsTx(trade, caller);
-    res.status(200).json({ unsignedXdr });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    res.status(500).json({ error: message });
-  }
-}
 
 export class TradeController {
   constructor(
     private readonly tradeService: TradeService = new TradeService(),
     private readonly contractService: ContractService = new ContractService(),
-  ) {}
+  ) { }
 
   public createTrade = async (
     req: AuthRequest,
@@ -174,8 +96,8 @@ export class TradeController {
 
       await this.tradeService.createPendingTrade({
         tradeId,
-        buyer: buyerAddress,
-        seller: sellerAddress,
+        buyerAddress,
+        sellerAddress,
         amountUsdc: normalizedAmountUsdc,
       });
 
@@ -233,6 +155,139 @@ export class TradeController {
       return res
         .status(500)
         .json({ error: "Failed to build deposit transaction" });
+    }
+  };
+
+  public confirmDelivery = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    const id = String(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
+    const caller = getCallerStellarAddress(req);
+    if (!caller) {
+      res.status(401).json({ error: "Missing X-Stellar-Address header" });
+      return;
+    }
+
+    try {
+      const trade = await this.tradeService.getTradeById(id, caller);
+      if (!trade) {
+        res.status(404).json({ error: "Trade not found" });
+        return;
+      }
+
+      if (trade.status !== TradeStatus.FUNDED) {
+        res.status(400).json({
+          error: `Trade must be FUNDED to confirm delivery (current: ${trade.status})`,
+        });
+        return;
+      }
+
+      if (!isBuyer(trade.buyerAddress, caller)) {
+        res.status(403).json({ error: "Only the buyer may confirm delivery" });
+        return;
+      }
+
+      const unsignedXdr = await buildConfirmDeliveryTx(trade, caller);
+      res.status(200).json({ unsignedXdr });
+    } catch (error) {
+      if (error instanceof TradeAccessDeniedError) {
+        res.status(403).json({ error: "Forbidden" });
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+
+  public releaseFunds = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    const id = String(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
+    const caller = getCallerStellarAddress(req);
+    if (!caller) {
+      res.status(401).json({ error: "Missing X-Stellar-Address header" });
+      return;
+    }
+
+    try {
+      const trade = await this.tradeService.getTradeById(id, caller);
+      if (!trade) {
+        res.status(404).json({ error: "Trade not found" });
+        return;
+      }
+
+      if (trade.status !== TradeStatus.DELIVERED) {
+        res.status(400).json({
+          error: `Trade must be DELIVERED to release funds (current: ${trade.status})`,
+        });
+        return;
+      }
+
+      if (!isBuyerOrAdmin(trade.buyerAddress, caller)) {
+        res
+          .status(403)
+          .json({ error: "Only the buyer or an admin may release funds" });
+        return;
+      }
+
+      const unsignedXdr = await buildReleaseFundsTx(trade, caller);
+      res.status(200).json({ unsignedXdr });
+    } catch (error) {
+      if (error instanceof TradeAccessDeniedError) {
+        res.status(403).json({ error: "Forbidden" });
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+
+  public initiateDispute = async (
+    req: AuthRequest,
+    res: Response,
+  ): Promise<Response | void> => {
+    try {
+      const tradeId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+      if (!tradeId) {
+        return res.status(400).json({ error: "Trade id is required" });
+      }
+
+      const callerAddress = req.user?.walletAddress;
+      if (!callerAddress) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      const { reason, category } = req.body as { reason?: unknown; category?: unknown };
+      if (!reason || typeof reason !== "string") {
+        return res.status(400).json({ error: "Reason string is required" });
+      }
+      if (!category || typeof category !== "string") {
+        return res.status(400).json({ error: "Category string is required" });
+      }
+
+      const { unsignedXdr } = await this.tradeService.initiateDispute(
+        tradeId,
+        callerAddress,
+        reason,
+        category,
+      );
+
+      return res.status(200).json({ unsignedXdr });
+    } catch (error) {
+      if (error instanceof TradeAccessDeniedError) {
+        return res.status(403).json({ error: "Forbidden" });
+      }
+      if (error instanceof DisputeTradeStatusError) {
+        return res.status(400).json({ error: error.message });
+      }
+      if (error instanceof Error && error.message === "Trade not found") {
+        return res.status(404).json({ error: "Trade not found" });
+      }
+
+      console.error("Dispute initiation failed:", error);
+      return res.status(500).json({ error: "Failed to initiate dispute" });
     }
   };
   private isValidPublicKey(value: unknown): value is string {

--- a/backend/src/repositories/trade.repository.ts
+++ b/backend/src/repositories/trade.repository.ts
@@ -8,7 +8,7 @@ export const tradeRepository = {
   },
 
   upsert(record: TradeRecord): void {
-    trades.set(record.id, record);
+    trades.set(String(record.id), record);
   },
 
   /** Test helper */

--- a/backend/src/routes/trade.routes.ts
+++ b/backend/src/routes/trade.routes.ts
@@ -29,6 +29,9 @@ export function createTradeRouter(prisma: PrismaClient = defaultPrisma) {
 
   router.post("/", authMiddleware, tradeController.createTrade);
   router.post("/:id/deposit", authMiddleware, tradeController.buildDepositTx);
+  router.post("/:id/confirm", authMiddleware, tradeController.confirmDelivery);
+  router.post("/:id/release", authMiddleware, tradeController.releaseFunds);
+  router.post("/:id/dispute", authMiddleware, tradeController.initiateDispute);
 
   router.get("/", async (req, res) => {
     const callerAddress = requireHeaderAuth(req, res);

--- a/backend/src/services/contract.service.ts
+++ b/backend/src/services/contract.service.ts
@@ -86,7 +86,7 @@ function getNetworkPassphrase(): string {
  * Caller should sign and submit via a wallet / RPC.
  */
 export async function buildConfirmDeliveryTx(
-  trade: TradeRecord,
+  trade: Pick<Trade, "tradeId" | "status">,
   sourceAccountId: string,
 ): Promise<string> {
   if (trade.status !== "FUNDED") {
@@ -106,7 +106,7 @@ export async function buildConfirmDeliveryTx(
       contract.call(
         "confirm_delivery",
         StellarSdk.xdr.ScVal.scvU64(
-          StellarSdk.xdr.Uint64.fromString(trade.chainTradeId),
+          StellarSdk.xdr.Uint64.fromString(trade.tradeId),
         ),
       ),
     )
@@ -121,7 +121,7 @@ export async function buildConfirmDeliveryTx(
  * Builds an unsigned Soroban transaction XDR (base64) for `release_funds(trade_id)`.
  */
 export async function buildReleaseFundsTx(
-  trade: TradeRecord,
+  trade: Pick<Trade, "tradeId" | "status">,
   sourceAccountId: string,
 ): Promise<string> {
   if (trade.status !== "DELIVERED") {
@@ -141,8 +141,38 @@ export async function buildReleaseFundsTx(
       contract.call(
         "release_funds",
         StellarSdk.xdr.ScVal.scvU64(
-          StellarSdk.xdr.Uint64.fromString(trade.chainTradeId),
+          StellarSdk.xdr.Uint64.fromString(trade.tradeId),
         ),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(transaction);
+  return prepared.toXDR();
+}
+
+/**
+ * Builds an unsigned Soroban transaction XDR (base64) for `initiate_dispute(trade_id, initiator, reason_hash)`.
+ */
+export async function buildInitiateDisputeTx(
+  trade: { tradeId: string },
+  initiatorAddress: string,
+  reasonHash: string,
+): Promise<string> {
+  const server = getRpcServer(getRpcUrl());
+  const account = await server.getAccount(initiatorAddress);
+  const contract = new StellarSdk.Contract(getEscrowContractId());
+  const transaction = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "initiate_dispute",
+        StellarSdk.nativeToScVal(BigInt(trade.tradeId), { type: "u64" }),
+        StellarSdk.Address.fromString(initiatorAddress).toScVal(),
+        StellarSdk.nativeToScVal(reasonHash, { type: "string" }),
       ),
     )
     .setTimeout(30)
@@ -208,7 +238,7 @@ export class ContractService {
   }
 
   public async buildDepositTx(
-    trade: Pick<Trade, "tradeId" | "buyer" | "amountUsdc">,
+    trade: Pick<Trade, "tradeId" | "buyerAddress" | "amountUsdc">,
   ): Promise<BuildDepositTxResult> {
     if (!this.contractId) {
       throw new Error("CONTRACT_ID is not configured");
@@ -218,7 +248,7 @@ export class ContractService {
       throw new Error("USDC_CONTRACT_ID is not configured");
     }
 
-    const account = await this.rpcServer.getAccount(trade.buyer);
+    const account = await this.rpcServer.getAccount(trade.buyerAddress);
     const contract = new StellarSdk.Contract(this.contractId);
 
     // The current escrow contract pulls the buyer's USDC during `deposit()`,
@@ -268,6 +298,38 @@ export class ContractService {
           StellarSdk.nativeToScVal(BigInt(input.tradeId), { type: "u64" }),
           StellarSdk.nativeToScVal(input.driverNameHash, { type: "string" }),
           StellarSdk.nativeToScVal(input.driverIdHash, { type: "string" }),
+        ),
+      )
+      .setTimeout(DEFAULT_TIMEOUT_SECONDS)
+      .build();
+
+    const prepared = await this.rpcServer.prepareTransaction(transaction);
+    return { unsignedXdr: prepared.toXDR() };
+  }
+
+  /**
+   * Builds an unsigned Soroban XDR for `initiate_dispute(trade_id, initiator, reason_hash)`.
+   */
+  public async buildInitiateDisputeTx(input: {
+    tradeId: string;
+    initiatorAddress: string;
+    reasonHash: string;
+  }): Promise<{ unsignedXdr: string }> {
+    if (!this.contractId) throw new Error("CONTRACT_ID is not configured");
+
+    const account = await this.rpcServer.getAccount(input.initiatorAddress);
+    const contract = new StellarSdk.Contract(this.contractId);
+
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          "initiate_dispute",
+          StellarSdk.nativeToScVal(BigInt(input.tradeId), { type: "u64" }),
+          StellarSdk.Address.fromString(input.initiatorAddress).toScVal(),
+          StellarSdk.nativeToScVal(input.reasonHash, { type: "string" }),
         ),
       )
       .setTimeout(DEFAULT_TIMEOUT_SECONDS)

--- a/backend/src/services/trade.service.ts
+++ b/backend/src/services/trade.service.ts
@@ -1,10 +1,16 @@
-import { Prisma, PrismaClient, Trade, TradeStatus } from "@prisma/client";
+import crypto from "crypto";
+import { Prisma, PrismaClient, Trade, TradeStatus, DisputeStatus } from "@prisma/client";
 import { prisma as defaultPrisma } from "../lib/db";
+import { ContractService } from "./contract.service";
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
 
 export interface CreatePendingTradeInput {
   tradeId: string;
-  buyer: string;
-  seller: string;
+  buyerAddress: string;
+  sellerAddress: string;
   amountUsdc: string;
 }
 
@@ -24,8 +30,19 @@ export class TradeAccessDeniedError extends Error {
   }
 }
 
+export class DisputeTradeStatusError extends Error {
+  status = 400;
+  constructor(status: string) {
+    super(`Trade must be in FUNDED or DELIVERED status to initiate a dispute (current: ${status})`);
+    this.name = "DisputeTradeStatusError";
+  }
+}
+
 export class TradeService {
-  constructor(private readonly prisma: TradeDatabase = defaultPrisma) {}
+  constructor(
+    private readonly prisma: TradeDatabase = defaultPrisma,
+    private readonly contractService: ContractService = new ContractService(),
+  ) { }
 
   async createPendingTrade(input: CreatePendingTradeInput): Promise<Trade> {
     return this.prisma.trade.create({
@@ -43,7 +60,7 @@ export class TradeService {
     const orderBy = this.parseSort(filters.sort);
 
     const where: Prisma.TradeWhereInput = {
-      OR: [{ buyer: address }, { seller: address }],
+      OR: [{ buyerAddress: address }, { sellerAddress: address }],
       ...(filters.status ? { status: filters.status } : {}),
     };
 
@@ -86,7 +103,7 @@ export class TradeService {
       return null;
     }
 
-    if (trade.buyer !== callerAddress && trade.seller !== callerAddress) {
+    if (trade.buyerAddress !== callerAddress && trade.sellerAddress !== callerAddress) {
       throw new TradeAccessDeniedError();
     }
 
@@ -96,7 +113,7 @@ export class TradeService {
   async getUserStats(address: string) {
     const trades = await this.prisma.trade.findMany({
       where: {
-        OR: [{ buyer: address }, { seller: address }],
+        OR: [{ buyerAddress: address }, { sellerAddress: address }],
       },
       select: {
         amountUsdc: true,
@@ -138,8 +155,8 @@ export class TradeService {
     const allowedFields = new Set<string>([
       "id",
       "tradeId",
-      "buyer",
-      "seller",
+      "buyerAddress",
+      "sellerAddress",
       "amountUsdc",
       "status",
       "createdAt",
@@ -151,5 +168,46 @@ export class TradeService {
     }
 
     return { [field]: direction };
+  }
+
+  async initiateDispute(id: string, callerAddress: string, reason: string, category: string) {
+    const trade = await this.getTradeById(id, callerAddress);
+    if (!trade) {
+      throw new Error("Trade not found");
+    }
+
+    // Access check is already done by getTradeById, but let's be explicit
+    if (trade.buyerAddress !== callerAddress && trade.sellerAddress !== callerAddress) {
+      throw new TradeAccessDeniedError();
+    }
+
+    // Check status: FUNDED or DELIVERED
+    if (trade.status !== TradeStatus.FUNDED && trade.status !== TradeStatus.DELIVERED) {
+      throw new DisputeTradeStatusError(trade.status);
+    }
+
+    const reasonHash = sha256(reason);
+
+    // Build contract transaction
+    // Note: getTradeById handles both numeric and string IDs for local lookup,
+    // but the contract needs the tradeId (the blockchain-sourced one).
+    const { unsignedXdr } = await this.contractService.buildInitiateDisputeTx({
+      tradeId: trade.tradeId,
+      initiatorAddress: callerAddress,
+      reasonHash,
+    });
+
+    // Create DB record
+    // We store the plaintext reason for human review.
+    await (this.prisma as PrismaClient).dispute.create({
+      data: {
+        tradeId: trade.tradeId,
+        initiator: callerAddress,
+        reason,
+        status: DisputeStatus.OPEN,
+      },
+    });
+
+    return { unsignedXdr };
   }
 }

--- a/backend/src/types/trade.ts
+++ b/backend/src/types/trade.ts
@@ -1,15 +1,18 @@
 /** Off-chain trade record (DB mirror). Status updates after on-chain events per product flow. */
 export type TradeDbStatus =
+  | "PENDING_SIGNATURE"
   | "CREATED"
   | "FUNDED"
   | "DELIVERED"
-  | "COMPLETED";
+  | "COMPLETED"
+  | "DISPUTED"
+  | "CANCELLED";
 
 export interface TradeRecord {
-  id: string;
-  /** Soroban `u64` trade id as a decimal string. */
-  chainTradeId: string;
-  buyerStellarAddress: string;
-  sellerStellarAddress: string;
+  id: number;
+  tradeId: string;
+  buyerAddress: string;
+  sellerAddress: string;
+  amountUsdc: string;
   status: TradeDbStatus;
 }


### PR DESCRIPTION
This PR addresses two main objectives: aligning the 
TradeController
 with the Prisma database schema and implementing the POST /trades/:id/dispute endpoint.

1. Trade Controller Refactoring & Prisma Alignment
Removed In-Memory Repository: Eliminated the dependency on tradeRepository in production handlers. All trade operations now correctly query the Prisma database via 
TradeService
.
Type Alignment: Updated 
TradeRecord
 and 
TradeDbStatus
 in 
backend/src/types/trade.ts
 to match the Prisma schema. This included Renaming buyerStellarAddress -> buyerAddress and sellerStellarAddress -> sellerAddress.
Controller Cleanup: Moved standalone handlers for confirmDelivery and releaseFunds into the 
TradeController
 class to ensure consistent dependency injection and access to 
TradeService
.
Contract Service Update: Updated standalone transaction builders to use the correct Prisma 
Trade
 field names (tradeId instead of chainTradeId).
Fixes: Resolved the 404 "Trade not found" issue in production for fund releases and delivery confirmations by replacing the unpopulated in-memory map with actual database queries.
2. Dispute Initiation Endpoint
New Endpoint: Added POST /trades/:id/dispute to allow buyers and sellers to initiate a trade dispute.
Service Logic: Implemented 
initiateDispute
 in 
TradeService
 with SHA-256 hashing of the reason and persistence of 
Dispute
 records in the database.
Contract Integration: Added 
buildInitiateDisputeTx
 to 
ContractService
 for building the unsigned Soroban transaction.
Verification Results
 
trade.service.test.ts
 passed (10/10 tests).
 
dispute.service.test.ts
 passed (5/5 tests).
 Property naming consistency verified across services, controllers,.


Closes #154 
Closes #142 