### PR TITLE
Fix: Enforce Design System Consistency for Mediator Authorization Status Badges

### DIFF
--- a/frontend/src/app/mediator/disputes/[id]/MediatorPanelClient.tsx
+++ b/frontend/src/app/mediator/disputes/[id]/MediatorPanelClient.tsx
@@ -13,6 +13,7 @@ import {
 import { signTransaction } from "@stellar/freighter-api";
 
 import { useFreighterIdentity } from "@/hooks/useFreighterIdentity";
+import { Badge } from "@/components/ui/Badge";
 
 type Props = { disputeId: string };
 
@@ -187,17 +188,13 @@ export default function MediatorPanelClient({ disputeId }: Props) {
           <div className="mt-3 text-sm text-gray-600">
             <div>Dispute ID: {disputeId}</div>
             <div>Pinata CID: {cid}</div>
-            <div>Gateway: {PINATA_GATEWAYS[activeGatewayIndex]}</div>
+            <div>Gateway: <Badge variant="info">{PINATA_GATEWAYS[activeGatewayIndex]}</Badge></div>
             <div>Mapped address: {address ?? "Not connected"}</div>
             <div className="mt-2">
               {isMediator ? (
-                <span className="px-2 py-1 bg-green-100 text-green-800 rounded">
-                  Mediator access
-                </span>
+                <Badge variant="success">Authorized</Badge>
               ) : (
-                <span className="px-2 py-1 bg-red-100 text-red-800 rounded">
-                  Not a mediator
-                </span>
+                <Badge variant="danger">Unauthorized</Badge>
               )}
             </div>
           </div>
@@ -221,9 +218,7 @@ export default function MediatorPanelClient({ disputeId }: Props) {
             )}
 
             {!isMediator && (
-              <div className="rounded-md border border-red-200 bg-red-50 text-red-700 text-sm p-3">
-                Unauthorized wallet. Access is restricted to mediator addresses.
-              </div>
+              <Badge variant="danger">Unauthorized wallet. Access is restricted to mediator addresses.</Badge>
             )}
 
             <div className="grid grid-cols-1 gap-3">


### PR DESCRIPTION
This PR closes #244 📌 Summary
This PR closes #346 
This PR standardizes how mediator authorization states are visually represented by enforcing the use of design-system Badge variants across the mediator disputes view.

🚨 Problem

Authorization indicators within the mediator panel were implemented inconsistently, leading to visual drift from the app's design system. Some states relied on custom styling instead of semantic badge variants, reducing UI consistency and clarity.

🔁 What Changed
Replaced all custom status indicators with standardized Badge component usage.
Applied semantic variants:
success → Authorized
danger → Unauthorized
info → Neutral/other states
Removed all hardcoded status chips and inline styling related to access state.
Ensured gateway/state tags follow the same badge semantics.
✅ Expected Outcome
Consistent UI across mediator authorization states.
Improved readability and alignment with the design system.
Easier maintainability and scalability for future UI updates.
🧪 How to Test
Navigate to a mediator dispute page.
Check both:
Authorized state
Unauthorized state
Confirm:
All status indicators use the Badge component.
Variants match expected semantics (success, danger, info).
No custom or inconsistent styling remains.
📂 Files Updated
frontend/src/app/mediator/disputes/[id]/MediatorPanelClient.tsx
frontend/src/components/ui/Badge.tsx
✔ Acceptance Criteria Checklist
 Access status uses Badge variants only
 Gateway/state tags use consistent badge semantics
 No one-off hardcoded status chips remain