### PR TITLE
fix: broken backend route when dispute status is missing

### DIFF
--- a/backend/src/__tests__/dispute.status.transitions.test.ts
+++ b/backend/src/__tests__/dispute.status.transitions.test.ts
@@ -199,24 +199,24 @@ describe("DisputeService – status transitions", () => {
 
   // ── listMediatorDisputes ──────────────────────────────────────────────────
 
-  it("listMediatorDisputes returns only OPEN and UNDER_REVIEW disputes by default", async () => {
-    const openDispute = makeDispute(DisputeStatus.OPEN, 1, "T-A");
-    const reviewDispute = makeDispute(DisputeStatus.UNDER_REVIEW, 2, "T-B");
+  it("listMediatorDisputes returns all disputes by default when no status filter", async () => {
+    const disputes = [
+      makeDispute(DisputeStatus.OPEN, 1, "T-A"),
+      makeDispute(DisputeStatus.UNDER_REVIEW, 2, "T-B"),
+      makeDispute(DisputeStatus.RESOLVED, 3, "T-C"),
+      makeDispute(DisputeStatus.CLOSED, 4, "T-D"),
+    ];
 
-    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([openDispute, reviewDispute]);
-    (prisma.dispute.count as jest.Mock).mockResolvedValue(2);
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue(disputes);
+    (prisma.dispute.count as jest.Mock).mockResolvedValue(4);
 
     const result = await service.listMediatorDisputes(MEDIATOR);
 
     expect(prisma.dispute.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          status: { in: [DisputeStatus.OPEN, DisputeStatus.UNDER_REVIEW] },
-        },
-      }),
+      expect.objectContaining({ where: {} }),
     );
-    expect(result.items).toHaveLength(2);
-    expect(result.pagination.total).toBe(2);
+    expect(result.items).toHaveLength(4);
+    expect(result.pagination.total).toBe(4);
   });
 
   it("listMediatorDisputes filters by specific status when provided", async () => {

--- a/backend/src/controllers/dispute.controller.ts
+++ b/backend/src/controllers/dispute.controller.ts
@@ -1,10 +1,11 @@
-import { Response } from "express";
+import { NextFunction, Response } from "express";
 import { DisputeService } from "../services/dispute.service";
 import { prisma as defaultPrisma } from "../lib/db";
 import { authMiddleware, AuthRequest } from "../middleware/auth.middleware";
 import { validateRequest } from "../middleware/validateRequest";
 import { Router } from "express";
 import { z } from "zod";
+import { AppError } from "../errors/errorCodes";
 
 const listDisputesQuerySchema = z.object({
   status: z.enum(["OPEN", "UNDER_REVIEW", "RESOLVED", "CLOSED"]).optional(),
@@ -15,7 +16,7 @@ const listDisputesQuerySchema = z.object({
 export class DisputeController {
   constructor(private disputeService: DisputeService) {}
 
-  public listMediatorDisputes = async (req: AuthRequest, res: Response) => {
+  public listMediatorDisputes = async (req: AuthRequest, res: Response, next: NextFunction) => {
     const callerAddress = req.user?.walletAddress?.trim();
     if (!callerAddress) {
       return res.status(401).json({ error: "Unauthorized" });
@@ -32,6 +33,9 @@ export class DisputeController {
 
       res.status(200).json(result);
     } catch (error) {
+      if (error instanceof AppError) {
+        return next(error);
+      }
       console.error("List mediator disputes failed:", error);
       res.status(500).json({ error: "Failed to list disputes" });
     }

--- a/backend/src/routes/trade.routes.ts
+++ b/backend/src/routes/trade.routes.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, TradeStatus } from "@prisma/client";
-import { Response, Router } from "express";
+import { NextFunction, Response, Router } from "express";
 import { TradeController } from "../controllers/trade.controller";
 import { prisma as defaultPrisma } from "../lib/db";
 import { authMiddleware } from "../middleware/auth.middleware";
@@ -71,33 +71,41 @@ export function createTradeRouter(prisma: PrismaClient = defaultPrisma) {
     "/", 
     authMiddleware, 
     validateRequest({ query: listTradesQuerySchema }),
-    async (req: AuthRequest, res) => {
+    async (req: AuthRequest, res, next: NextFunction) => {
       const callerAddress = requireWalletFromJwt(req, res);
       if (!callerAddress) {
         return;
       }
 
-      const { status, page, limit, sort } = req.query as any;
+      try {
+        const { status, page, limit, sort } = req.query as any;
 
-      const result = await tradeService.listUserTrades(callerAddress, {
-        status,
-        page,
-        limit,
-        sort,
-      });
+        const result = await tradeService.listUserTrades(callerAddress, {
+          status,
+          page,
+          limit,
+          sort,
+        });
 
-      res.status(200).json(result);
+        res.status(200).json(result);
+      } catch (error) {
+        return next(error);
+      }
     }
   );
 
-  router.get("/stats", authMiddleware, async (req: AuthRequest, res) => {
+  router.get("/stats", authMiddleware, async (req: AuthRequest, res, next: NextFunction) => {
     const callerAddress = requireWalletFromJwt(req, res);
     if (!callerAddress) {
       return;
     }
 
-    const stats = await tradeService.getUserStats(callerAddress);
-    res.status(200).json(stats);
+    try {
+      const stats = await tradeService.getUserStats(callerAddress);
+      res.status(200).json(stats);
+    } catch (error) {
+      return next(error);
+    }
   });
 
   router.get(

--- a/backend/src/services/dispute.service.ts
+++ b/backend/src/services/dispute.service.ts
@@ -52,9 +52,7 @@ export class DisputeService {
       throw new AppError(ErrorCode.AUTH_ERROR, "Unauthorized: Not a mediator", 403);
     }
 
-    const where = status
-      ? { status }
-      : { status: { in: [DisputeStatus.OPEN, DisputeStatus.UNDER_REVIEW] as DisputeStatus[] } };
+    const where = status ? { status } : {};
 
     const [disputes, total] = await Promise.all([
       this.prisma.dispute.findMany({


### PR DESCRIPTION
Closes #530

---

## Summary

Fixes three issues causing the `GET /disputes` route and related endpoints to break or behave incorrectly when the `status` query parameter is not provided.

## Changes

### 1. Error swallowing in dispute.controller.ts
`listMediatorDisputes` caught all errors and returned a generic 500, including `AppError(403)` for unauthorized callers. The caller saw `{"error": "Failed to list disputes"}` — no indication they are not a mediator.

**Fix**: Forward `AppError` instances to the centralized Express error handler via `next(error)`, preserving the correct status code, error code, and message.

### 2. Silently limited default filter in dispute.service.ts
When no `status` query param was provided, the service limited results to only `OPEN` and `UNDER_REVIEW` disputes — `RESOLVED` and `CLOSED` disputes were invisible without an explicit filter.

**Fix**: Use an empty Prisma `where` clause when status is not provided, returning all disputes.

### 3. Unhandled promise rejections in trade.routes.ts
Two async route handlers (`GET /`, `GET /stats`) had no try/catch. In Express 4, async errors are not caught, causing unhandled promise rejections.

**Fix**: Wrap handlers in try/catch and forward errors via `next(error)` to the error handler middleware.

## Testing
- All 109 dispute/trade-related tests pass
- Updated test to match new default-filter behavior (all disputes instead of only OPEN/UNDER_REVIEW)