### PR TITLE
fix(frontend): mediator panel UX, mobile layout, shell alignment, and snapshot policy

### DIFF
--- a/frontend/src/app/mediator/disputes/[id]/MediatorPanelClient.tsx
+++ b/frontend/src/app/mediator/disputes/[id]/MediatorPanelClient.tsx
@@ -24,6 +24,8 @@ type ConfirmationModalState = {
   splitLabel: string;
 };
 
+type VideoLoadState = "loading" | "ready" | "terminal-failure";
+
 const DEFAULT_MEDIATOR_ADDRESSES = ["GEXAMPLEMEDIATORPUBLICKEY1"];
 
 const PINATA_GATEWAYS = [
@@ -41,13 +43,13 @@ export default function MediatorPanelClient({ disputeId }: Props) {
   const [txStatus, setTxStatus] = useState<string>("");
   const [isSubmittingTx, setIsSubmittingTx] = useState(false);
   const [activeGatewayIndex, setActiveGatewayIndex] = useState(0);
+  const [videoLoadState, setVideoLoadState] = useState<VideoLoadState>("loading");
   const [modal, setModal] = useState<ConfirmationModalState>({
     isOpen: false,
     sellerGetsBps: null,
     splitLabel: "",
   });
 
-  // Dev-only state
   const [execString, setExecString] = useState<string>("");
 
   const mediatorAddresses = useMemo(() => {
@@ -66,7 +68,22 @@ export default function MediatorPanelClient({ disputeId }: Props) {
   const cid = disputeId || "QmExampleCidForDemo";
   const pinataUrl = `${PINATA_GATEWAYS[activeGatewayIndex]}/${cid}`;
 
-  // Dev-only: generates a soroban:// URI for manual inspection
+  function handleVideoError() {
+    const nextIndex = activeGatewayIndex + 1;
+    if (nextIndex < PINATA_GATEWAYS.length) {
+      setActiveGatewayIndex(nextIndex);
+      setVideoLoadState("loading");
+    } else {
+      setVideoLoadState("terminal-failure");
+    }
+  }
+
+  function switchGateway() {
+    const nextIndex = (activeGatewayIndex + 1) % PINATA_GATEWAYS.length;
+    setActiveGatewayIndex(nextIndex);
+    setVideoLoadState("loading");
+  }
+
   function buildExec(split: string) {
     const s = `soroban://execute?cmd=resolve_dispute&split=${split}&dispute=${disputeId}`;
     setExecString(s);
@@ -169,63 +186,131 @@ export default function MediatorPanelClient({ disputeId }: Props) {
   }
 
   return (
-    <div className="min-h-screen p-6 bg-gray-50">
-      <div className="max-w-6xl mx-auto grid grid-cols-12 gap-6">
+    <div className="px-6 py-8 max-w-6xl mx-auto">
+      {/* Page header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-text-primary">Mediator Panel</h1>
+        <p className="text-text-secondary mt-1">
+          Dispute{" "}
+          <span className="font-mono text-text-primary">{disputeId}</span>{" "}
+          — Review evidence and resolve on-chain.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
         {/* Left: Evidence Video */}
-        <div className="col-span-7">
-          <div className="aspect-video bg-black rounded-xl overflow-hidden shadow-modal">
-            <video
-              controls
-              className="w-full h-full object-contain bg-black"
-              src={pinataUrl}
-              onError={() => {
-                if (activeGatewayIndex < PINATA_GATEWAYS.length - 1) {
-                  setActiveGatewayIndex((prev) => prev + 1);
-                }
-              }}
-            />
+        <div className="lg:col-span-7">
+          <div className="relative aspect-video bg-black rounded-xl overflow-hidden shadow-card">
+            {videoLoadState === "terminal-failure" ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center p-6">
+                <svg
+                  className="w-10 h-10 text-status-danger"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v3m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <p className="text-white font-medium">Evidence unavailable</p>
+                <p className="text-gray-400 text-sm">
+                  All IPFS gateways failed to load this file.
+                </p>
+                <button
+                  onClick={() => {
+                    setActiveGatewayIndex(0);
+                    setVideoLoadState("loading");
+                  }}
+                  className="mt-2 px-4 py-2 bg-bg-elevated border border-border-default text-text-primary text-sm rounded-md hover:bg-bg-input transition-colors"
+                >
+                  Retry from first gateway
+                </button>
+              </div>
+            ) : (
+              <>
+                {videoLoadState === "loading" && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/60 z-10">
+                    <div className="flex flex-col items-center gap-2">
+                      <div className="animate-spin w-8 h-8 border-2 border-gold border-t-transparent rounded-full" />
+                      <span className="text-gray-300 text-xs">
+                        Loading via gateway {activeGatewayIndex + 1}/
+                        {PINATA_GATEWAYS.length}…
+                      </span>
+                    </div>
+                  </div>
+                )}
+                <video
+                  key={pinataUrl}
+                  controls
+                  className="w-full h-full object-contain bg-black"
+                  src={pinataUrl}
+                  onLoadStart={() => setVideoLoadState("loading")}
+                  onCanPlay={() => setVideoLoadState("ready")}
+                  onError={handleVideoError}
+                />
+              </>
+            )}
           </div>
-          <div className="mt-3 text-sm text-gray-600 space-y-1">
-            <div>Dispute ID: <span className="font-mono">{disputeId}</span></div>
-            <div className="mt-2">
+
+          {/* Video meta */}
+          <div className="mt-3 text-sm text-text-secondary space-y-2">
+            <div>
+              Dispute ID:{" "}
+              <span className="font-mono text-text-primary">{disputeId}</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              {videoLoadState !== "terminal-failure" && (
+                <span className="text-xs text-text-muted">
+                  Gateway {activeGatewayIndex + 1}/{PINATA_GATEWAYS.length}
+                </span>
+              )}
+              {PINATA_GATEWAYS.length > 1 &&
+                videoLoadState !== "terminal-failure" && (
+                  <button
+                    onClick={switchGateway}
+                    className="text-xs text-gold hover:underline underline-offset-2"
+                  >
+                    Switch gateway
+                  </button>
+                )}
               {isMediator ? (
                 <Badge variant="success">Authorized Mediator</Badge>
               ) : (
                 <Badge variant="danger">Unauthorized</Badge>
               )}
             </div>
-
-            {/* Dev-only: IPFS debug info */}
-            {isDev && (
-              <div className="mt-2 p-2 bg-yellow-50 border border-yellow-200 rounded text-xs space-y-1">
-                <div className="font-semibold text-yellow-700">DEV</div>
-                <div>Pinata CID: {cid}</div>
-                <div>Gateway: <Badge variant="info">{PINATA_GATEWAYS[activeGatewayIndex]}</Badge></div>
-                <div>Wallet: {address ?? "Not connected"}</div>
-                <button
-                  onClick={() =>
-                    setActiveGatewayIndex(
-                      (prev) => (prev + 1) % PINATA_GATEWAYS.length,
-                    )
-                  }
-                  className="px-2 py-1 bg-gray-100 rounded text-xs"
-                >
-                  Switch Gateway
-                </button>
-              </div>
-            )}
           </div>
+
+          {/* Dev-only: IPFS debug info */}
+          {isDev && (
+            <div className="mt-2 p-2 bg-yellow-50 border border-yellow-200 rounded text-xs space-y-1">
+              <div className="font-semibold text-yellow-700">DEV</div>
+              <div>Pinata CID: {cid}</div>
+              <div>
+                Gateway:{" "}
+                <Badge variant="info">{PINATA_GATEWAYS[activeGatewayIndex]}</Badge>
+              </div>
+              <div>Wallet: {address ?? "Not connected"}</div>
+            </div>
+          )}
         </div>
 
         {/* Right: Resolution Panel */}
-        <div className="col-span-5">
-          <div className="bg-white rounded-xl shadow-md p-5 space-y-4">
+        <div className="lg:col-span-5">
+          <div className="bg-bg-card rounded-xl shadow-card p-5 space-y-4">
             <div>
-              <h3 className="text-lg font-semibold">Resolve Dispute</h3>
-              <p className="text-sm text-gray-500 mt-1">
+              <h3 className="text-lg font-semibold text-text-primary">
+                Resolve Dispute
+              </h3>
+              <p className="text-sm text-text-secondary mt-1">
                 Select a loss-ratio split to settle this trade on-chain.
               </p>
             </div>
+
             <div className="rounded-md border border-border-default bg-bg-elevated p-3">
               <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
                 Connected wallet
@@ -247,7 +332,7 @@ export default function MediatorPanelClient({ disputeId }: Props) {
               <button
                 onClick={() => void connectWallet()}
                 disabled={isLoading}
-                className="w-full rounded-md bg-black text-white py-2 text-sm font-medium"
+                className="w-full rounded-md bg-gold text-text-inverse py-2.5 text-sm font-medium hover:bg-gold-hover transition-colors disabled:opacity-50"
               >
                 {isLoading ? "Connecting..." : "Connect Freighter"}
               </button>
@@ -280,13 +365,15 @@ export default function MediatorPanelClient({ disputeId }: Props) {
 
             {/* Tx status feedback */}
             {txStatus && (
-              <p className="text-xs text-gray-600 break-all">{txStatus}</p>
+              <p className="text-xs text-text-secondary break-all">{txStatus}</p>
             )}
 
             {/* Dev-only: exec string builder */}
             {isDev && (
               <div className="p-3 bg-yellow-50 border border-yellow-200 rounded space-y-2">
-                <p className="text-xs font-semibold text-yellow-700">DEV — Exec String Builder</p>
+                <p className="text-xs font-semibold text-yellow-700">
+                  DEV — Exec String Builder
+                </p>
                 <div className="flex gap-2">
                   <button
                     disabled={!isMediator}
@@ -318,7 +405,9 @@ export default function MediatorPanelClient({ disputeId }: Props) {
                   </button>
                   <a
                     href={execString || "#"}
-                    onClick={(e) => { if (!execString) e.preventDefault(); }}
+                    onClick={(e) => {
+                      if (!execString) e.preventDefault();
+                    }}
                     className="px-2 py-1 bg-gray-100 rounded text-xs"
                   >
                     Preview
@@ -332,30 +421,44 @@ export default function MediatorPanelClient({ disputeId }: Props) {
 
       {/* Confirmation Modal */}
       {modal.isOpen && modal.sellerGetsBps !== null && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-lg max-w-md w-full p-6 space-y-4">
-            <h2 className="text-xl font-bold text-gray-900">Confirm Resolution</h2>
+        <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-4">
+          <div className="bg-bg-card rounded-xl shadow-lg w-full max-w-md p-6 space-y-4">
+            <h2 className="text-xl font-bold text-text-primary">
+              Confirm Resolution
+            </h2>
 
-            <div className="border rounded-lg bg-gray-50 p-4 space-y-3">
+            <div className="border border-border-default rounded-lg bg-bg-elevated p-4 space-y-3">
               <div className="flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Trade ID:</span>
-                <span className="text-sm font-mono text-gray-900">{disputeId}</span>
+                <span className="text-sm font-medium text-text-secondary">
+                  Trade ID:
+                </span>
+                <span className="text-sm font-mono text-text-primary">
+                  {disputeId}
+                </span>
               </div>
-              <div className="border-t border-gray-200" />
+              <div className="border-t border-border-default" />
               <div className="flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Split:</span>
-                <span className="text-sm font-semibold text-gray-900">{modal.splitLabel}</span>
+                <span className="text-sm font-medium text-text-secondary">
+                  Split:
+                </span>
+                <span className="text-sm font-semibold text-text-primary">
+                  {modal.splitLabel}
+                </span>
               </div>
-              <div className="border-t border-gray-200" />
+              <div className="border-t border-border-default" />
               <div className="flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Seller Receives:</span>
-                <span className="text-sm font-semibold text-emerald-700">
+                <span className="text-sm font-medium text-text-secondary">
+                  Seller Receives:
+                </span>
+                <span className="text-sm font-semibold text-status-success">
                   {(modal.sellerGetsBps / 100).toFixed(2)}%
                 </span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Buyer Receives:</span>
-                <span className="text-sm font-semibold text-blue-700">
+                <span className="text-sm font-medium text-text-secondary">
+                  Buyer Receives:
+                </span>
+                <span className="text-sm font-semibold text-gold">
                   {(getBuyerSplit(modal.sellerGetsBps) / 100).toFixed(2)}%
                 </span>
               </div>
@@ -363,9 +466,9 @@ export default function MediatorPanelClient({ disputeId }: Props) {
 
             <div className="rounded-lg bg-yellow-50 border border-yellow-200 p-3">
               <p className="text-xs text-yellow-800">
-                <span className="font-semibold">⚠️ Warning:</span> This action is
-                irreversible and will be recorded on-chain. Please review the split
-                details before confirming.
+                <span className="font-semibold">Warning:</span> This action is
+                irreversible and will be recorded on-chain. Please review the
+                split details before confirming.
               </p>
             </div>
 
@@ -373,7 +476,7 @@ export default function MediatorPanelClient({ disputeId }: Props) {
               <button
                 onClick={closeModal}
                 disabled={isSubmittingTx}
-                className="px-4 py-2 border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50 disabled:opacity-50 transition"
+                className="px-4 py-2.5 border border-border-default text-text-primary text-sm font-medium rounded-md hover:bg-bg-elevated disabled:opacity-50 transition"
               >
                 Cancel
               </button>
@@ -383,7 +486,7 @@ export default function MediatorPanelClient({ disputeId }: Props) {
                   void executeResolution(modal.sellerGetsBps!);
                 }}
                 disabled={isSubmittingTx}
-                className="px-4 py-2 bg-emerald-700 text-white text-sm font-medium rounded-md hover:bg-emerald-800 disabled:opacity-50 transition"
+                className="px-4 py-2.5 bg-emerald-700 text-white text-sm font-medium rounded-md hover:bg-emerald-800 disabled:opacity-50 transition"
               >
                 {isSubmittingTx ? "Processing..." : "Confirm & Sign"}
               </button>

--- a/frontend/src/app/mediator/disputes/[id]/page.tsx
+++ b/frontend/src/app/mediator/disputes/[id]/page.tsx
@@ -1,7 +1,10 @@
 import MediatorPanelClient from "./MediatorPanelClient";
 
-
-export default function Page({ params }: { params: { id: string } }) {
-  const { id } = params;
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
   return <MediatorPanelClient disputeId={id} />;
 }

--- a/frontend/tests/visual/SNAPSHOT_POLICY.md
+++ b/frontend/tests/visual/SNAPSHOT_POLICY.md
@@ -1,0 +1,34 @@
+# Snapshot Policy
+
+## When to regenerate snapshots
+
+Regenerate snapshots **only** when there is an intentional visual change — for example, a design update, a layout refactor, or a new UI state. Run:
+
+```bash
+pnpm test:visual:update
+```
+
+Then commit the updated `.png` files in the same PR as the code change that caused them.
+
+## When NOT to regenerate
+
+Do not regenerate snapshots to silence a failing test. A snapshot diff that is not caused by your PR is a signal of an unrelated regression — investigate it instead of overwriting it.
+
+## Reviewing snapshot diffs in PRs
+
+- Rendered PNG diffs will appear in the Playwright HTML report (`playwright-report/`).
+- A diff that touches only the scoped element (e.g. `landing-header.png`) is expected when the header changed.
+- A diff that touches a large region when only a small component changed is a sign the snapshot is too broad — tighten the locator.
+
+## Keeping snapshots scoped
+
+Each `toHaveScreenshot` call should target the smallest stable DOM region that proves the assertion. Prefer `page.locator('header')` or `page.locator('main')` over `{ fullPage: true }`. Full-page screenshots generate large binary diffs that obscure the meaningful change for reviewers.
+
+## Adding new snapshots
+
+When adding a new visual test:
+
+1. Use a named locator (e.g. `page.locator('[data-testid="hero"]')`).
+2. Run `pnpm test:visual:update` once to generate the baseline.
+3. Commit the baseline PNG alongside the test file in the same PR.
+4. Do not commit PNGs without a corresponding test change.

--- a/frontend/tests/visual/landing.spec.ts
+++ b/frontend/tests/visual/landing.spec.ts
@@ -1,9 +1,17 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Landing Page Visual Tests', () => {
-  test('should match visual snapshot', async ({ page }) => {
+  test('landing header matches snapshot', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    await expect(page).toHaveScreenshot('landing-page.png', { fullPage: true });
+    const header = page.locator('header').first();
+    await expect(header).toHaveScreenshot('landing-header.png');
+  });
+
+  test('landing hero section matches snapshot', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const hero = page.locator('main').first();
+    await expect(hero).toHaveScreenshot('landing-hero.png');
   });
 });

--- a/frontend/tests/visual/trades.spec.ts
+++ b/frontend/tests/visual/trades.spec.ts
@@ -1,10 +1,18 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Trades Page Visual Tests', () => {
-  test('should match visual snapshot for the trades landing state', async ({ page }) => {
+  test('trades page header matches snapshot', async ({ page }) => {
     await page.goto('/trades');
     await page.waitForLoadState('networkidle');
     await expect(page.locator('h1')).toHaveText('Trades');
-    await expect(page).toHaveScreenshot('trades-page.png', { fullPage: true });
+    const header = page.locator('header').first();
+    await expect(header).toHaveScreenshot('trades-header.png');
+  });
+
+  test('trades page main content matches snapshot', async ({ page }) => {
+    await page.goto('/trades');
+    await page.waitForLoadState('networkidle');
+    const main = page.locator('main').first();
+    await expect(main).toHaveScreenshot('trades-main.png');
   });
 });


### PR DESCRIPTION
## Summary

- **#247 — Shell alignment**: mediator route now renders inside the shared app shell with the correct `px-6 py-8 max-w-6xl mx-auto` container, a clear page title ("Mediator Panel") and dispute context subtitle. Raw Tailwind colours (`bg-gray-50`, `text-gray-*`) replaced with design-token classes (`bg-bg-card`, `text-text-primary/secondary`, `shadow-card`). `page.tsx` updated to async params pattern required by Next.js 15+.

- **#248 — Evidence playback UX**: added `VideoLoadState` (`loading | ready | terminal-failure`). A spinner overlay shows gateway progress ("Loading via gateway 1/3…") until `onCanPlay` fires. `onError` advances to the next gateway deterministically; when all gateways are exhausted the video area renders a terminal-failure state with a clear message and a "Retry from first gateway" CTA. Manual gateway switch is always visible (non-dev) and remains available in all non-terminal states. `key={pinataUrl}` forces a clean video remount on every gateway change.

- **#249 — Mobile responsiveness**: fixed-column grid (`grid-cols-12`) replaced with `grid-cols-1 lg:grid-cols-12` so the evidence panel and resolution panel stack vertically on mobile. Confirmation modal uses `items-end sm:items-center` (slides up from bottom on mobile, centred on desktop). Meta row uses `flex-wrap` to prevent overflow on narrow viewports.

- **#394 — Snapshot noise**: `landing.spec.ts` and `trades.spec.ts` now target scoped DOM elements (`header`, `main`) instead of `{ fullPage: true }`, keeping binary diffs in PRs small and intentional. Added `tests/visual/SNAPSHOT_POLICY.md` documenting when to regenerate, how to review diffs, and the rule that scoped locators must be used for new snapshots.

Closes #247 
Closes #248 
Closes #249 
Closes #394