### PR TITLE
test(backend): add auth abuse and JWT misuse coverage

### DIFF
--- a/backend/src/services/__tests__/auth.service.test.ts
+++ b/backend/src/services/__tests__/auth.service.test.ts
@@ -120,6 +120,46 @@ describe('AuthService', () => {
         statusCode: 401
       });
     });
+
+    it('burns the challenge after a failed signature attempt to block replay guessing', async () => {
+      const challenge = 'test-challenge';
+      const redisMock = getRedisMock();
+      redisMock.get.mockResolvedValueOnce(challenge).mockResolvedValueOnce(null);
+      redisMock.del.mockResolvedValue(1);
+
+      const invalidSignature = Buffer.from('invalid').toString('base64url');
+      await expect(AuthService.verifySignatureAndIssueJWT(realWallet, invalidSignature)).rejects.toMatchObject({
+        code: ErrorCode.AUTH_ERROR,
+        statusCode: 401
+      });
+
+      const validSignature = keypair.sign(Buffer.from(challenge, 'utf8')).toString('base64url');
+      await expect(AuthService.verifySignatureAndIssueJWT(realWallet, validSignature)).rejects.toMatchObject({
+        code: ErrorCode.AUTH_ERROR,
+        statusCode: 401
+      });
+      expect(redisMock.del).toHaveBeenCalledTimes(1);
+      expect(findOrCreateUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects nonce reuse after a successful verification', async () => {
+      const challenge = 'single-use-challenge';
+      const redisMock = getRedisMock();
+      redisMock.get.mockResolvedValueOnce(challenge).mockResolvedValueOnce(null);
+      redisMock.del.mockResolvedValue(1);
+      redisMock.exists.mockResolvedValue(0);
+      (findOrCreateUser as jest.Mock).mockResolvedValue({ id: 'user-1' });
+
+      const signedChallenge = keypair.sign(Buffer.from(challenge, 'utf8')).toString('base64url');
+      const token = await AuthService.verifySignatureAndIssueJWT(realWallet, signedChallenge);
+      expect(token).toBeDefined();
+
+      await expect(AuthService.verifySignatureAndIssueJWT(realWallet, signedChallenge)).rejects.toMatchObject({
+        code: ErrorCode.AUTH_ERROR,
+        statusCode: 401
+      });
+      expect(findOrCreateUser).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('validateToken', () => {
@@ -170,6 +210,42 @@ describe('AuthService', () => {
       await expect(AuthService.validateToken(token)).rejects.toMatchObject({
         code: ErrorCode.AUTH_ERROR,
         message: expect.stringMatching(/missing jti/)
+      });
+    });
+
+    it('rejects JWTs signed with an unexpected algorithm', async () => {
+      const payload = {
+        sub: realWallet.toLowerCase(),
+        walletAddress: realWallet.toLowerCase(),
+        jti: 'bad-alg-jti',
+        iss: 'amana',
+        aud: 'amana-api',
+      };
+      const token = jwt.sign(payload, 'test-secret', { algorithm: 'HS384' });
+      const redisMock = getRedisMock();
+      redisMock.exists.mockResolvedValue(0);
+
+      await expect(AuthService.validateToken(token)).rejects.toMatchObject({
+        code: ErrorCode.AUTH_ERROR,
+        message: 'Invalid token'
+      });
+    });
+
+    it('rejects JWTs minted for another audience', async () => {
+      const payload = {
+        sub: realWallet.toLowerCase(),
+        walletAddress: realWallet.toLowerCase(),
+        jti: 'wrong-audience-jti',
+        iss: 'amana',
+        aud: 'other-api',
+      };
+      const token = jwt.sign(payload, 'test-secret');
+      const redisMock = getRedisMock();
+      redisMock.exists.mockResolvedValue(0);
+
+      await expect(AuthService.validateToken(token)).rejects.toMatchObject({
+        code: ErrorCode.AUTH_ERROR,
+        message: 'Invalid token'
       });
     });
   });
@@ -242,6 +318,24 @@ describe('AuthService', () => {
       await expect(AuthService.refreshToken(token)).rejects.toMatchObject({
         code: ErrorCode.AUTH_ERROR
       });
+    });
+
+    it('rejects refresh tokens missing jti or walletAddress claims', async () => {
+      const token = jwt.sign(
+        {
+          sub: realWallet.toLowerCase(),
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        },
+        'test-secret'
+      );
+      const redisMock = getRedisMock();
+      redisMock.exists.mockResolvedValue(0);
+
+      await expect(AuthService.refreshToken(token)).rejects.toMatchObject({
+        code: ErrorCode.AUTH_ERROR,
+        statusCode: 401
+      });
+      expect(redisMock.exists).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -129,6 +129,10 @@ export class AuthService {
         ignoreExpiration: true, // Allow refresh of expired tokens
       }) as JWTPayload;
 
+      if (!decoded.jti || !decoded.walletAddress) {
+        throw new AppError(ErrorCode.AUTH_ERROR, 'Token refresh failed: invalid token claims', 401);
+      }
+
       // But only within a grace period (e.g., 7 days)
       const now = Math.floor(Date.now() / 1000);
       const gracePeriod = 7 * 24 * 60 * 60;
@@ -202,5 +206,4 @@ export class AuthService {
     return jwt.sign(payload, secret, { algorithm: 'HS256' });
   }
 }
-
 


### PR DESCRIPTION
Closes #290

## Summary
- add tests for failed-signature challenge burn behavior
- add tests for successful challenge nonce reuse rejection
- add JWT misuse coverage for unexpected algorithms and wrong audiences
- reject refresh attempts for tokens missing required jti or walletAddress claims

## Validation
- attempted: npm test -- --runTestsByPath src/services/__tests__/auth.service.test.ts
- blocked locally: backend dependencies are not installed, so jest is not available
