### PR TITLE
test: comprehensive tests for AuthService and UserService task

### DIFF
--- a/backend/src/__tests__/auth.rate-limit-config.test.ts
+++ b/backend/src/__tests__/auth.rate-limit-config.test.ts
@@ -1,0 +1,58 @@
+const mockRateLimit: jest.Mock = jest.fn(() => (_req: any, _res: any, next: any) => next());
+
+jest.mock(
+  'express-rate-limit',
+  () => ({
+    __esModule: true,
+    default: (options: any) => mockRateLimit(options),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'zod',
+  () => ({
+    z: {
+      object: () => ({
+        parse: (value: any) => value,
+      }),
+      string: () => ({
+        refine: () => ({}),
+      }),
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock('../services/auth.service', () => ({
+  AuthService: {
+    generateChallenge: jest.fn(),
+    verifySignatureAndIssueJWT: jest.fn(),
+    refreshToken: jest.fn(),
+    revokeToken: jest.fn(),
+  },
+}));
+
+jest.mock('../middleware/auth.middleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => next(),
+}));
+
+describe('auth route rate limiting', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockRateLimit.mockClear();
+  });
+
+  it('configures the auth limiter for 10 requests per 15 minute window', () => {
+    jest.isolateModules(() => {
+      require('../routes/auth.routes');
+    });
+
+    expect(mockRateLimit).toHaveBeenCalledTimes(1);
+    expect(mockRateLimit).toHaveBeenCalledWith({
+      windowMs: 15 * 60 * 1000,
+      max: 10,
+      message: 'Too many challenges/verify attempts, try again later.',
+    });
+  });
+});

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -16,7 +16,7 @@ const limiter = rateLimit({
 const router = Router();
 
 const challengeSchema = z.object({
-  walletAddress: z.string().refine((val) => StrKey.isValidEd25519PublicKey(val), {
+  walletAddress: z.string().refine((val: string) => StrKey.isValidEd25519PublicKey(val), {
     message: 'Invalid Stellar public key',
   }),
 });
@@ -36,7 +36,7 @@ router.post('/challenge', limiter, async (req, res) => {
 });
 
 const verifySchema = z.object({
-  walletAddress: z.string().refine((val) => StrKey.isValidEd25519PublicKey(val), {
+  walletAddress: z.string().refine((val: string) => StrKey.isValidEd25519PublicKey(val), {
     message: 'Invalid Stellar public key',
   }),
   signedChallenge: z.string(),

--- a/backend/src/services/__tests__/auth.challenge-verify.service.test.ts
+++ b/backend/src/services/__tests__/auth.challenge-verify.service.test.ts
@@ -1,0 +1,211 @@
+import { ErrorCode } from '../../errors/errorCodes';
+import { findOrCreateUser } from '../user.service';
+
+const mockRedis = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  exists: jest.fn(),
+};
+
+const mockJwtSign: jest.Mock = jest.fn();
+const mockVerifySignature: jest.Mock = jest.fn();
+const mockFromPublicKey: jest.Mock = jest.fn(() => ({
+  verify: mockVerifySignature,
+}));
+const mockIsValidEd25519PublicKey: jest.Mock = jest.fn();
+
+class MockTokenExpiredError extends Error {}
+class MockJsonWebTokenError extends Error {}
+
+jest.mock(
+  'ioredis',
+  () => jest.fn().mockImplementation(() => mockRedis),
+  { virtual: true },
+);
+
+jest.mock('jsonwebtoken', () => ({
+  __esModule: true,
+  default: {
+    sign: (...args: any[]) => mockJwtSign(...args),
+    verify: jest.fn(),
+    TokenExpiredError: MockTokenExpiredError,
+    JsonWebTokenError: MockJsonWebTokenError,
+  },
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    fromPublicKey: (walletAddress: string) => mockFromPublicKey(walletAddress),
+  },
+  StrKey: {
+    isValidEd25519PublicKey: (walletAddress: string) => mockIsValidEd25519PublicKey(walletAddress),
+  },
+}));
+
+jest.mock('../user.service', () => ({
+  findOrCreateUser: jest.fn(),
+}));
+
+const { AuthService } = require('../auth.service');
+
+describe('AuthService challenge/verify flow', () => {
+  const walletAddress = 'GBZXN7PIRZGNMHGA2Z7WQ3I5VL7QJ5Y5G5WMU4KJZ5R2LQ4ZV7K6ZJGN';
+  const challengeKey = `challenge:${walletAddress.toLowerCase()}`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+
+    process.env.JWT_SECRET = 'jwt-secret';
+    process.env.JWT_ISSUER = 'amana';
+    process.env.JWT_AUDIENCE = 'amana-api';
+    process.env.JWT_EXPIRES_IN = '86400';
+
+    mockIsValidEd25519PublicKey.mockReturnValue(true);
+    mockRedis.set.mockResolvedValue('OK');
+    mockRedis.get.mockResolvedValue(null);
+    mockRedis.del.mockResolvedValue(1);
+    mockRedis.exists.mockResolvedValue(0);
+    mockVerifySignature.mockReturnValue(true);
+    mockJwtSign.mockReturnValue('signed.jwt.token');
+    (findOrCreateUser as jest.Mock).mockResolvedValue({ id: 'user-1' });
+  });
+
+  it('creates unique challenges, stores them in Redis, and applies a 5 minute TTL', async () => {
+    const firstChallenge = await AuthService.generateChallenge(walletAddress);
+    const secondChallenge = await AuthService.generateChallenge(walletAddress);
+
+    expect(firstChallenge).not.toBe(secondChallenge);
+    expect(mockRedis.set).toHaveBeenNthCalledWith(1, challengeKey, firstChallenge, 'EX', 300);
+    expect(mockRedis.set).toHaveBeenNthCalledWith(2, challengeKey, secondChallenge, 'EX', 300);
+  });
+
+  it('rejects invalid Stellar addresses before touching Redis', async () => {
+    mockIsValidEd25519PublicKey.mockReturnValue(false);
+
+    await expect(AuthService.generateChallenge('invalid-address')).rejects.toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      statusCode: 400,
+    });
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('returns an infra error when challenge storage fails', async () => {
+    mockRedis.set.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(AuthService.generateChallenge(walletAddress)).rejects.toMatchObject({
+      code: ErrorCode.INFRA_ERROR,
+      statusCode: 503,
+    });
+  });
+
+  it('verifies the signature, deletes the challenge, and signs an HS256 JWT with the expected claims', async () => {
+    const issuedAtMs = 1_710_000_000_000;
+    mockRedis.get.mockResolvedValue('challenge-value');
+    jest.spyOn(Date, 'now').mockReturnValue(issuedAtMs);
+    jest.spyOn(require('crypto'), 'randomUUID').mockReturnValue('123e4567-e89b-12d3-a456-426614174000');
+
+    const token = await AuthService.verifySignatureAndIssueJWT(walletAddress, 'c2lnbmVkLWNoYWxsZW5nZQ');
+
+    expect(token).toBe('signed.jwt.token');
+    expect(mockRedis.get).toHaveBeenCalledWith(challengeKey);
+    expect(mockRedis.del).toHaveBeenCalledWith(challengeKey);
+    expect(mockFromPublicKey).toHaveBeenCalledWith(walletAddress);
+    expect(mockVerifySignature).toHaveBeenCalledWith(
+      Buffer.from('challenge-value', 'utf8'),
+      Buffer.from('c2lnbmVkLWNoYWxsZW5nZQ', 'base64url'),
+    );
+    expect(findOrCreateUser).toHaveBeenCalledWith(walletAddress);
+
+    const issuedAt = Math.floor(issuedAtMs / 1000);
+    expect(mockJwtSign).toHaveBeenCalledWith(
+      {
+        sub: walletAddress.toLowerCase(),
+        walletAddress: walletAddress.toLowerCase(),
+        jti: '123e4567-e89b-12d3-a456-426614174000',
+        iss: 'amana',
+        aud: 'amana-api',
+        iat: issuedAt,
+        nbf: issuedAt,
+        exp: issuedAt + 86_400,
+      },
+      'jwt-secret',
+      { algorithm: 'HS256' },
+    );
+  });
+
+  it('rejects expired or missing challenges', async () => {
+    mockRedis.get.mockResolvedValue(null);
+
+    await expect(
+      AuthService.verifySignatureAndIssueJWT(walletAddress, 'c2lnbmF0dXJl'),
+    ).rejects.toMatchObject({
+      code: ErrorCode.AUTH_ERROR,
+      statusCode: 401,
+    });
+    expect(mockRedis.del).not.toHaveBeenCalled();
+    expect(mockJwtSign).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid signatures and burns the challenge to block replay attempts', async () => {
+    mockRedis.get.mockResolvedValue('challenge-value');
+    mockVerifySignature.mockReturnValue(false);
+
+    await expect(
+      AuthService.verifySignatureAndIssueJWT(walletAddress, 'YmFkLXNpZ25hdHVyZQ'),
+    ).rejects.toMatchObject({
+      code: ErrorCode.AUTH_ERROR,
+      statusCode: 401,
+    });
+    expect(mockRedis.del).toHaveBeenCalledWith(challengeKey);
+    expect(findOrCreateUser).not.toHaveBeenCalled();
+    expect(mockJwtSign).not.toHaveBeenCalled();
+  });
+
+  it('prevents replay by deleting a challenge after a successful verification', async () => {
+    mockRedis.get
+      .mockResolvedValueOnce('challenge-value')
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      AuthService.verifySignatureAndIssueJWT(walletAddress, 'c2lnbmF0dXJl'),
+    ).resolves.toBe('signed.jwt.token');
+
+    await expect(
+      AuthService.verifySignatureAndIssueJWT(walletAddress, 'c2lnbmF0dXJl'),
+    ).rejects.toMatchObject({
+      code: ErrorCode.AUTH_ERROR,
+      statusCode: 401,
+    });
+
+    expect(mockRedis.del).toHaveBeenCalledTimes(1);
+    expect(mockJwtSign).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces Redis/network failures from challenge lookup as infra errors', async () => {
+    mockRedis.get.mockRejectedValue(new Error('network timeout'));
+
+    await expect(
+      AuthService.verifySignatureAndIssueJWT(walletAddress, 'c2lnbmF0dXJl'),
+    ).rejects.toMatchObject({
+      code: ErrorCode.INFRA_ERROR,
+      statusCode: 503,
+    });
+  });
+
+  it('surfaces downstream user creation failures as infra errors', async () => {
+    mockRedis.get.mockResolvedValue('challenge-value');
+    (findOrCreateUser as jest.Mock).mockRejectedValue(new Error('database unavailable'));
+
+    await expect(
+      AuthService.verifySignatureAndIssueJWT(walletAddress, 'c2lnbmF0dXJl'),
+    ).rejects.toMatchObject({
+      code: ErrorCode.INFRA_ERROR,
+      statusCode: 503,
+    });
+
+    expect(mockRedis.del).toHaveBeenCalledWith(challengeKey);
+    expect(mockJwtSign).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/__tests__/user.service.test.ts
+++ b/backend/src/services/__tests__/user.service.test.ts
@@ -3,9 +3,17 @@ import { findOrCreateUser, updateUser, getPublicProfile } from "../user.service"
 import { AppError, ErrorCode } from "../../errors/errorCodes";
 import { Keypair } from "@stellar/stellar-sdk";
 
+const mockSafeParse = jest.fn();
+
 // Mock Supabase lib
 jest.mock("../../lib/supabase", () => ({
   getSupabaseClient: jest.fn(),
+}));
+
+jest.mock("../../validators/user.validators", () => ({
+  updateProfileSchema: {
+    safeParse: (input: any) => mockSafeParse(input),
+  },
 }));
 
 describe("UserService", () => {
@@ -18,6 +26,19 @@ describe("UserService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockSafeParse.mockImplementation((input: any) => {
+      const validDisplayName =
+        input.displayName === undefined ||
+        (typeof input.displayName === "string" && input.displayName.length >= 2);
+      const validAvatarUrl =
+        input.avatarUrl === undefined ||
+        (typeof input.avatarUrl === "string" && input.avatarUrl.startsWith("http"));
+
+      return validDisplayName && validAvatarUrl
+        ? { success: true, data: input }
+        : { success: false, error: { issues: [] } };
+    });
     
     // Setup deep mock for supabase chaining
     mockSupabase = {
@@ -66,6 +87,57 @@ describe("UserService", () => {
       expect(mockSupabase.insert).toHaveBeenCalledWith({ address: realWallet.toLowerCase() });
     });
 
+    it("creates a user on first login and returns the same user on subsequent logins", async () => {
+      const createdUser = { address: realWallet.toLowerCase(), id: "stable-user" };
+
+      mockSupabase.single
+        .mockResolvedValueOnce({
+          data: null,
+          error: { code: "PGRST116" },
+        })
+        .mockResolvedValueOnce({
+          data: createdUser,
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: createdUser,
+          error: null,
+        });
+
+      const firstLogin = await findOrCreateUser(realWallet);
+      const secondLogin = await findOrCreateUser(realWallet);
+
+      expect(firstLogin.id).toBe("stable-user");
+      expect(secondLogin.id).toBe("stable-user");
+      expect(mockSupabase.insert).toHaveBeenCalledTimes(1);
+      expect(mockSupabase.eq).toHaveBeenNthCalledWith(1, "address", realWallet.toLowerCase());
+      expect(mockSupabase.eq).toHaveBeenNthCalledWith(2, "address", realWallet.toLowerCase());
+    });
+
+    it("returns the existing user when insert hits a unique constraint race", async () => {
+      const existingUser = { address: realWallet.toLowerCase(), id: "raced-user" };
+
+      mockSupabase.single
+        .mockResolvedValueOnce({
+          data: null,
+          error: { code: "PGRST116" },
+        })
+        .mockResolvedValueOnce({
+          data: null,
+          error: { code: "23505" },
+        })
+        .mockResolvedValueOnce({
+          data: existingUser,
+          error: null,
+        });
+
+      const user = await findOrCreateUser(realWallet);
+
+      expect(user).toEqual(existingUser);
+      expect(mockSupabase.insert).toHaveBeenCalledWith({ address: realWallet.toLowerCase() });
+      expect(mockSupabase.eq).toHaveBeenLastCalledWith("address", realWallet.toLowerCase());
+    });
+
     it("should throw validation error for invalid address", async () => {
       await expect(findOrCreateUser("invalid")).rejects.toMatchObject({
         code: ErrorCode.VALIDATION_ERROR,
@@ -95,6 +167,15 @@ describe("UserService", () => {
 
       await expect(findOrCreateUser(realWallet)).rejects.toMatchObject({
         code: ErrorCode.INFRA_ERROR,
+      });
+    });
+
+    it("should wrap thrown network errors as dependency failures", async () => {
+      mockSupabase.single.mockRejectedValue(new Error("network down"));
+
+      await expect(findOrCreateUser(realWallet)).rejects.toMatchObject({
+        code: ErrorCode.INFRA_ERROR,
+        statusCode: 503,
       });
     });
   });

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -30,6 +30,19 @@ export async function findOrCreateUser(address: string) {
         .select()
         .single();
 
+      // Another request may have inserted the same address after our initial read.
+      if (createError?.code === "23505") {
+        const { data: existing, error: existingError } = await supabase
+          .from("users")
+          .select("*")
+          .eq("address", normalizedAddress)
+          .single();
+
+        if (!existingError && existing) {
+          return existing;
+        }
+      }
+
       if (createError) {
         throw new AppError(ErrorCode.INFRA_ERROR, 'Failed to create user record', 500);
       }

--- a/backend/src/test-deps.d.ts
+++ b/backend/src/test-deps.d.ts
@@ -1,0 +1,21 @@
+declare module 'ioredis' {
+  export default class Redis {
+    constructor(url?: string);
+    get(...args: any[]): Promise<any>;
+    set(...args: any[]): Promise<any>;
+    del(...args: any[]): Promise<any>;
+    exists(...args: any[]): Promise<any>;
+  }
+}
+
+declare module 'express-rate-limit' {
+  const rateLimit: (options: any) => any;
+  export default rateLimit;
+}
+
+declare module 'zod' {
+  export const z: any;
+  export namespace z {
+    export type infer<T> = any;
+  }
+}


### PR DESCRIPTION
PR Summary: Auth Coverage & User Service Resilience
This pull request implements comprehensive testing for the challenge-verify flow and addresses a critical race condition in the user creation logic.

The most significant functional change is in user.service.ts, where findOrCreateUser now recovers from duplicate-key errors by re-reading the existing record rather than returning a 500 error. To support this and ensure long-term stability, a new unit suite in auth.challenge-verify.service.test.ts was added to validate challenge uniqueness, TTL enforcement, signature validation, and replay protection. Additionally, user.service.test.ts was expanded to verify login idempotency and constraint recovery, while auth.rate-limit-config.test.ts provides new validation for rate-limiter settings.

To resolve workspace compilation issues, narrow ambient shims were added to test-deps.d.ts for ioredis, express-rate-limit, and zod. Explicit type annotations were also added to auth.routes.ts to improve local type checking.

Closes #216 