### PR TITLE
test(backend): stabilize trade pagination ordering

### DIFF
--- a/backend/src/__tests__/trade.service.test.ts
+++ b/backend/src/__tests__/trade.service.test.ts
@@ -106,6 +106,58 @@ describe("TradeService", () => {
     );
   });
 
+  it("uses a stable default order with an id tie-breaker", async () => {
+    prisma.trade.findMany = jest.fn().mockResolvedValue([]);
+    prisma.trade.count = jest.fn().mockResolvedValue(0);
+
+    await service.listUserTrades("GA_CALLER", {
+      page: 1,
+      limit: 20,
+    });
+
+    expect(prisma.trade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        skip: 0,
+        take: 20,
+      })
+    );
+  });
+
+  it("keeps custom pagination sorts deterministic under identical sort values", async () => {
+    prisma.trade.findMany = jest.fn().mockResolvedValue([]);
+    prisma.trade.count = jest.fn().mockResolvedValue(0);
+
+    await service.listUserTrades("GA_CALLER", {
+      page: 2,
+      limit: 5,
+      sort: "createdAt:asc",
+    });
+
+    expect(prisma.trade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        skip: 5,
+        take: 5,
+      })
+    );
+  });
+
+  it("falls back to stable default ordering for unsupported sort fields", async () => {
+    prisma.trade.findMany = jest.fn().mockResolvedValue([]);
+    prisma.trade.count = jest.fn().mockResolvedValue(0);
+
+    await service.listUserTrades("GA_CALLER", {
+      sort: "randomField:asc",
+    });
+
+    expect(prisma.trade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      })
+    );
+  });
+
   it("GET /trades/:id returns 403 if caller is not party", async () => {
     prisma.trade.findFirst = jest.fn().mockResolvedValue({
       id: 10,

--- a/backend/src/services/trade.service.ts
+++ b/backend/src/services/trade.service.ts
@@ -145,9 +145,9 @@ export class TradeService {
     };
   }
 
-  private parseSort(sort?: string): Prisma.TradeOrderByWithRelationInput {
+  private parseSort(sort?: string): Prisma.TradeOrderByWithRelationInput[] {
     if (!sort) {
-      return { createdAt: "desc" };
+      return [{ createdAt: "desc" }, { id: "desc" }];
     }
 
     const [fieldRaw, dirRaw] = sort.split(":");
@@ -166,10 +166,14 @@ export class TradeService {
     ]);
 
     if (!allowedFields.has(fieldRaw)) {
-      return { createdAt: "desc" };
+      return [{ createdAt: "desc" }, { id: "desc" }];
     }
 
-    return { [field]: direction };
+    if (fieldRaw === "id") {
+      return [{ id: direction }];
+    }
+
+    return [{ [field]: direction }, { id: direction }];
   }
 
   async initiateDispute(id: string, callerAddress: string, reason: string, category: string) {


### PR DESCRIPTION
Closes #291

## Summary
- make trade list ordering deterministic by appending an id tie-breaker
- preserve default createdAt descending behavior with a stable secondary sort
- add service tests for default, custom, and invalid sort behavior

## Validation
- attempted: npm test -- --runTestsByPath src/__tests__/trade.service.test.ts
- blocked locally: backend dependencies are not installed, so jest is not available
