### PR TITLE
docs: add backend data model relationships and event flow documentation

### DIFF
--- a/docs/data-model-relationships.md
+++ b/docs/data-model-relationships.md
@@ -1,0 +1,409 @@
+# Data Model Relationships
+
+This document describes the backend data models, their fields, relationships, and the
+business rules that govern state transitions. It is the authoritative reference for the
+Prisma schema at `backend/prisma/schema.prisma`.
+
+---
+
+## 1. Enums
+
+### TradeStatus
+
+| Value             | Description                                       |
+|-------------------|---------------------------------------------------|
+| `PENDING_SIGNATURE` | Trade created off-chain, awaiting on-chain funding |
+| `CREATED`         | Trade initialized on-chain                        |
+| `FUNDED`          | Buyer deposited USDC into escrow                  |
+| `DELIVERED`       | Seller confirmed delivery                         |
+| `COMPLETED`       | Funds released to seller (or after dispute)       |
+| `DISPUTED`        | Buyer or seller initiated a dispute               |
+| `CANCELLED`       | Trade cancelled before funding                    |
+
+### DisputeStatus
+
+| Value          | Description                              |
+|----------------|------------------------------------------|
+| `OPEN`         | Dispute filed, awaiting review           |
+| `UNDER_REVIEW` | Mediator actively reviewing evidence      |
+| `RESOLVED`     | Mediator issued a decision                |
+| `CLOSED`       | Dispute closed (funds released/refunded)  |
+
+### GoalStatus
+
+| Value       | Description               |
+|-------------|---------------------------|
+| `ACTIVE`    | Goal in progress          |
+| `COMPLETED` | Target amount reached     |
+| `CANCELLED` | Goal abandoned            |
+
+### ChainEventSyncStatus
+
+| Value          | Description                                        |
+|----------------|----------------------------------------------------|
+| `PENDING`      | Event received, not yet processed                  |
+| `RETRYING`     | Processing failed, scheduled for retry              |
+| `PROCESSED`    | Event handled successfully                         |
+| `DEAD_LETTER`  | All retry attempts exhausted, requires intervention |
+
+---
+
+## 2. Entity Relationship Diagram (Text)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                           User                                │
+│  id (PK) │ walletAddress (UK) │ displayName │ createdAt/At   │
+└──────────┬──────────────────────────────────────┬────────────┘
+           │ 1                      N             │
+           │ tradesBought (buyer)                 │ tradesSold (seller)
+           ▼                                      ▼
+┌──────────────────────────────────────────────────────────────┐
+│                           Trade                               │
+│  id (PK) │ tradeId (UK) │ buyerAddress (FK) │ sellerAddress   │
+│  amountUsdc │ status │ version │ fundedAt/deliveredAt/...      │
+└───────┬──────────────┬──────────────────┬────────────────────┘
+        │ 0..1          │ 0..1             │ N
+        │               │                  │
+        ▼               ▼                  ▼
+┌──────────────┐ ┌──────────────────┐ ┌─────────────────┐
+│   Dispute    │ │ DeliveryManifest │ │  TradeEvidence   │
+│  tradeId(FK) │ │  tradeId (FK)    │ │  tradeId (FK)    │
+│  initiator   │ │  driverName/hash │ │  cid │ filename  │
+│  status      │ │  vehicleReg, etc │ │  mimeType │ etc  │
+│  reason      │ └──────────────────┘ └─────────────────┘
+│  categoryId  │
+└──────┬───────┘
+       │ N
+       │
+       ▼
+┌──────────────────┐
+│ DisputeCategory  │
+│  id (PK)         │
+│  name (UK)       │
+│  description     │
+│  isActive        │
+└──────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│                            Vault                              │
+│  id (PK) │ vaultId (UK) │ ownerAddress (FK→User) │ balance   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │ 1
+                           │
+                           ▼ N
+┌──────────────────────────────────────────────────────────────┐
+│                            Goal                               │
+│  id (PK) │ goalId (UK) │ vaultId (FK→Vault) │ userId (FK→User)│
+│  targetAmount │ currentAmount │ deadline │ status             │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│                      ProcessedEvent                           │
+│  id (PK) │ ledgerSequence │ contractId │ eventId            │
+│  ─ UNIQUE (ledgerSequence, contractId, eventId)              │
+│  (Used for exactly-once event deduplication)                  │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│                      ChainEventOutbox                         │
+│  id (PK) │ ledgerSequence │ contractId │ eventId │ eventType │
+│  tradeId │ payload (JSON) │ status │ attempts │ nextAttemptAt│
+│  lastError │ deadLetteredAt │ processedAt                     │
+│  ─ UNIQUE (ledgerSequence, contractId, eventId)              │
+│  ─ INDEX (status, nextAttemptAt)  ── for retry polling        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Model Reference
+
+### 3.1 User
+
+**Table**: `User`
+
+| Column         | Type          | Constraints         | Description                                |
+|----------------|---------------|---------------------|--------------------------------------------|
+| `id`           | Int           | PK, autoincrement   | Internal primary key                       |
+| `walletAddress`| VarChar(255)  | Unique, NOT NULL    | Stellar wallet address (lowercase)         |
+| `displayName`  | VarChar(255)  | NOT NULL            | User display name                          |
+| `createdAt`    | DateTime      | @default(now())     | Account creation timestamp                 |
+| `updatedAt`    | DateTime      | @updatedAt          | Last update timestamp                      |
+
+**Indexes**: `walletAddress`
+
+**Relations**:
+- `tradesBought` → **Trade[]** — trades where this user is the buyer
+- `tradesSold` → **Trade[]** — trades where this user is the seller
+- `initiatedDisputes` → **Dispute[]** — disputes initiated by this user
+- `vaults` → **Vault[]** — savings vaults owned by this user
+- `goals` → **Goal[]** — savings goals created by this user
+
+### 3.2 Trade
+
+**Table**: `Trade`
+
+| Column            | Type          | Constraints         | Description                                   |
+|-------------------|---------------|---------------------|-----------------------------------------------|
+| `id`              | Int           | PK, autoincrement   | Internal primary key                          |
+| `tradeId`         | VarChar(255)  | Unique, NOT NULL    | On-chain trade identifier                     |
+| `buyerAddress`    | VarChar(255)  | FK→User             | Buyer wallet address (lowercase)              |
+| `sellerAddress`   | VarChar(255)  | FK→User             | Seller wallet address (lowercase)             |
+| `amountUsdc`      | VarChar(100)  | Default "0"         | Trade amount (string for precision)           |
+| `buyerLossBps`    | Int           | Default 5000        | Buyer loss share in basis points (50% default)|
+| `sellerLossBps`   | Int           | Default 5000        | Seller loss share in basis points (50% default)|
+| `version`         | Int           | Default 0           | Optimistic concurrency counter                |
+| `status`          | TradeStatus   | Default CREATED     | Current trade lifecycle status                |
+| `fundedAt`        | DateTime?     | Nullable            | Set once when trade transitions to FUNDED     |
+| `deliveredAt`     | DateTime?     | Nullable            | Set once when trade transitions to DELIVERED  |
+| `completedAt`     | DateTime?     | Nullable            | Set once when trade transitions to COMPLETED  |
+| `createdAt`       | DateTime      | @default(now())     | Record creation timestamp                     |
+| `updatedAt`       | DateTime      | @updatedAt          | Last update timestamp                         |
+
+**Indexes**: `tradeId`, `buyerAddress`, `sellerAddress`, `status`
+
+**Relations**:
+- `buyer` → **User** (M:1) — joined on `buyerAddress` → `walletAddress`
+- `seller` → **User** (M:1) — joined on `sellerAddress` → `walletAddress`
+- `dispute` → **Dispute?** (1:0..1) — optional dispute on this trade
+- `manifest` → **DeliveryManifest?** (1:0..1) — optional delivery manifest
+- `evidence` → **TradeEvidence[]** (1:N) — evidence files for this trade
+
+### 3.3 Dispute
+
+**Table**: `Dispute`
+
+| Column       | Type          | Constraints         | Description                               |
+|--------------|---------------|---------------------|-------------------------------------------|
+| `id`         | Int           | PK, autoincrement   | Internal primary key                      |
+| `tradeId`    | VarChar(255)  | Unique, FK→Trade    | Associated trade ID                       |
+| `initiator`  | VarChar(255)  | FK→User             | Wallet address of the disputing party     |
+| `reason`     | Text          | NOT NULL            | Reason for the dispute                    |
+| `status`     | DisputeStatus | Default OPEN        | Current dispute state                     |
+| `resolvedAt` | DateTime?     | Nullable            | Resolution timestamp                      |
+| `categoryId` | Int?          | FK→DisputeCategory  | Optional dispute category                 |
+| `createdAt`  | DateTime      | @default(now())     | Record creation timestamp                 |
+| `updatedAt`  | DateTime      | @updatedAt          | Last update timestamp                     |
+
+**Indexes**: `tradeId`, `initiator`, `status`, `categoryId`
+
+**Relations**:
+- `trade` → **Trade** (1:1) — joined on `tradeId` (cascade delete)
+- `initiatorUser` → **User** (M:1) — joined on `initiator` → `walletAddress`
+- `category` → **DisputeCategory?** (M:1) — joined on `categoryId`
+
+### 3.4 DisputeCategory
+
+**Table**: `DisputeCategory`
+
+| Column        | Type          | Constraints         | Description                        |
+|---------------|---------------|---------------------|------------------------------------|
+| `id`          | Int           | PK, autoincrement   | Internal primary key               |
+| `name`        | VarChar(100)  | Unique, NOT NULL    | Category name                      |
+| `description` | Text?         | Nullable            | Optional description               |
+| `isActive`    | Boolean       | Default true        | Soft-enable/disable flag           |
+| `createdAt`   | DateTime      | @default(now())     | Record creation timestamp          |
+| `updatedAt`   | DateTime      | @updatedAt          | Last update timestamp              |
+
+**Indexes**: `name`, `isActive`
+
+**Relations**:
+- `disputes` → **Dispute[]** (1:N) — disputes assigned to this category
+
+### 3.5 DeliveryManifest
+
+**Table**: `DeliveryManifest`
+
+| Column              | Type          | Constraints         | Description                                        |
+|---------------------|---------------|---------------------|----------------------------------------------------|
+| `id`                | Int           | PK, autoincrement   | Internal primary key                               |
+| `tradeId`           | VarChar(255)  | Unique, FK→Trade    | Associated trade ID                                |
+| `driverName`        | VarChar(255)  | NOT NULL            | Plaintext driver name (mediator-only access)        |
+| `driverIdNumber`    | VarChar(255)  | NOT NULL            | Raw driver ID number                               |
+| `vehicleRegistration| VarChar(100)  | NOT NULL            | Vehicle registration                               |
+| `routeDescription`  | Text          | NOT NULL            | Route description                                  |
+| `expectedDeliveryAt`| DateTime      | NOT NULL            | Expected delivery timestamp                         |
+| `driverNameHash`    | VarChar(64)   | NOT NULL            | SHA-256 hash of driverName (sent on-chain)         |
+| `driverIdHash`      | VarChar(64)   | NOT NULL            | SHA-256 hash of driverIdNumber (sent on-chain)     |
+| `createdAt`         | DateTime      | @default(now())     | Record creation timestamp                          |
+
+**Indexes**: `tradeId`
+
+**Relations**:
+- `trade` → **Trade** (1:1) — joined on `tradeId` (cascade delete)
+
+### 3.6 TradeEvidence
+
+**Table**: `TradeEvidence`
+
+| Column       | Type          | Constraints         | Description                        |
+|--------------|---------------|---------------------|------------------------------------|
+| `id`         | Int           | PK, autoincrement   | Internal primary key               |
+| `tradeId`    | VarChar(255)  | FK→Trade            | Associated trade ID                |
+| `cid`        | VarChar(255)  | NOT NULL            | IPFS content identifier            |
+| `filename`   | VarChar(255)  | NOT NULL            | Original filename                  |
+| `mimeType`   | VarChar(100)  | NOT NULL            | MIME type of the file              |
+| `uploadedBy` | VarChar(255)  | NOT NULL            | Wallet address of uploader         |
+| `createdAt`  | DateTime      | @default(now())     | Upload timestamp                   |
+
+**Indexes**: `tradeId`, `cid`
+
+**Relations**:
+- `trade` → **Trade** (1:1) — joined on `tradeId` (cascade delete)
+
+### 3.7 ProcessedEvent
+
+**Table**: `ProcessedEvent`
+
+| Column           | Type          | Constraints         | Description                                |
+|------------------|---------------|---------------------|--------------------------------------------|
+| `id`             | Int           | PK, autoincrement   | Internal primary key                       |
+| `ledgerSequence` | Int           | NOT NULL            | Stellar ledger sequence                    |
+| `contractId`     | VarChar(255)  | NOT NULL            | Emitting Soroban contract ID               |
+| `eventId`        | VarChar(255)  | NOT NULL            | Unique Soroban event ID                    |
+| `processedAt`    | DateTime      | @default(now())     | Processing timestamp                       |
+
+**Unique constraint**: `(ledgerSequence, contractId, eventId)`
+
+**Purpose**: Provides durable deduplication for the event listener. Combined with the
+in-memory `Set<String>` cache, it guarantees **exactly-once** event processing even
+across service restarts.
+
+### 3.8 ChainEventOutbox
+
+**Table**: `ChainEventOutbox`
+
+| Column           | Type                | Constraints         | Description                                    |
+|------------------|---------------------|---------------------|------------------------------------------------|
+| `id`             | Int                 | PK, autoincrement   | Internal primary key                           |
+| `ledgerSequence` | Int                 | NOT NULL            | Stellar ledger sequence                        |
+| `contractId`     | VarChar(255)        | NOT NULL            | Emitting contract ID                           |
+| `eventId`        | VarChar(255)        | NOT NULL            | Unique Soroban event ID                        |
+| `eventType`      | VarChar(100)        | NOT NULL            | Event type string (e.g. "TradeCreated")        |
+| `tradeId`        | VarChar(255)        | NOT NULL            | Associated trade ID                            |
+| `payload`        | Json                | NOT NULL            | Raw event payload data                         |
+| `status`         | ChainEventSyncStatus| Default PENDING     | Processing state                               |
+| `attempts`       | Int                 | Default 0           | Number of processing attempts                  |
+| `nextAttemptAt`  | DateTime            | Default now()       | When the next retry is scheduled               |
+| `lastError`      | Text?               | Nullable            | Error message from last failure                |
+| `deadLetteredAt` | DateTime?           | Nullable            | When the event was moved to dead-letter        |
+| `processedAt`    | DateTime?           | Nullable            | When the event was successfully processed      |
+| `createdAt`      | DateTime            | @default(now())     | Record creation timestamp                      |
+| `updatedAt`      | DateTime            | @updatedAt          | Last update timestamp                          |
+
+**Unique constraint**: `(ledgerSequence, contractId, eventId)`
+**Index**: `(status, nextAttemptAt)` — for efficient retry polling
+
+**Purpose**: Provides a retryable outbox for event processing. Failed events are
+retried with exponential backoff (default 5 max attempts). Events that exhaust
+all retries are moved to `DEAD_LETTER` state for manual intervention.
+
+### 3.9 Vault
+
+**Table**: `Vault`
+
+| Column        | Type          | Constraints         | Description                                 |
+|---------------|---------------|---------------------|---------------------------------------------|
+| `id`          | Int           | PK, autoincrement   | Internal primary key                        |
+| `vaultId`     | VarChar(255)  | Unique, NOT NULL    | On-chain vault identifier                   |
+| `ownerAddress`| VarChar(255)  | FK→User             | Vault owner wallet address                  |
+| `balanceUsdc` | VarChar(100)  | Default "0"         | Current balance (string for precision)      |
+| `createdAt`   | DateTime      | @default(now())     | Record creation timestamp                   |
+| `updatedAt`   | DateTime      | @updatedAt          | Last update timestamp                       |
+
+**Indexes**: `vaultId`, `ownerAddress`
+
+**Relations**:
+- `owner` → **User** (M:1) — joined on `ownerAddress` → `walletAddress`
+- `goals` → **Goal[]** (1:N) — savings goals targeting this vault
+
+### 3.10 Goal
+
+**Table**: `Goal`
+
+| Column              | Type        | Constraints         | Description                              |
+|---------------------|-------------|---------------------|------------------------------------------|
+| `id`                | Int         | PK, autoincrement   | Internal primary key                     |
+| `goalId`            | VarChar(255)| Unique, NOT NULL    | On-chain goal identifier                 |
+| `vaultId`           | VarChar(255)| FK→Vault            | Parent vault ID                          |
+| `userId`            | Int         | FK→User             | Goal creator user ID                     |
+| `targetAmountUsdc`  | VarChar(100)| NOT NULL            | Target amount (string for precision)     |
+| `currentAmountUsdc` | VarChar(100)| Default "0"         | Current accumulated amount               |
+| `deadline`          | DateTime    | NOT NULL            | Target completion date                   |
+| `status`            | GoalStatus  | Default ACTIVE      | Goal lifecycle state                     |
+| `createdAt`         | DateTime    | @default(now())     | Record creation timestamp                |
+| `updatedAt`         | DateTime    | @updatedAt          | Last update timestamp                    |
+
+**Indexes**: `goalId`, `vaultId`, `userId`, `status`
+
+**Relations**:
+- `vault` → **Vault** (M:1) — joined on `vaultId` (cascade delete)
+- `user` → **User** (M:1) — joined on `userId` (cascade delete)
+
+---
+
+## 4. Trade State Machine
+
+The `Trade.status` field follows a strict state machine enforced by the event handler
+layer (`backend/src/services/eventHandlers.ts`). Only the transitions below are allowed
+(see `VALID_PREDECESSORS` map); all others are silently ignored.
+
+```
+  PENDING_SIGNATURE ──► CREATED ──► FUNDED ──► DELIVERED ──► COMPLETED
+                                       │
+                                       ▼
+                                    DISPUTED ──► COMPLETED
+```
+
+| Transition                  | Triggering Event       | Valid Predecessors       | Description                          |
+|-----------------------------|------------------------|--------------------------|--------------------------------------|
+| → CREATED                   | `TradeCreated`         | (none — creates record)  | Trade initialized on-chain           |
+| CREATED → FUNDED            | `TradeFunded`          | CREATED                  | Buyer deposited funds                |
+| FUNDED → DELIVERED          | `DeliveryConfirmed`    | FUNDED                   | Seller claims delivery               |
+| DELIVERED → COMPLETED       | `FundsReleased`        | DELIVERED                | Funds released to seller             |
+| FUNDED → DISPUTED           | `DisputeInitiated`     | FUNDED                   | Dispute opened by buyer/seller       |
+| DISPUTED → COMPLETED        | `DisputeResolved`      | DISPUTED                 | Mediator resolved the dispute        |
+
+**Optimistic Concurrency Control**: Each transition uses a compare-and-swap pattern:
+- Verifies the current `status` and `version` match expected values
+- Increments `version` on success
+- Throws a concurrency conflict if another handler already moved the state
+
+---
+
+## 5. Canonical Timestamps
+
+Three timestamp fields are set exactly once during the trade lifecycle and never
+overwritten:
+
+| Field          | Set When                              | Set By Event           |
+|----------------|---------------------------------------|------------------------|
+| `fundedAt`     | Trade transitions to FUNDED           | `TradeFunded`          |
+| `deliveredAt`  | Trade transitions to DELIVERED        | `DeliveryConfirmed`    |
+| `completedAt`  | Trade transitions to COMPLETED        | `FundsReleased` or     |
+|                |                                       | `DisputeResolved`      |
+
+These fields serve as single source of truth for auditing and reporting.
+
+---
+
+## 6. Relationship Summary
+
+| Model              | Related Models                                     | Type     |
+|--------------------|----------------------------------------------------|----------|
+| **User**           | Trade (bought), Trade (sold), Dispute, Vault, Goal | 1:N      |
+| **Trade**          | User (buyer/seller), Dispute, Manifest, Evidence   | N:1 / 1:1|
+| **Dispute**        | Trade, User (initiator), DisputeCategory           | N:1      |
+| **DisputeCategory**| Dispute                                            | 1:N      |
+| **DeliveryManifest**| Trade                                              | 1:1      |
+| **TradeEvidence**  | Trade                                              | N:1      |
+| **ProcessedEvent** | (standalone — dedup marker)                        | —        |
+| **ChainEventOutbox**| (standalone — retry queue)                        | —        |
+| **Vault**          | User, Goal                                         | N:1 / 1:N|
+| **Goal**           | Vault, User                                        | N:1      |
+
+All foreign-key relationships use **cascade delete** where the child is conceptually
+owned by the parent (Dispute, Manifest, Evidence, Goal). The `User`→`Trade` and
+`User`→`Dispute` relations use wallet addresses as natural keys (`walletAddress`
+lowercase stored in `VarChar`).

--- a/docs/event-flow.md
+++ b/docs/event-flow.md
@@ -1,0 +1,453 @@
+# Event Flow
+
+This document describes the end-to-end flow of on-chain Soroban contract events into
+the Amana backend, including how they are polled, parsed, deduplicated, handled, and
+dispatched to external webhooks.
+
+---
+
+## 1. Architecture Overview
+
+```
+  ┌──────────────────┐
+  │  Stellar Network  │  ◄── User sends transaction
+  │  (Soroban RPC)    │
+  └────────┬─────────┘
+           │ poll (getEvents)
+           ▼
+  ┌──────────────────┐
+  │ EventListener    │  Recursive setTimeout loop
+  │ Service          │  In-memory Set for fast dedup
+  │                  │  DB-backed ProcessedEvent for durable dedup
+  │                  │  ChainEventOutbox for retry persistence
+  └────────┬─────────┘
+           │ dispatchEvent()
+           ▼
+  ┌──────────────────┐
+  │  Event Handlers  │  handleTradeCreated / handleTradeFunded / etc.
+  │                  │  Atomic Prisma $transaction
+  │                  │  Optimistic concurrency (version field)
+  └────────┬─────────┘
+           │
+     ┌─────┴─────┐
+     ▼           ▼
+  ┌──────┐  ┌──────────┐
+  │  DB  │  │ Webhook  │  HTTP POST with HMAC-SHA256 signature
+  │      │  │ Service  │  trade.{status} event format
+  └──────┘  └──────────┘
+```
+
+### Key Files
+
+| Layer | File |
+|-------|------|
+| Config | `backend/src/config/eventListener.config.ts` |
+| Types | `backend/src/types/events.ts` |
+| Listener | `backend/src/services/eventListener.service.ts` |
+| Handlers | `backend/src/services/eventHandlers.ts` |
+| Webhooks | `backend/src/services/webhook.service.ts` |
+| Dedup model | `prisma/schema.prisma` → `ProcessedEvent` |
+| Outbox model | `prisma/schema.prisma` → `ChainEventOutbox` |
+| Startup | `backend/src/index.ts` |
+
+---
+
+## 2. Smart Contract Events
+
+The Soroban contract (`contracts/amana_escrow/src/lib.rs`) emits 14 event types.
+The backend listens for the 6 **status-transition** events below. Other events
+(EvidenceSubmitted, VideoProofSubmitted, ManifestSubmitted, etc.) are recorded on-chain
+but not currently handled by the backend event listener.
+
+| # | Event (contract)              | Topic Symbol | Backend EventType       | Resulting TradeStatus |
+|---|-------------------------------|--------------|-------------------------|-----------------------|
+| 1 | `TradeCreatedEvent`           | `TRDCRT`     | `TradeCreated`          | CREATED               |
+| 2 | `TradeFundedEvent`            | `TRDFND`     | `TradeFunded`           | FUNDED                |
+| 3 | `DeliveryConfirmedEvent`      | `DELCNF`     | `DeliveryConfirmed`     | DELIVERED             |
+| 4 | `FundsReleasedEvent`          | `RELSD`      | `FundsReleased`         | COMPLETED             |
+| 5 | `DisputeInitiatedEvent`       | `DISINI`     | `DisputeInitiated`      | DISPUTED              |
+| 6 | `DisputeResolvedEvent`        | `DISRES`     | `DisputeResolved`       | COMPLETED             |
+
+Non-status events (not consumed by the backend listener):
+- `TradeCancelledEvent` (`TRDCAN`)
+- `EvidenceSubmittedEvent` (`EVDSUB`)
+- `VideoProofSubmittedEvent` (`VIDPRF`)
+- `ManifestSubmittedEvent` (`MNFST`)
+- `MediatorAddedEvent` (`MEDADD`)
+- `MediatorRemovedEvent` (`MEDREM`)
+- `InitializedEvent`
+
+---
+
+## 3. Event Listener Service
+
+### 3.1 Lifecycle
+
+The `EventListenerService` is created in `backend/src/index.ts` and started after the
+Express app initializes. It runs as a background polling loop for the lifetime of the
+process.
+
+```
+App boot ──► Create EventListenerService ──► service.start()
+                                                  │
+                                                  ▼
+                                          Hydrate in-memory cache
+                                          (last N processed ledgers from DB)
+                                                  │
+                                                  ▼
+                                          Schedule first poll
+```
+
+On graceful shutdown (`SIGTERM`/`SIGINT`), `service.stop()` is called to clear the
+timeout.
+
+### 3.2 Polling Loop
+
+The loop uses **recursive `setTimeout`** (not `setInterval`) to prevent overlapping
+polls. Each cycle:
+
+```
+  1. Call server.getEvents({
+       startLedger: lastLedger + 1,
+       filters: [{ type: "contract", contractIds: [contractId] }],
+       limit: 100
+     })
+  2. For each raw event in response:
+       a. Parse XDR → ParsedEvent (parseEvent)
+       b. Check in-memory Set (fast path)
+       c. Check ProcessedEvent DB table (durable path)
+       d. Process via outbox or atomic transaction
+  3. On success:
+       - Reset backoff to initial value
+       - Schedule next poll at pollIntervalMs
+  4. On RPC failure:
+       - Apply exponential backoff with jitter
+       - Schedule retry at backoff delay
+```
+
+### 3.3 Parsing
+
+Raw Soroban events arrive as `StellarSdk.rpc.Api.EventResponse` objects. The
+`parseEvent()` method extracts:
+
+- **eventType**: Mapped from the first topic element via `mapSymbolToEventType()`
+  (supports both PascalCase and snake_case symbols, e.g. `TradeCreated` or
+  `trade_created`)
+- **tradeId**: Extracted from the second topic element
+- **ledgerSequence**: From `rawEvent.ledger`
+- **contractId**: From `rawEvent.contractId` or config default
+- **eventId**: From `rawEvent.id`
+- **data**: Parsed map entries from the XDR event value
+
+### 3.4 Event Dispatch
+
+A parsed event is dispatched via:
+
+```
+dispatchEvent(tx, parsedEvent) ──► handlers[eventType](tx, parsedEvent)
+```
+
+The handler registry:
+
+| EventType             | Handler                  |
+|-----------------------|--------------------------|
+| `TradeCreated`        | `handleTradeCreated`     |
+| `TradeFunded`         | `handleTradeFunded`      |
+| `DeliveryConfirmed`   | `handleDeliveryConfirmed`|
+| `FundsReleased`       | `handleFundsReleased`    |
+| `DisputeInitiated`    | `handleDisputeInitiated` |
+| `DisputeResolved`     | `handleDisputeResolved`  |
+
+---
+
+## 4. Exactly-Once Processing
+
+The event listener guarantees **exactly-once** semantics through a two-layer
+deduplication strategy:
+
+```
+Incoming Event
+      │
+      ▼
+┌─────────────────────┐
+│ In-Memory Set       │  Fast path — O(1) lookup
+│ cacheKey =           │  Hydrated from DB on startup
+│ "{ledger}:{ctr}:{id}"│  LRU-evicted at capacity limit
+└─────────┬───────────┘
+     ┌────┴────┐
+     │  Hit?   │── Yes ──► Skip
+     └────┬────┘
+          │ No
+          ▼
+┌──────────────────────┐
+│ DB ProcessedEvent    │  Durable path — survives restarts
+│ findUnique({          │  Unique on (ledgerSequence, contractId, eventId)
+│   ledgerSequence,     │
+│   contractId,         │
+│   eventId             │
+│ })                    │
+└──────────┬───────────┘
+     ┌─────┴─────┐
+     │ Exists?   │── Yes ──► Add to in-memory cache, skip
+     └─────┬─────┘
+           │ No
+           ▼
+┌──────────────────────┐
+│ Atomic Transaction   │  Prisma $transaction wrapping:
+│                       │   1. handler(tx, event) — DB mutations
+│                       │   2. processedEvent.create(...) — dedup marker
+│                       │  Both succeed or both roll back
+└──────────────────────┘
+```
+
+### Cache Hydration
+
+On startup, the service loads the most recent `processedLedgersCacheSize` (default
+10,000) `ProcessedEvent` records into the in-memory `Set`. This prevents re-processing
+events that were handled before a restart.
+
+### In-Memory Eviction
+
+When the in-memory set exceeds `processedLedgersCacheSize`, the oldest entries (by
+ledger sequence) are evicted. The DB record remains as the durable source of truth.
+
+---
+
+## 5. ChainEventOutbox (Retry & Dead-Letter)
+
+When outbox persistence is available (the `ChainEventOutbox` model exists), the event
+listener uses an outbox pattern for resilient processing:
+
+### 5.1 Processing Flow with Outbox
+
+```
+  1. ensureOutboxRecord(event)
+     - Upserts a ChainEventOutbox row with status = PENDING
+     - Unique on (ledgerSequence, contractId, eventId)
+
+  2. isOutboxReadyForAttempt(outbox)
+     - Skips if status is PROCESSED or DEAD_LETTER
+     - Skips if nextAttemptAt is in the future
+
+  3. processOutboxEventAtomically(outboxId, event)
+     - Prisma $transaction:
+       a. handler(tx, event) — business logic
+       b. processedEvent.create(...) — dedup marker
+       c. chainEventOutbox.update(...) → PROCESSED status
+
+  4. On failure:
+     - recordOutboxFailure(outbox, error)
+     - Increments attempts counter
+     - If attempts < maxAttempts: status = RETRYING,
+       nextAttemptAt = now + exponential_backoff(attempts)
+     - If attempts >= maxAttempts: status = DEAD_LETTER,
+       deadLetteredAt = now
+```
+
+### 5.2 Retry Schedule
+
+| Attempt | Delay (default config: initial=1s, max=30s) |
+|---------|---------------------------------------------|
+| 1       | ~1s (initial backoff + random jitter)       |
+| 2       | ~2s                                         |
+| 3       | ~4s                                         |
+| 4       | ~8s                                         |
+| 5       | ~16s                                        |
+| 6       | Dead-letter (no more retries)               |
+
+Default max attempts: **5** (configurable via `EVENT_OUTBOX_MAX_ATTEMPTS`).
+
+### 5.3 Outbox Status State Machine
+
+```
+  PENDING ──► RETRYING ──► PROCESSED
+                │
+                ▼
+            DEAD_LETTER
+```
+
+### 5.4 Dead-Letter Recovery
+
+Events in `DEAD_LETTER` state require manual intervention. The `lastError` field
+contains the error message for debugging. After the root cause is fixed, an operator
+can reset the status to `PENDING` or `RETRYING` to re-attempt processing.
+
+---
+
+## 6. Event Handlers — Business Logic
+
+### 6.1 `handleTradeCreated`
+
+```typescript
+async function handleTradeCreated(tx, event)
+```
+
+1. Extracts `buyer`, `seller`, `amount_usdc` from `event.data`
+2. Calls `applyStatusTransition()` which:
+   - Checks if a `Trade` record exists for `event.tradeId`
+   - If **not found**: creates a new `Trade` record with `status = CREATED`, `version = 1`
+   - If **found**: validates the current status is a valid predecessor (for
+     `TradeCreated`, no predecessor check since the event creates the record)
+3. Dispatches webhook: `trade.created`
+
+### 6.2 `handleTradeFunded`
+
+```typescript
+async function handleTradeFunded(tx, event)
+```
+
+1. Calls `applyStatusTransition()`:
+   - Validates current status is `CREATED` (see `VALID_PREDECESSORS`)
+   - Updates trade to `status = FUNDED`, increments `version`
+   - Sets `fundedAt` canonical timestamp
+2. Dispatches webhook: `trade.funded`
+3. Logs payment authorization approval
+
+### 6.3 `handleDeliveryConfirmed`
+
+```typescript
+async function handleDeliveryConfirmed(tx, event)
+```
+
+1. Calls `applyStatusTransition()`:
+   - Validates current status is `FUNDED`
+   - Updates trade to `status = DELIVERED`, increments `version`
+   - Sets `deliveredAt` canonical timestamp
+2. Dispatches webhook: `trade.delivered`
+
+### 6.4 `handleFundsReleased`
+
+```typescript
+async function handleFundsReleased(tx, event)
+```
+
+1. Calls `applyStatusTransition()`:
+   - Validates current status is `DELIVERED`
+   - Updates trade to `status = COMPLETED`, increments `version`
+   - Sets `completedAt` canonical timestamp
+2. Dispatches webhook: `trade.completed`
+
+### 6.5 `handleDisputeInitiated`
+
+```typescript
+async function handleDisputeInitiated(tx, event)
+```
+
+1. Calls `applyStatusTransition()`:
+   - Validates current status is `FUNDED`
+   - Updates trade to `status = DISPUTED`, increments `version`
+2. Dispatches webhook: `trade.disputed`
+
+### 6.6 `handleDisputeResolved`
+
+```typescript
+async function handleDisputeResolved(tx, event)
+```
+
+1. Calls `applyStatusTransition()`:
+   - Validates current status is `DISPUTED`
+   - Updates trade to `status = COMPLETED`, increments `version`
+   - Sets `completedAt` canonical timestamp
+2. Dispatches webhook: `trade.completed`
+
+---
+
+## 7. `applyStatusTransition` — Core State Machine
+
+This function implements the optimistic concurrency control for all status transitions:
+
+```
+1. Find existing Trade by tradeId
+2. If not found: create Trade record (only for TradeCreated)
+3. If found:
+   a. Check VALID_PREDECESSORS[eventType] includes current status
+      - If invalid: silently return (idempotent no-op)
+   b. updateMany({
+        where: {
+          tradeId,
+          status: currentStatus,     // CAS on status
+          version: currentVersion     // CAS on version
+        },
+        data: {
+          status: newStatus,
+          version: { increment: 1 },  // monotonic counter
+          updatedAt: new Date()
+        }
+      })
+   c. If result.count === 0: throw "Concurrency conflict"
+      (another handler already moved the state)
+```
+
+This pattern ensures:
+- **Idempotency**: Replaying an already-applied event is a no-op
+- **Linearizability**: Concurrent handlers for the same trade cannot race
+- **Ordering**: Events applied out-of-order are ignored by predecessor validation
+
+---
+
+## 8. Webhook Dispatch
+
+After each successful status transition, the `WebhookService` sends an HTTP POST to
+the configured webhook URL (`WEBHOOK_URL` env var).
+
+### Payload Format
+
+```json
+{
+  "event": "trade.created",
+  "tradeId": "12345",
+  "status": "CREATED",
+  "timestamp": "2026-05-29T12:00:00.000Z",
+  "data": {
+    "ledger": 123456
+  }
+}
+```
+
+### Security
+
+- If `WEBHOOK_SECRET` is configured, the payload is signed with **HMAC-SHA256**
+- The signature is sent in the `X-Webhook-Signature` header
+- Receivers can verify the signature using the shared secret
+
+### Error Handling
+
+- Non-OK responses are logged as warnings
+- Network/protocol errors are logged as errors
+- Webhook failures do **not** block event processing or roll back the DB transaction
+- The webhook is fire-and-forget; no retry mechanism is built in (re-delivery would
+  require replaying on-chain events)
+
+---
+
+## 9. Configuration Reference
+
+All event listener configuration is in `backend/src/config/eventListener.config.ts`,
+overridable via environment variables.
+
+| Variable                     | Default                              | Description                              |
+|------------------------------|--------------------------------------|------------------------------------------|
+| `STELLAR_RPC_URL`            | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint                     |
+| `CONTRACT_ID`                | `""`                                 | Target Soroban contract ID               |
+| `EVENT_POLL_INTERVAL_MS`     | `10000`                              | Polling interval in milliseconds         |
+| `BACKOFF_INITIAL_MS`         | `1000`                               | Initial RPC backoff delay                |
+| `BACKOFF_MAX_MS`             | `30000`                              | Maximum RPC backoff delay                |
+| `PROCESSED_LEDGERS_CACHE_SIZE`| `10000`                             | In-memory dedup cache capacity           |
+| `EVENT_OUTBOX_MAX_ATTEMPTS`  | `5`                                  | Outbox retry limit before dead-letter    |
+| `WEBHOOK_URL`                | (none)                               | Webhook destination URL                  |
+| `WEBHOOK_SECRET`             | (none)                               | HMAC-SHA256 signing key                  |
+
+---
+
+## 10. Testing
+
+| Test File | Description | Lines |
+|-----------|-------------|-------|
+| `backend/src/__tests__/events.integration.test.ts` | End-to-end event emission & consumption | 984 |
+| `backend/src/__tests__/eventHandlers.test.ts` | Unit tests for each event handler | 262 |
+| `backend/src/__tests__/eventListener.test.ts` | EventListenerService poll/parse/dispatch | 625 |
+| `backend/src/__tests__/eventListener.outbox.test.ts` | Outbox retry & dead-letter behavior | 170 |
+| `backend/src/__tests__/eventListener.idempotency.test.ts` | Exactly-once dedup semantics | 511 |
+| `backend/src/__tests__/event.ingestion.test.ts` | Event ingestion pipeline | — |
+| `contracts/amana_escrow/tests/event_emission_tests.rs` | Contract-level event emission validation | 469 |
+| `contracts/amana_escrow/src/tests/event_schema_tests.rs` | Unit-level event schema validation | — |


### PR DESCRIPTION
Closes #528

---

## Summary

Adds two comprehensive documentation files covering backend data models and event flow.

### docs/data-model-relationships.md
- All 10 Prisma models with field references, constraints, and descriptions
- Text ER diagram showing entity relationships
- Trade state machine with valid predecessor transitions
- Canonical timestamp semantics
- All 4 enums

### docs/event-flow.md
- End-to-end event flow from Soroban contract to webhooks
- Two-layer exactly-once dedup strategy
- ChainEventOutbox retry pattern with dead-letter queue
- Optimistic concurrency control
- Webhook payload format with HMAC-SHA256 signing

## Testing
Documentation only — no code changes.