### PR TITLE
feat: refactor(frontend): normalize surface, border, and elevation token usage

### DIFF
--- a/frontend/src/app/trades/page.tsx
+++ b/frontend/src/app/trades/page.tsx
@@ -19,20 +19,24 @@ const FILTERS: { label: string; value: TradeStatus }[] = [
   { label: "Disputed", value: "disputed" },
 ];
 
+// Status chip tokens: text = status color, bg = status/10, border = status/20.
+// "completed" and "draft" use neutral surface tokens (no alert color).
 const STATUS_STYLES: Record<string, string> = {
-  active: "text-status-success bg-status-success/10",
-  pending: "text-status-warning bg-status-warning/10",
-  completed: "text-text-secondary bg-bg-elevated",
-  disputed: "text-status-danger bg-status-danger/10",
-  locked: "text-status-locked bg-status-locked/10",
+  active:    "text-status-success bg-status-success/10 border border-status-success/20",
+  pending:   "text-status-warning bg-status-warning/10 border border-status-warning/20",
+  completed: "text-text-secondary bg-surface-2 border border-border-default",
+  disputed:  "text-status-danger  bg-status-danger/10  border border-status-danger/20",
+  locked:    "text-status-locked  bg-status-locked/10  border border-status-locked/20",
+  draft:     "text-status-draft   bg-surface-1         border border-border-default",
 };
 
 const PAGE_SIZE = 10;
 
 function TradesTableSkeleton() {
   return (
-    <div className="rounded-lg border border-border-default overflow-hidden">
-      <div className="border-b border-border-default bg-bg-card px-4 py-3">
+    <div className="rounded-lg border border-border-default overflow-hidden shadow-elev-1">
+      {/* Header: surface-1 (card level) */}
+      <div className="border-b border-border-default bg-surface-1 px-4 py-3">
         <div className="grid grid-cols-5 gap-4">
           <Skeleton className="h-3 w-14" />
           <Skeleton className="h-3 w-24" />
@@ -41,7 +45,8 @@ function TradesTableSkeleton() {
           <Skeleton className="h-3 w-20" />
         </div>
       </div>
-      <div className="divide-y divide-border-default bg-bg-primary">
+      {/* Rows: surface-0 (canvas) */}
+      <div className="divide-y divide-border-default bg-surface-0">
         {Array.from({ length: 6 }).map((_, index) => (
           <div key={index} className="grid grid-cols-5 gap-4 px-4 py-4">
             <Skeleton className="h-4 w-20" />
@@ -164,10 +169,10 @@ export default function TradesPage() {
       {!loading && !error && (
         <>
           {trades.length === 0 ? (
-            <div className="rounded-lg border border-border-default bg-bg-card py-20 px-6 text-center">
+            <div className="rounded-lg border border-border-default bg-surface-1 py-20 px-6 text-center shadow-elev-1">
               {/* Icon */}
               <div className="flex justify-center mb-6">
-                <div className="w-16 h-16 rounded-lg bg-bg-elevated border border-border-default flex items-center justify-center">
+                <div className="w-16 h-16 rounded-lg bg-surface-2 border border-border-default flex items-center justify-center">
                   <svg
                     className="w-8 h-8 text-text-muted"
                     fill="none"
@@ -201,10 +206,11 @@ export default function TradesPage() {
               </Link>
             </div>
           ) : (
-            <div className="rounded-lg border border-border-default overflow-hidden">
+            <div className="rounded-lg border border-border-default overflow-hidden shadow-elev-1">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-border-default bg-bg-card">
+                  {/* Header: surface-1 (card level), subtle bottom border */}
+                  <tr className="border-b border-border-default bg-surface-1">
                     <th className="text-left px-4 py-3 text-text-muted font-medium">
                       ID
                     </th>
@@ -226,8 +232,10 @@ export default function TradesPage() {
                   {trades.map((trade, i) => (
                     <tr
                       key={trade.tradeId}
-                      className={`border-b border-border-default last:border-0 hover:bg-bg-elevated transition-colors ${
-                        i % 2 === 0 ? "bg-bg-primary" : "bg-bg-card"
+                      // Even rows: surface-0 (canvas), odd rows: surface-1 (card).
+                      // Hover lifts to surface-2 + elev-2 shadow for clear depth feedback.
+                      className={`border-b border-border-default last:border-0 hover:bg-surface-2 hover:shadow-elev-2 transition-colors ${
+                        i % 2 === 0 ? "bg-surface-0" : "bg-surface-1"
                       }`}
                     >
                       <td className="px-4 py-3 text-gold font-mono">

--- a/frontend/src/components/layout/SideNavBar.tsx
+++ b/frontend/src/components/layout/SideNavBar.tsx
@@ -120,7 +120,7 @@ export function SideNavBar({
     <aside
       className={`${
         collapsed ? "w-20" : "w-64"
-      } flex-shrink-0 bg-card border-r border-border-default flex flex-col min-h-screen`}
+      } flex-shrink-0 bg-surface-1 border-r border-border-default shadow-elev-1 flex flex-col min-h-screen`}
       aria-label="Primary sidebar"
     >
       <div className="h-16 px-4 border-b border-border-default flex items-center justify-between">
@@ -144,7 +144,7 @@ export function SideNavBar({
           <button
             type="button"
             onClick={onClose}
-            className="lg:hidden w-8 h-8 rounded-lg flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-elevated transition-all"
+            className="lg:hidden w-8 h-8 rounded-lg flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-2 transition-all"
             aria-label="Close menu"
           >
             <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
@@ -177,8 +177,10 @@ export function SideNavBar({
                     collapsed ? "justify-center px-2" : "px-4"
                   } py-3 border-l-4 transition-all focus-visible:outline-2 focus-visible:outline-gold focus-visible:outline-offset-2 ${
                     isActive
-                      ? "border-l-gold bg-elevated text-gold hover:bg-elevated/80"
-                      : "border-transparent text-text-secondary hover:text-text-primary hover:bg-white/5"
+                      // Active: surface-2 lift + gold left border + elev-2 shadow
+                      ? "border-l-gold bg-surface-2 text-gold shadow-elev-2 hover:bg-surface-2/80"
+                      // Inactive: hover lifts to surface-2/30
+                      : "border-transparent text-text-secondary hover:text-text-primary hover:bg-surface-2/30"
                   }`}
                   title={collapsed ? item.label : undefined}
                 >
@@ -196,7 +198,7 @@ export function SideNavBar({
       <div className="p-4 border-t border-border-default">
         {isConnected ? (
           <div
-            className={`rounded-lg bg-bg-elevated border border-border-default ${
+            className={`rounded-lg bg-surface-2 border border-border-raised ${
               collapsed ? "px-2 py-3 text-center" : "px-3 py-3"
             }`}
           >

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,11 +9,23 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        "bg-primary": "#0B1A14",
-        "bg-card": "#122A1F",
-        "bg-elevated": "#1A3D2C",
-        "bg-input": "#0F2219",
-        "bg-overlay": "rgba(11,26,20,0.85)",
+        // ── Surface / Elevation scale ──────────────────────────────────────
+        // surface-0  page canvas (deepest background)
+        // surface-1  card / panel (one step up)
+        // surface-2  elevated surface — active rows, modals, dropdowns
+        // surface-3  overlay / scrim
+        "surface-0": "#0B1A14",
+        "surface-1": "#122A1F",
+        "surface-2": "#1A3D2C",
+        "surface-3": "rgba(11,26,20,0.85)",
+
+        // Legacy bg-* aliases — kept for backward-compat, map to surface tokens
+        "bg-primary":  "#0B1A14",             // → surface-0
+        "bg-card":     "#122A1F",             // → surface-1
+        "bg-elevated": "#1A3D2C",             // → surface-2
+        "bg-input":    "#0F2219",
+        "bg-overlay":  "rgba(11,26,20,0.85)", // → surface-3
+
         gold: "#D4A853",
         "gold-hover": "#E0BA6A",
         "gold-muted": "rgba(212,168,83,0.15)",
@@ -21,37 +33,68 @@ const config: Config = {
         "emerald-muted": "rgba(52,211,153,0.15)",
         "accent-emerald": "#34D399",
         teal: "#14B8A6",
-        "text-primary": "#F0F5F1",
+        "text-primary":   "#F0F5F1",
         "text-secondary": "#8BA89A",
-        "text-muted": "#5A7A6A",
-        "text-inverse": "#0B1A14",
+        "text-muted":     "#5A7A6A",
+        "text-inverse":   "#0B1A14",
+
+        // Status chip tokens
         "status-success": "#34D399",
         "status-warning": "#F59E0B",
-        "status-danger": "#EF4444",
-        "status-info": "#3B82F6",
-        "status-locked": "#D4A853",
-        "status-draft": "#6B7280",
-        "border-default": "rgba(139,168,154,0.2)",
-        "border-hover": "rgba(139,168,154,0.4)",
-        "border-focus": "rgba(212,168,83,0.6)",
+        "status-danger":  "#EF4444",
+        "status-info":    "#3B82F6",
+        "status-locked":  "#D4A853",
+        "status-draft":   "#6B7280",
+
+        // ── Border tokens — elevation-aware ───────────────────────────────
+        "border-subtle":  "rgba(139,168,154,0.12)", // surface-0 dividers
+        "border-default": "rgba(139,168,154,0.2)",  // surface-1 card borders
+        "border-raised":  "rgba(139,168,154,0.32)", // surface-2 elevated borders
+        "border-hover":   "rgba(139,168,154,0.4)",
+        "border-focus":   "rgba(212,168,83,0.6)",
       },
       backgroundColor: {
-        primary: "#0B1A14",
-        card: "#122A1F",
+        // Surface scale
+        "surface-0": "#0B1A14",
+        "surface-1": "#122A1F",
+        "surface-2": "#1A3D2C",
+        "surface-3": "rgba(11,26,20,0.85)",
+        // Legacy aliases
+        primary:  "#0B1A14",
+        card:     "#122A1F",
         elevated: "#1A3D2C",
-        input: "#0F2219",
-        overlay: "rgba(11,26,20,0.85)",
+        input:    "#0F2219",
+        overlay:  "rgba(11,26,20,0.85)",
       },
       textColor: {
-        primary: "#F0F5F1",
+        primary:   "#F0F5F1",
         secondary: "#8BA89A",
-        muted: "#5A7A6A",
-        inverse: "#0B1A14",
+        muted:     "#5A7A6A",
+        inverse:   "#0B1A14",
       },
       borderColor: {
+        subtle:  "rgba(139,168,154,0.12)",
         default: "rgba(139,168,154,0.2)",
-        hover: "rgba(139,168,154,0.4)",
-        focus: "rgba(212,168,83,0.6)",
+        raised:  "rgba(139,168,154,0.32)",
+        hover:   "rgba(139,168,154,0.4)",
+        focus:   "rgba(212,168,83,0.6)",
+      },
+      // ── Elevation / shadow scale ─────────────────────────────────────────
+      // elev-0  flat — surface-0 canvas, no lift
+      // elev-1  subtle lift — cards, panels, sidebar (surface-1)
+      // elev-2  raised — active rows, dropdowns, modals (surface-2)
+      // elev-3  overlay — dialogs, scrim (surface-3)
+      boxShadow: {
+        "elev-0": "none",
+        "elev-1": "0 1px 4px rgba(0,0,0,0.25), 0 4px 24px rgba(0,0,0,0.3)",
+        "elev-2": "0 4px 12px rgba(0,0,0,0.35), 0 8px 32px rgba(0,0,0,0.4)",
+        "elev-3": "0 16px 48px rgba(0,0,0,0.5)",
+        // Legacy aliases
+        card:           "0 1px 4px rgba(0,0,0,0.25), 0 4px 24px rgba(0,0,0,0.3)",
+        "card-hover":   "0 4px 12px rgba(0,0,0,0.35), 0 8px 32px rgba(0,0,0,0.4)",
+        "glow-gold":    "0 0 20px rgba(212,168,83,0.2)",
+        "glow-emerald": "0 0 20px rgba(52,211,153,0.15)",
+        modal:          "0 16px 48px rgba(0,0,0,0.5)",
       },
       spacing: {
         1: "4px",
@@ -64,20 +107,13 @@ const config: Config = {
         10: "40px",
       },
       borderRadius: {
-        none: "0",
-        sm: "6px",
-        md: "8px",
-        lg: "12px",
-        xl: "16px",
+        none:  "0",
+        sm:    "6px",
+        md:    "8px",
+        lg:    "12px",
+        xl:    "16px",
         "2xl": "24px",
-        full: "9999px",
-      },
-      boxShadow: {
-        card: "0 4px 24px rgba(0,0,0,0.3)",
-        "card-hover": "0 8px 32px rgba(0,0,0,0.4)",
-        "glow-gold": "0 0 20px rgba(212,168,83,0.2)",
-        "glow-emerald": "0 0 20px rgba(52,211,153,0.15)",
-        modal: "0 16px 48px rgba(0,0,0,0.5)",
+        full:  "9999px",
       },
       fontFamily: {
         sans: [
@@ -87,11 +123,7 @@ const config: Config = {
           "system-ui",
           "sans-serif",
         ],
-        manrope: [
-          "var(--font-manrope)",
-          "Manrope",
-          "sans-serif",
-        ],
+        manrope: ["var(--font-manrope)", "Manrope", "sans-serif"],
         mono: [
           "var(--font-geist-mono)",
           "Geist Mono",
@@ -106,29 +138,29 @@ const config: Config = {
         ],
       },
       // #444 — Figma type scale tokens: display → 3xl → 2xl → xl for headings;
-      // lg → base → sm for body and metadata. Sizes are referenced only via
-      // these tokens; no ad-hoc values should appear in component files.
+      // lg → base → sm for body and metadata. No ad-hoc sizes in components.
       fontSize: {
-        xs: ["12px", { lineHeight: "1.5" }],
-        sm: ["14px", { lineHeight: "1.5" }],
-        base: ["16px", { lineHeight: "1.5" }],
-        lg: ["18px", { lineHeight: "1.6" }],
-        xl: ["20px", { lineHeight: "1.4" }],
-        "2xl": ["24px", { lineHeight: "1.3" }],
-        "3xl": ["30px", { lineHeight: "1.25" }],
-        "4xl": ["36px", { lineHeight: "1.2" }],
-        "5xl": ["48px", { lineHeight: "1.15" }],
+        xs:      ["12px", { lineHeight: "1.5" }],
+        sm:      ["14px", { lineHeight: "1.5" }],
+        base:    ["16px", { lineHeight: "1.5" }],
+        lg:      ["18px", { lineHeight: "1.6" }],
+        xl:      ["20px", { lineHeight: "1.4" }],
+        "2xl":   ["24px", { lineHeight: "1.3" }],
+        "3xl":   ["30px", { lineHeight: "1.25" }],
+        "4xl":   ["36px", { lineHeight: "1.2" }],
+        "5xl":   ["48px", { lineHeight: "1.15" }],
         display: ["60px", { lineHeight: "1.1", letterSpacing: "-0.02em" }],
       },
       lineHeight: {
-        tight: "1.2",
-        normal: "1.5",
+        tight:   "1.2",
+        normal:  "1.5",
         relaxed: "1.75",
       },
       backgroundImage: {
         "gradient-hero":
           "linear-gradient(135deg, #0B1A14 0%, #122A1F 50%, #1A3D2C 100%)",
-        "gradient-gold-cta": "linear-gradient(135deg, #D4A853 0%, #E0BA6A 100%)",
+        "gradient-gold-cta":
+          "linear-gradient(135deg, #D4A853 0%, #E0BA6A 100%)",
         "gradient-card-glow":
           "linear-gradient(135deg, rgba(52,211,153,0.05) 0%, rgba(212,168,83,0.05) 100%)",
       },


### PR DESCRIPTION
FE-REF-005 — Implement Surface and Elevation System

tailwind.config.ts:
- Add surface-0/1/2/3 color + backgroundColor tokens (0=canvas, 1=card, 2=elevated, 3=overlay); legacy bg-* aliases preserved for compat
- Add border-subtle/raised tokens alongside existing default/hover/focus
- Consolidate into single boxShadow block with elev-0/1/2/3 scale aligned to surface layers; legacy card/modal aliases kept

trades/page.tsx:
- Status chips: token-driven bg + matching border at status/20 opacity; completed/draft use neutral surface tokens instead of ad-hoc bg-bg-elevated
- Skeleton: header bg-surface-1, rows bg-surface-0
- Table: header bg-surface-1; even rows surface-0, odd rows surface-1; hover lifts to surface-2 + shadow-elev-2

SideNavBar.tsx:
- Sidebar chrome: bg-surface-1 + shadow-elev-1
- Active nav item: bg-surface-2 + shadow-elev-2 + border-l-gold
- Inactive hover: bg-surface-2/30 (replaces ad-hoc bg-white/5)
- Wallet card: bg-surface-2 + border-border-raised
closes #354 