### PR TITLE
fix: backend reliability — dispute cleanup, access control, migration rollback safety, JWT claims validation

### DIFF
--- a/backend/src/__tests__/access.control.test.ts
+++ b/backend/src/__tests__/access.control.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the shared access-control helpers (Issue #525)
+ *
+ * Validates that getMediatorAllowlist and isMediatorAddress correctly parse
+ * ADMIN_STELLAR_PUBKEYS and enforce mediator/arbitrator route guards.
+ */
+import { getMediatorAllowlist, isMediatorAddress } from "../lib/accessControl";
+
+const ADDR_A = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const ADDR_B = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const ADDR_C = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+
+describe("getMediatorAllowlist", () => {
+  afterEach(() => {
+    delete process.env.ADMIN_STELLAR_PUBKEYS;
+  });
+
+  it("returns an empty set when env var is unset", () => {
+    delete process.env.ADMIN_STELLAR_PUBKEYS;
+    expect(getMediatorAllowlist().size).toBe(0);
+  });
+
+  it("returns an empty set when env var is an empty string", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = "";
+    expect(getMediatorAllowlist().size).toBe(0);
+  });
+
+  it("returns a set with one address for a single entry", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = ADDR_A;
+    const allowlist = getMediatorAllowlist();
+    expect(allowlist.size).toBe(1);
+    expect(allowlist.has(ADDR_A)).toBe(true);
+  });
+
+  it("returns all addresses for a comma-separated list", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = `${ADDR_A},${ADDR_B},${ADDR_C}`;
+    const allowlist = getMediatorAllowlist();
+    expect(allowlist.size).toBe(3);
+    expect(allowlist.has(ADDR_A)).toBe(true);
+    expect(allowlist.has(ADDR_B)).toBe(true);
+    expect(allowlist.has(ADDR_C)).toBe(true);
+  });
+
+  it("trims whitespace around addresses", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = `  ${ADDR_A}  ,  ${ADDR_B}  `;
+    const allowlist = getMediatorAllowlist();
+    expect(allowlist.has(ADDR_A)).toBe(true);
+    expect(allowlist.has(ADDR_B)).toBe(true);
+  });
+
+  it("ignores empty entries produced by trailing commas", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = `${ADDR_A},${ADDR_B},`;
+    const allowlist = getMediatorAllowlist();
+    expect(allowlist.size).toBe(2);
+  });
+
+  it("returns a new Set on each call (no shared mutable state)", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = ADDR_A;
+    const first = getMediatorAllowlist();
+    const second = getMediatorAllowlist();
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("isMediatorAddress", () => {
+  afterEach(() => {
+    delete process.env.ADMIN_STELLAR_PUBKEYS;
+  });
+
+  it("returns false when the allowlist is empty", () => {
+    delete process.env.ADMIN_STELLAR_PUBKEYS;
+    expect(isMediatorAddress(ADDR_A)).toBe(false);
+  });
+
+  it("returns true for an address that is in the allowlist", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = `${ADDR_A},${ADDR_B}`;
+    expect(isMediatorAddress(ADDR_A)).toBe(true);
+    expect(isMediatorAddress(ADDR_B)).toBe(true);
+  });
+
+  it("returns false for an address that is not in the allowlist", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = ADDR_A;
+    expect(isMediatorAddress(ADDR_B)).toBe(false);
+  });
+
+  it("is case-sensitive — uppercase and lowercase do not match", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = ADDR_A;
+    expect(isMediatorAddress(ADDR_A.toLowerCase())).toBe(false);
+  });
+
+  it("returns false for an empty-string address", () => {
+    process.env.ADMIN_STELLAR_PUBKEYS = ADDR_A;
+    expect(isMediatorAddress("")).toBe(false);
+  });
+});

--- a/backend/src/__tests__/dispute.cleanup.test.ts
+++ b/backend/src/__tests__/dispute.cleanup.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for DisputeService.purgeCompletedDisputeData (Issue #524)
+ *
+ * Validates the data-cleanup contract:
+ *  - Only mediators can trigger the purge
+ *  - Only RESOLVED/CLOSED disputes older than the cutoff are affected
+ *  - Active/open disputes are never touched
+ *  - Returns correct metadata (purgedCount, tradeIds)
+ */
+import { PrismaClient, DisputeStatus } from "@prisma/client";
+import { DisputeService, COMPLETED_DISPUTE_STATUSES } from "../services/dispute.service";
+import { ErrorCode } from "../errors/errorCodes";
+
+const MEDIATOR = "GA_MEDIATOR_ADDR_VALID";
+const NOW = new Date("2025-06-01T00:00:00.000Z");
+const OLD_DATE = new Date("2024-12-01T00:00:00.000Z"); // > 90 days ago
+const RECENT_DATE = new Date("2025-05-25T00:00:00.000Z"); // < 90 days ago
+
+function createMockPrisma() {
+  return {
+    dispute: {
+      findMany: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("DisputeService – purgeCompletedDisputeData", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+  let service: DisputeService;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new DisputeService(prisma as any);
+    process.env.ADMIN_STELLAR_PUBKEYS = MEDIATOR;
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_STELLAR_PUBKEYS;
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("throws AUTH_ERROR when caller is not a mediator", async () => {
+    await expect(
+      service.purgeCompletedDisputeData("GA_ATTACKER")
+    ).rejects.toMatchObject({ code: ErrorCode.AUTH_ERROR });
+    expect(prisma.dispute.findMany).not.toHaveBeenCalled();
+    expect(prisma.dispute.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns zero purgedCount when no completed disputes qualify", async () => {
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await service.purgeCompletedDisputeData(MEDIATOR);
+
+    expect(result.purgedCount).toBe(0);
+    expect(result.tradeIds).toEqual([]);
+    expect(prisma.dispute.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("purges reason field for qualifying completed disputes", async () => {
+    const rows = [
+      { id: 1, tradeId: "T-001" },
+      { id: 2, tradeId: "T-002" },
+    ];
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue(rows);
+    (prisma.dispute.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+    const result = await service.purgeCompletedDisputeData(MEDIATOR);
+
+    expect(result.purgedCount).toBe(2);
+    expect(result.tradeIds).toEqual(["T-001", "T-002"]);
+    expect(prisma.dispute.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: [1, 2] } },
+      data: { reason: "" },
+    });
+  });
+
+  it("queries with status filter limited to completed statuses", async () => {
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.purgeCompletedDisputeData(MEDIATOR);
+
+    expect(prisma.dispute.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: COMPLETED_DISPUTE_STATUSES },
+        }),
+      })
+    );
+  });
+
+  it("queries with a cutoff date based on olderThanDays", async () => {
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.purgeCompletedDisputeData(MEDIATOR, 90);
+
+    const call = (prisma.dispute.findMany as jest.Mock).mock.calls[0][0];
+    const cutoff: Date = call.where.resolvedAt.lte;
+    const expectedCutoff = new Date(NOW.getTime() - 90 * 24 * 60 * 60 * 1000);
+    expect(cutoff.getTime()).toBe(expectedCutoff.getTime());
+  });
+
+  it("respects custom olderThanDays parameter", async () => {
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.purgeCompletedDisputeData(MEDIATOR, 30);
+
+    const call = (prisma.dispute.findMany as jest.Mock).mock.calls[0][0];
+    const cutoff: Date = call.where.resolvedAt.lte;
+    const expectedCutoff = new Date(NOW.getTime() - 30 * 24 * 60 * 60 * 1000);
+    expect(cutoff.getTime()).toBe(expectedCutoff.getTime());
+  });
+
+  it("does not call updateMany when findMany returns empty", async () => {
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.purgeCompletedDisputeData(MEDIATOR);
+
+    expect(prisma.dispute.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("only selects id and tradeId in the query to minimise data exposure", async () => {
+    (prisma.dispute.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.purgeCompletedDisputeData(MEDIATOR);
+
+    expect(prisma.dispute.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { id: true, tradeId: true },
+      })
+    );
+  });
+});
+
+describe("COMPLETED_DISPUTE_STATUSES constant", () => {
+  it("contains RESOLVED and CLOSED", () => {
+    expect(COMPLETED_DISPUTE_STATUSES).toContain(DisputeStatus.RESOLVED);
+    expect(COMPLETED_DISPUTE_STATUSES).toContain(DisputeStatus.CLOSED);
+  });
+
+  it("does not contain OPEN or UNDER_REVIEW", () => {
+    expect(COMPLETED_DISPUTE_STATUSES).not.toContain(DisputeStatus.OPEN);
+    expect(COMPLETED_DISPUTE_STATUSES).not.toContain(DisputeStatus.UNDER_REVIEW);
+  });
+});

--- a/backend/src/__tests__/jwt.claims.test.ts
+++ b/backend/src/__tests__/jwt.claims.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for JWT claims validation helpers (Issue #527)
+ *
+ * Verifies that validateJwtClaims and assertJwtClaims correctly enforce the
+ * presence of required claims before service logic executes.
+ */
+import { validateJwtClaims, assertJwtClaims, requireWalletAddress } from "../lib/jwtClaims";
+import { JWTPayload } from "../services/auth.service";
+import { ErrorCode } from "../errors/errorCodes";
+
+const NOW = Math.floor(Date.now() / 1000);
+
+function validPayload(overrides: Partial<JWTPayload> = {}): JWTPayload {
+  return {
+    sub: "gaddr",
+    walletAddress: "GADDR_VALID",
+    jti: "test-jti-abc",
+    iat: NOW,
+    exp: NOW + 86400,
+    ...overrides,
+  };
+}
+
+// ── validateJwtClaims ────────────────────────────────────────────────────────
+
+describe("validateJwtClaims", () => {
+  it("returns valid=true for a complete payload", () => {
+    const result = validateJwtClaims(validPayload());
+    expect(result.valid).toBe(true);
+    expect(result.missingClaims).toEqual([]);
+  });
+
+  it("returns valid=false and lists 'sub' when sub is missing", () => {
+    const { sub: _sub, ...rest } = validPayload();
+    const result = validateJwtClaims(rest as Partial<JWTPayload>);
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("sub");
+  });
+
+  it("returns valid=false and lists 'walletAddress' when walletAddress is missing", () => {
+    const { walletAddress: _w, ...rest } = validPayload();
+    const result = validateJwtClaims(rest as Partial<JWTPayload>);
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("walletAddress");
+  });
+
+  it("returns valid=false and lists 'jti' when jti is missing", () => {
+    const { jti: _jti, ...rest } = validPayload();
+    const result = validateJwtClaims(rest as Partial<JWTPayload>);
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("jti");
+  });
+
+  it("returns valid=false and lists 'iat' when iat is missing", () => {
+    const { iat: _iat, ...rest } = validPayload();
+    const result = validateJwtClaims(rest as Partial<JWTPayload>);
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("iat");
+  });
+
+  it("returns valid=false and lists 'exp' when exp is missing", () => {
+    const { exp: _exp, ...rest } = validPayload();
+    const result = validateJwtClaims(rest as Partial<JWTPayload>);
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("exp");
+  });
+
+  it("reports all missing claims when multiple claims are absent", () => {
+    const result = validateJwtClaims({});
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("sub");
+    expect(result.missingClaims).toContain("walletAddress");
+    expect(result.missingClaims).toContain("jti");
+    expect(result.missingClaims).toContain("iat");
+    expect(result.missingClaims).toContain("exp");
+  });
+
+  it("treats an empty string walletAddress as missing", () => {
+    const result = validateJwtClaims(validPayload({ walletAddress: "" }));
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("walletAddress");
+  });
+
+  it("treats an empty string jti as missing", () => {
+    const result = validateJwtClaims(validPayload({ jti: "" }));
+    expect(result.valid).toBe(false);
+    expect(result.missingClaims).toContain("jti");
+  });
+
+  it("does not mutate the input payload", () => {
+    const payload = validPayload();
+    const copy = { ...payload };
+    validateJwtClaims(payload);
+    expect(payload).toEqual(copy);
+  });
+});
+
+// ── assertJwtClaims ──────────────────────────────────────────────────────────
+
+describe("assertJwtClaims", () => {
+  it("does not throw for a complete valid payload", () => {
+    expect(() => assertJwtClaims(validPayload())).not.toThrow();
+  });
+
+  it("throws AUTH_ERROR (401) when payload is undefined", () => {
+    expect(() => assertJwtClaims(undefined)).toThrow(
+      expect.objectContaining({
+        code: ErrorCode.AUTH_ERROR,
+        statusCode: 401,
+      })
+    );
+  });
+
+  it("throws AUTH_ERROR (401) when a required claim is missing", () => {
+    const { jti: _jti, ...rest } = validPayload();
+    expect(() => assertJwtClaims(rest as Partial<JWTPayload>)).toThrow(
+      expect.objectContaining({
+        code: ErrorCode.AUTH_ERROR,
+        statusCode: 401,
+      })
+    );
+  });
+
+  it("error message names the missing claims", () => {
+    const { jti: _jti, ...rest } = validPayload();
+    let caught: Error | undefined;
+    try {
+      assertJwtClaims(rest as Partial<JWTPayload>);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toMatch(/jti/);
+  });
+
+  it("error details contains missingClaims array", () => {
+    const { sub: _sub, walletAddress: _w, ...rest } = validPayload();
+    let caught: any;
+    try {
+      assertJwtClaims(rest as Partial<JWTPayload>);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught?.details?.missingClaims).toEqual(
+      expect.arrayContaining(["sub", "walletAddress"])
+    );
+  });
+});
+
+// ── requireWalletAddress ─────────────────────────────────────────────────────
+
+describe("requireWalletAddress", () => {
+  it("returns the trimmed walletAddress for a valid payload", () => {
+    const addr = requireWalletAddress(validPayload({ walletAddress: "  GADDR_VALID  " }));
+    expect(addr).toBe("GADDR_VALID");
+  });
+
+  it("throws AUTH_ERROR (401) when payload is undefined", () => {
+    expect(() => requireWalletAddress(undefined)).toThrow(
+      expect.objectContaining({ code: ErrorCode.AUTH_ERROR, statusCode: 401 })
+    );
+  });
+
+  it("throws AUTH_ERROR (401) when walletAddress is missing", () => {
+    const { walletAddress: _w, ...rest } = validPayload();
+    expect(() => requireWalletAddress(rest as Partial<JWTPayload>)).toThrow(
+      expect.objectContaining({ code: ErrorCode.AUTH_ERROR, statusCode: 401 })
+    );
+  });
+
+  it("throws AUTH_ERROR (401) when walletAddress is empty", () => {
+    expect(() => requireWalletAddress(validPayload({ walletAddress: "" }))).toThrow(
+      expect.objectContaining({ code: ErrorCode.AUTH_ERROR, statusCode: 401 })
+    );
+  });
+
+  it("throws AUTH_ERROR (401) when walletAddress is whitespace only", () => {
+    expect(() => requireWalletAddress(validPayload({ walletAddress: "   " }))).toThrow(
+      expect.objectContaining({ code: ErrorCode.AUTH_ERROR, statusCode: 401 })
+    );
+  });
+});

--- a/backend/src/__tests__/migration.rollback.test.ts
+++ b/backend/src/__tests__/migration.rollback.test.ts
@@ -1,0 +1,173 @@
+/**
+ * migration.rollback.test.ts  (Issue #523)
+ *
+ * Validates rollback-safety practices for schema migrations:
+ *  - Destructive DDL in a migration should be paired with a rollback.sql
+ *  - Rollback scripts must be valid (non-empty, contains reversal DDL)
+ *  - Non-destructive migrations do not require a rollback script
+ *  - Rollback SQL must not itself contain irreversible operations
+ *  - Idempotency markers (IF EXISTS / IF NOT EXISTS) are present where expected
+ *
+ * Runs entirely without a database connection — file-system checks only.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../prisma/migrations");
+
+const DESTRUCTIVE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /DROP\s+TABLE(?!\s+IF\s+EXISTS)/i,    label: "DROP TABLE (no IF EXISTS)" },
+  { pattern: /DROP\s+COLUMN(?!\s+IF\s+EXISTS)/i,   label: "DROP COLUMN (no IF EXISTS)" },
+  { pattern: /DROP\s+SCHEMA/i,                      label: "DROP SCHEMA" },
+  { pattern: /DROP\s+DATABASE/i,                    label: "DROP DATABASE" },
+  { pattern: /TRUNCATE/i,                           label: "TRUNCATE" },
+];
+
+const SAFE_ROLLBACK_FORBIDDEN: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /DROP\s+DATABASE/i, label: "DROP DATABASE in rollback" },
+  { pattern: /DROP\s+SCHEMA/i,   label: "DROP SCHEMA in rollback" },
+  { pattern: /TRUNCATE/i,        label: "TRUNCATE in rollback" },
+];
+
+function getMigrationDirs(): string[] {
+  if (!fs.existsSync(MIGRATIONS_DIR)) return [];
+  return fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => path.join(MIGRATIONS_DIR, d.name))
+    .sort();
+}
+
+function readFile(filePath: string): string | null {
+  if (!fs.existsSync(filePath)) return null;
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function hasDestructiveDDL(sql: string): { found: boolean; labels: string[] } {
+  const labels = DESTRUCTIVE_PATTERNS.filter(({ pattern }) => pattern.test(sql)).map(
+    ({ label }) => label
+  );
+  return { found: labels.length > 0, labels };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Rollback script presence", () => {
+  const dirs = getMigrationDirs();
+
+  it.each(dirs)("%s — migration with destructive DDL should have rollback.sql", (dir) => {
+    const sqlPath = path.join(dir, "migration.sql");
+    if (!fs.existsSync(sqlPath)) return;
+
+    const sql = fs.readFileSync(sqlPath, "utf8");
+    const { found, labels } = hasDestructiveDDL(sql);
+
+    if (found) {
+      const rollbackPath = path.join(dir, "rollback.sql");
+      const rollbackExists = fs.existsSync(rollbackPath);
+      // Report which patterns triggered the requirement
+      expect(
+        rollbackExists,
+        `Migration at ${path.basename(dir)} contains [${labels.join(", ")}] but has no rollback.sql`
+      ).toBe(true);
+    }
+  });
+
+  it.each(dirs)("%s — non-destructive migration does not require rollback.sql", (dir) => {
+    const sqlPath = path.join(dir, "migration.sql");
+    if (!fs.existsSync(sqlPath)) return;
+
+    const sql = fs.readFileSync(sqlPath, "utf8");
+    const { found } = hasDestructiveDDL(sql);
+
+    if (!found) {
+      // Non-destructive migrations are allowed to have a rollback.sql (belt-and-suspenders)
+      // but it is not required — this test simply confirms the classification is consistent.
+      expect(found).toBe(false);
+    }
+  });
+});
+
+describe("Rollback script validity", () => {
+  const dirs = getMigrationDirs();
+
+  it.each(dirs)("%s — rollback.sql (if present) is non-empty", (dir) => {
+    const rollbackPath = path.join(dir, "rollback.sql");
+    const rollback = readFile(rollbackPath);
+    if (rollback === null) return; // no rollback.sql — skip
+
+    expect(rollback.trim().length).toBeGreaterThan(0);
+  });
+
+  it.each(dirs)("%s — rollback.sql (if present) contains at least one DDL statement", (dir) => {
+    const rollbackPath = path.join(dir, "rollback.sql");
+    const rollback = readFile(rollbackPath);
+    if (rollback === null) return;
+
+    const hasDDL = /\b(CREATE|ALTER|DROP|INSERT|UPDATE|DELETE)\b/i.test(rollback);
+    expect(hasDDL).toBe(true);
+  });
+
+  it.each(dirs)(
+    "%s — rollback.sql (if present) does not contain catastrophic operations",
+    (dir) => {
+      const rollbackPath = path.join(dir, "rollback.sql");
+      const rollback = readFile(rollbackPath);
+      if (rollback === null) return;
+
+      for (const { pattern, label } of SAFE_ROLLBACK_FORBIDDEN) {
+        expect(pattern.test(rollback)).toBe(
+          false
+        );
+        void label;
+      }
+    }
+  );
+});
+
+describe("Idempotency markers in migration SQL", () => {
+  const IDEMPOTENT_CREATE = /CREATE\s+(?:TABLE|INDEX)\s+IF\s+NOT\s+EXISTS/i;
+  const IDEMPOTENT_DROP   = /DROP\s+(?:TABLE|INDEX|COLUMN)\s+IF\s+EXISTS/i;
+
+  it("CREATE TABLE IF NOT EXISTS pattern is idempotent", () => {
+    expect(IDEMPOTENT_CREATE.test("CREATE TABLE IF NOT EXISTS \"Foo\" (id SERIAL);")).toBe(true);
+  });
+
+  it("DROP TABLE IF EXISTS pattern is idempotent", () => {
+    expect(IDEMPOTENT_DROP.test('DROP TABLE IF EXISTS "OldFoo";')).toBe(true);
+  });
+
+  it("CREATE TABLE without IF NOT EXISTS is detected as non-idempotent", () => {
+    expect(IDEMPOTENT_CREATE.test('CREATE TABLE "Foo" (id SERIAL);')).toBe(false);
+  });
+});
+
+describe("Rollback safety regression samples", () => {
+  const ROLLBACK_REVERSAL_PAIRS: Array<{ forward: string; expected_reversal_pattern: RegExp }> = [
+    {
+      forward: 'ALTER TABLE "Foo" ADD COLUMN "bar" TEXT;',
+      expected_reversal_pattern: /ALTER\s+TABLE[^;]+DROP\s+COLUMN[^;]+"bar"/i,
+    },
+    {
+      forward: 'CREATE TABLE "NewTable" (id SERIAL PRIMARY KEY);',
+      expected_reversal_pattern: /DROP\s+TABLE[^;]+"NewTable"/i,
+    },
+    {
+      forward: 'CREATE INDEX idx_foo ON "Foo" ("bar");',
+      expected_reversal_pattern: /DROP\s+INDEX[^;]+idx_foo/i,
+    },
+  ];
+
+  it.each(ROLLBACK_REVERSAL_PAIRS)(
+    "forward migration '$forward' has a plausible reversal pattern",
+    ({ forward, expected_reversal_pattern }) => {
+      // This test documents the expected reversal form for common DDL operations.
+      // It validates the regex patterns used for rollback review rather than
+      // asserting that production rollback scripts exist.
+      expect(expected_reversal_pattern.source.length).toBeGreaterThan(0);
+      // The forward statement itself should NOT match its own reversal pattern.
+      expect(expected_reversal_pattern.test(forward)).toBe(false);
+    }
+  );
+});

--- a/backend/src/controllers/disputeCategory.controller.ts
+++ b/backend/src/controllers/disputeCategory.controller.ts
@@ -8,6 +8,7 @@ import {
   DisputeCategoryNotFoundError,
   DisputeCategoryNameConflictError,
 } from "../services/disputeCategory.service";
+import { isMediatorAddress } from "../lib/accessControl";
 
 const createCategorySchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(100, "Name must be 100 characters or fewer"),
@@ -31,14 +32,6 @@ const listCategoriesQuerySchema = z.object({
     .transform((v: string) => v === "true")
     .optional(),
 });
-
-function isMediatorAddress(address: string): boolean {
-  const mediatorAddresses = (process.env.ADMIN_STELLAR_PUBKEYS ?? "")
-    .split(",")
-    .map((a) => a.trim())
-    .filter(Boolean);
-  return mediatorAddresses.includes(address);
-}
 
 export class DisputeCategoryController {
   constructor(private categoryService: DisputeCategoryService) {}

--- a/backend/src/controllers/trade.controller.ts
+++ b/backend/src/controllers/trade.controller.ts
@@ -15,6 +15,7 @@ import {
   DisputeCategoryValidationError,
 } from "../services/trade.service";
 import { AppError, ErrorCode } from "../errors/errorCodes";
+import { getMediatorAllowlist } from "../lib/accessControl";
 
 const AMOUNT_USDC_PATTERN = /^\d+(?:\.\d{1,7})?$/;
 
@@ -26,13 +27,7 @@ interface CreateTradeBody {
 }
 
 function parseAdminPubkeys(): Set<string> {
-  const raw = process.env.ADMIN_STELLAR_PUBKEYS ?? "";
-  return new Set(
-    raw
-      .split(",")
-      .map((value) => value.trim())
-      .filter(Boolean),
-  );
+  return getMediatorAllowlist();
 }
 
 export function isBuyer(tradeBuyer: string, caller: string): boolean {

--- a/backend/src/lib/accessControl.ts
+++ b/backend/src/lib/accessControl.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared access-control helpers for mediator and arbitrator route guards.
+ *
+ * Centralises the ADMIN_STELLAR_PUBKEYS check so every controller and service
+ * reads the allowlist from the same place rather than duplicating the parsing
+ * logic inline.
+ */
+
+/** Returns the set of mediator/arbitrator addresses from the environment. */
+export function getMediatorAllowlist(): Set<string> {
+  return new Set(
+    (process.env.ADMIN_STELLAR_PUBKEYS ?? "")
+      .split(",")
+      .map((a: string) => a.trim())
+      .filter(Boolean)
+  );
+}
+
+/** Returns true when `address` appears in the ADMIN_STELLAR_PUBKEYS allowlist. */
+export function isMediatorAddress(address: string): boolean {
+  return getMediatorAllowlist().has(address);
+}

--- a/backend/src/lib/jwtClaims.ts
+++ b/backend/src/lib/jwtClaims.ts
@@ -1,0 +1,77 @@
+/**
+ * JWT claims validation helpers.
+ *
+ * Centralises pre-service claim checks so route handlers and service methods
+ * can validate required JWT fields before executing business logic, rather than
+ * scattering individual `if (!payload.xyz)` guards across files.
+ */
+
+import { AppError, ErrorCode } from "../errors/errorCodes";
+import { JWTPayload } from "../services/auth.service";
+
+export interface ClaimsValidationResult {
+  valid: boolean;
+  missingClaims: string[];
+}
+
+/** Required claims that every authenticated request must carry. */
+const REQUIRED_CLAIMS: ReadonlyArray<keyof JWTPayload> = [
+  "sub",
+  "walletAddress",
+  "jti",
+  "iat",
+  "exp",
+];
+
+/**
+ * Validates that all required claims are present and non-empty on a decoded
+ * JWT payload.  Returns a result object so callers can inspect which claims
+ * failed without catching an exception.
+ */
+export function validateJwtClaims(payload: Partial<JWTPayload>): ClaimsValidationResult {
+  const missingClaims: string[] = [];
+
+  for (const claim of REQUIRED_CLAIMS) {
+    const value = payload[claim];
+    if (value === undefined || value === null || value === "") {
+      missingClaims.push(claim);
+    }
+  }
+
+  return { valid: missingClaims.length === 0, missingClaims };
+}
+
+/**
+ * Asserts that all required JWT claims are present.
+ * Throws AUTH_ERROR (401) with the list of missing claims when validation fails.
+ * Intended to be called at the top of service methods that require an
+ * authenticated caller, before any database access.
+ */
+export function assertJwtClaims(payload: Partial<JWTPayload> | undefined): asserts payload is JWTPayload {
+  if (!payload) {
+    throw new AppError(ErrorCode.AUTH_ERROR, "Unauthorized: missing JWT payload", 401);
+  }
+
+  const { valid, missingClaims } = validateJwtClaims(payload);
+  if (!valid) {
+    throw new AppError(
+      ErrorCode.AUTH_ERROR,
+      `Unauthorized: missing required JWT claims: ${missingClaims.join(", ")}`,
+      401,
+      { missingClaims }
+    );
+  }
+}
+
+/**
+ * Extracts and validates the walletAddress claim from a request's JWT payload.
+ * Throws AUTH_ERROR (401) when the claim is absent or empty.
+ */
+export function requireWalletAddress(payload: Partial<JWTPayload> | undefined): string {
+  assertJwtClaims(payload);
+  const addr = payload.walletAddress.trim();
+  if (!addr) {
+    throw new AppError(ErrorCode.AUTH_ERROR, "Unauthorized: walletAddress claim is empty", 401);
+  }
+  return addr;
+}

--- a/backend/src/services/dispute.service.ts
+++ b/backend/src/services/dispute.service.ts
@@ -1,5 +1,17 @@
 import { PrismaClient, DisputeStatus } from "@prisma/client";
 import { AppError, ErrorCode } from "../errors/errorCodes";
+import { getMediatorAllowlist } from "../lib/accessControl";
+
+/** Terminal dispute statuses — disputes in these states are considered complete. */
+export const COMPLETED_DISPUTE_STATUSES: DisputeStatus[] = [
+  DisputeStatus.RESOLVED,
+  DisputeStatus.CLOSED,
+];
+
+export interface DisputeCleanupResult {
+  purgedCount: number;
+  tradeIds: string[];
+}
 
 export interface DisputeResponse {
   id: number;
@@ -45,10 +57,7 @@ export class DisputeService {
     const { status, page = 1, limit = 10 } = params;
     const offset = (page - 1) * limit;
 
-    const mediatorAddresses = (process.env.ADMIN_STELLAR_PUBKEYS ?? "")
-      .split(",")
-      .map(addr => addr.trim());
-    if (!mediatorAddresses.includes(mediatorAddress)) {
+    if (!getMediatorAllowlist().has(mediatorAddress)) {
       throw new AppError(ErrorCode.AUTH_ERROR, "Unauthorized: Not a mediator", 403);
     }
 
@@ -116,6 +125,51 @@ export class DisputeService {
   }
 
   /**
+   * Purge transient/sensitive data fields from disputes that have reached a
+   * terminal status (RESOLVED or CLOSED).  The core record is retained for
+   * audit purposes; only the free-text `reason` field is cleared so that PII
+   * is not stored indefinitely after a case concludes.
+   *
+   * Only a mediator (address listed in ADMIN_STELLAR_PUBKEYS) may trigger this
+   * operation.  Returns the number of records updated and the affected tradeIds.
+   */
+  async purgeCompletedDisputeData(
+    mediatorAddress: string,
+    olderThanDays = 90
+  ): Promise<DisputeCleanupResult> {
+    if (!getMediatorAllowlist().has(mediatorAddress)) {
+      throw new AppError(ErrorCode.AUTH_ERROR, "Unauthorized: Not a mediator", 403);
+    }
+
+    const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000);
+
+    const completed = await this.prisma.dispute.findMany({
+      where: {
+        status: { in: COMPLETED_DISPUTE_STATUSES },
+        resolvedAt: { lte: cutoff },
+        reason: { not: "" },
+      },
+      select: { id: true, tradeId: true },
+    });
+
+    if (completed.length === 0) {
+      return { purgedCount: 0, tradeIds: [] };
+    }
+
+    const ids = completed.map((d: { id: number; tradeId: string }) => d.id);
+
+    await this.prisma.dispute.updateMany({
+      where: { id: { in: ids } },
+      data: { reason: "" },
+    });
+
+    return {
+      purgedCount: completed.length,
+      tradeIds: completed.map((d: { id: number; tradeId: string }) => d.tradeId),
+    };
+  }
+
+  /**
    * Transition a dispute to a new status.
    * Only valid forward transitions are permitted; backwards or sideways moves throw
    * DISPUTE_STATUS_TRANSITION_INVALID.
@@ -125,10 +179,7 @@ export class DisputeService {
     mediatorAddress: string,
     newStatus: DisputeStatus
   ): Promise<DisputeResponse> {
-    const mediatorAddresses = (process.env.ADMIN_STELLAR_PUBKEYS ?? "")
-      .split(",")
-      .map(addr => addr.trim());
-    if (!mediatorAddresses.includes(mediatorAddress)) {
+    if (!getMediatorAllowlist().has(mediatorAddress)) {
       throw new AppError(ErrorCode.AUTH_ERROR, "Unauthorized: Not a mediator", 403);
     }
 

--- a/backend/src/services/manifest.service.ts
+++ b/backend/src/services/manifest.service.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import { PrismaClient, TradeStatus } from "@prisma/client";
 import { prisma as defaultPrisma } from "../lib/db";
+import { getMediatorAllowlist } from "../lib/accessControl";
 
 export interface SubmitManifestInput {
     tradeId: string;
@@ -79,13 +80,7 @@ function isUniqueConstraintError(error: unknown): boolean {
 }
 
 function parseMediatorAllowlist(): Set<string> {
-    const raw = process.env.ADMIN_STELLAR_PUBKEYS ?? "";
-    return new Set(
-        raw
-            .split(",")
-            .map((value) => value.trim().toLowerCase())
-            .filter(Boolean),
-    );
+    return getMediatorAllowlist();
 }
 
 function maskDriverName(driverName: string): string {


### PR DESCRIPTION
## Summary

Resolves four backend improvement issues in a single cohesive PR. All changes follow the existing code patterns, introduce no breaking changes to public contracts, and ship with new test files.

Closes #523
Closes #524
Closes #525
Closes #527

---

## Changes

### Issue #524 — Synchronize backend data cleanup logic for completed disputes

**Problem:** Disputes that reach a terminal status (`RESOLVED`/`CLOSED`) retained their free-text `reason` field indefinitely, meaning PII could persist long after a case concluded.

**Solution:**
- Added `purgeCompletedDisputeData(mediatorAddress, olderThanDays?)` to `DisputeService`.
- The method clears the `reason` field (sets it to `""`) on `RESOLVED`/`CLOSED` disputes whose `resolvedAt` timestamp is older than the configurable cutoff (default: 90 days), while keeping the audit record intact.
- Only mediators listed in `ADMIN_STELLAR_PUBKEYS` can trigger the purge (throws `AUTH_ERROR` otherwise).
- Exported `COMPLETED_DISPUTE_STATUSES` constant as the canonical terminal-status set.
- New test file: `dispute.cleanup.test.ts` — covers mediator guard, cutoff date filtering, idempotent no-op when nothing qualifies, `updateMany` never called on empty result, and minimal select projection.

---

### Issue #525 — Audit backend access control for mediator and arbitrator routes

**Problem:** The `ADMIN_STELLAR_PUBKEYS` env-var parsing was duplicated inline across four files (`DisputeService`, `DisputeCategoryController`, `TradeController`, `ManifestService`), each with slightly different whitespace/case handling — a maintenance and consistency risk.

**Solution:**
- Created `src/lib/accessControl.ts` with `getMediatorAllowlist(): Set<string>` and `isMediatorAddress(address): boolean` as the single source of truth.
- Removed all four inline copies, replacing each with a call to the shared helper.
- New test file: `access.control.test.ts` — covers empty env, single/multiple entries, whitespace trimming, trailing-comma handling, case-sensitivity, and Set isolation (no shared mutable state between calls).

---

### Issue #523 — Improve backend schema migration rollback safety practices

**Problem:** The existing `migration-safety.test.ts` detected destructive DDL but did not enforce companion rollback scripts, validate rollback script content, or check idempotency markers.

**Solution:**
- Added `migration.rollback.test.ts` (file-system-only, no DB connection required):
  - Migrations containing destructive DDL must ship a `rollback.sql`.
  - `rollback.sql` (if present) must be non-empty and contain at least one DDL statement.
  - Rollback scripts must not contain catastrophic operations (`DROP DATABASE`, `DROP SCHEMA`, `TRUNCATE`).
  - Idempotency-marker regexes (`IF EXISTS` / `IF NOT EXISTS`) are validated for correctness.
  - Reversal-pair samples document the expected rollback form for common forward DDL operations.

---

### Issue #527 — Add backend helper to validate JWT claims before service logic

**Problem:** JWT claim presence was checked ad-hoc (scattered `if (!req.user?.walletAddress)` guards) with no consistent error shape or coverage of all required claims.

**Solution:**
- Created `src/lib/jwtClaims.ts` with three exports:
  - `validateJwtClaims(payload)` — returns `{ valid, missingClaims[] }` without throwing.
  - `assertJwtClaims(payload)` — throws `AUTH_ERROR` (401) with structured `details.missingClaims` when any required claim (`sub`, `walletAddress`, `jti`, `iat`, `exp`) is absent or empty.
  - `requireWalletAddress(payload)` — asserts claims and returns the trimmed wallet address in one call.
- New test file: `jwt.claims.test.ts` — full coverage: per-claim missing detection, multi-claim failure, empty-string treatment, undefined payload, error code/statusCode shape, details payload, and whitespace trimming.

---

## Test plan

- [ ] `dispute.cleanup.test.ts` — all scenarios pass (mediator guard, cutoff, idempotency)
- [ ] `access.control.test.ts` — all allowlist parsing scenarios pass
- [ ] `migration.rollback.test.ts` — file-system checks pass against current migrations
- [ ] `jwt.claims.test.ts` — all claim validation scenarios pass
- [ ] Existing tests unchanged — no regressions in `dispute.status.transitions.test.ts`, `auth.middleware.test.ts`, `disputeCategory.routes.test.ts`
- [ ] `npm run lint` and `tsc --noEmit` pass cleanly