### PR TITLE
chore: remove dist/ from git tracking and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 **/node_modules/
+# Any package `dist/` (includes backend TypeScript output)
 dist/
 coverage/
 .env

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
+
+# TypeScript emit from `npm run build` — never commit (merge noise, CI drift)
 dist/
+
 .env


### PR DESCRIPTION
Closes #152

---

Document that backend TypeScript emit (dist/) must not be committed. backend/.gitignore already listed dist/; clarified with a comment. Root dist/ rule already covers backend/dist; added a short comment. git rm --cached backend/dist had no matches on this branch (nothing tracked). If your fork still tracks dist/, run: git rm -r --cached backend/dist/

Made-with: Cursor