### PR TITLE
fix: add backend metrics for Stellar transaction success and latency

### DIFF
--- a/backend/src/__tests__/metrics.stellar.test.ts
+++ b/backend/src/__tests__/metrics.stellar.test.ts
@@ -1,0 +1,278 @@
+/**
+ * metrics.stellar.test.ts
+ *
+ * Regression coverage for Stellar transaction success/latency metrics — Issue #521.
+ */
+
+import {
+  __resetMetricsForTests,
+  __setMetricsRecorderForTests,
+  classifySubmissionError,
+  recordRpcCall,
+  recordTransactionSubmission,
+  StellarMetricsRecorder,
+} from "../lib/metrics";
+import { StellarService } from "../services/stellar.service";
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: { loadAccount: jest.fn() },
+  sorobanRpcClient: { sendTransaction: jest.fn() },
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+jest.mock("../middleware/logger", () => ({
+  appLogger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("../config/tracing", () => ({
+  TracingHelper: {
+    withSpan: async (_name: string, fn: (span: { setAttributes: jest.Mock }) => Promise<unknown>) =>
+      fn({ setAttributes: jest.fn() }),
+    addEvent: jest.fn(),
+  },
+}));
+
+function makeRecorder(): StellarMetricsRecorder & {
+  submissions: Array<{
+    operation: string;
+    outcome: string;
+    durationMs: number;
+  }>;
+  rpcCalls: Array<{
+    rpcMethod: string;
+    outcome: string;
+    durationMs: number;
+  }>;
+} {
+  const submissions: Array<{
+    operation: string;
+    outcome: string;
+    durationMs: number;
+  }> = [];
+  const rpcCalls: Array<{
+    rpcMethod: string;
+    outcome: string;
+    durationMs: number;
+  }> = [];
+
+  return {
+    submissions,
+    rpcCalls,
+    recordTransactionSubmission(operation, outcome, durationMs) {
+      submissions.push({ operation, outcome, durationMs });
+    },
+    recordRpcCall(rpcMethod, outcome, durationMs) {
+      rpcCalls.push({ rpcMethod, outcome, durationMs });
+    },
+  };
+}
+
+function makeSendTxMock(): jest.Mock {
+  const { sorobanRpcClient } = require("../config/stellar");
+  return sorobanRpcClient.sendTransaction as jest.Mock;
+}
+
+describe("Stellar metrics (#521)", () => {
+  let recorder: ReturnType<typeof makeRecorder>;
+
+  beforeEach(() => {
+    recorder = makeRecorder();
+    __setMetricsRecorderForTests(recorder);
+  });
+
+  afterEach(() => {
+    __resetMetricsForTests();
+    jest.restoreAllMocks();
+  });
+
+  describe("classifySubmissionError", () => {
+    it("maps known error messages to outcome labels", () => {
+      expect(classifySubmissionError(new Error("Invalid transaction XDR: bad"))).toBe(
+        "xdr_invalid",
+      );
+      expect(classifySubmissionError(new Error("Contract Panic: locked"))).toBe(
+        "contract_panic",
+      );
+      expect(classifySubmissionError(new Error("RPC Error: ERROR"))).toBe("rpc_error");
+      expect(classifySubmissionError(new Error("ECONNREFUSED"))).toBe("network_error");
+    });
+  });
+
+  describe("recordTransactionSubmission", () => {
+    it("forwards submission events to the test recorder", () => {
+      recordTransactionSubmission("submit_transaction", "success", 42);
+
+      expect(recorder.submissions).toEqual([
+        { operation: "submit_transaction", outcome: "success", durationMs: 42 },
+      ]);
+    });
+  });
+
+  describe("recordRpcCall", () => {
+    it("forwards RPC latency events to the test recorder", () => {
+      recordRpcCall("simulateTransaction", "success", 15);
+
+      expect(recorder.rpcCalls).toEqual([
+        { rpcMethod: "simulateTransaction", outcome: "success", durationMs: 15 },
+      ]);
+    });
+  });
+
+  describe("StellarService.submitTransaction", () => {
+    let sendTxMock: jest.Mock;
+
+    beforeEach(() => {
+      sendTxMock = makeSendTxMock();
+      sendTxMock.mockReset();
+    });
+
+    it("records success metrics when RPC accepts the transaction", async () => {
+      const { TransactionBuilder } = require("@stellar/stellar-sdk");
+      jest
+        .spyOn(TransactionBuilder, "fromXDR")
+        .mockReturnValue({ toEnvelope: jest.fn() } as any);
+      sendTxMock.mockResolvedValue({ status: "PENDING", hash: "abc123" });
+
+      const service = new StellarService();
+      await service.submitTransaction("MOCKED_XDR");
+
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "submit_transaction",
+          outcome: "success",
+        }),
+      ]);
+      expect(recorder.submissions[0].durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("records contract_panic metrics when the contract reverts", async () => {
+      const { TransactionBuilder } = require("@stellar/stellar-sdk");
+      jest
+        .spyOn(TransactionBuilder, "fromXDR")
+        .mockReturnValue({ toEnvelope: jest.fn() } as any);
+      sendTxMock.mockResolvedValue({
+        status: "ERROR",
+        hash: "deadbeef",
+        errorResult: "insufficient_funds",
+      });
+
+      const service = new StellarService();
+      await expect(service.submitTransaction("MOCKED_XDR")).rejects.toThrow(
+        /contract panic/i,
+      );
+
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "submit_transaction",
+          outcome: "contract_panic",
+        }),
+      ]);
+    });
+
+    it("records rpc_error metrics when Soroban RPC returns an infrastructure error", async () => {
+      const { TransactionBuilder } = require("@stellar/stellar-sdk");
+      jest
+        .spyOn(TransactionBuilder, "fromXDR")
+        .mockReturnValue({ toEnvelope: jest.fn() } as any);
+      sendTxMock.mockResolvedValue({ status: "ERROR", hash: "deadbeef" });
+
+      const service = new StellarService();
+      await expect(service.submitTransaction("MOCKED_XDR")).rejects.toThrow(
+        /rpc error/i,
+      );
+
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "submit_transaction",
+          outcome: "rpc_error",
+        }),
+      ]);
+    });
+
+    it("records xdr_invalid metrics without calling Soroban RPC", async () => {
+      const service = new StellarService();
+
+      await expect(service.submitTransaction("not-valid-xdr-at-all")).rejects.toThrow(
+        /invalid transaction xdr|xdr|parse/i,
+      );
+
+      expect(sendTxMock).not.toHaveBeenCalled();
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "submit_transaction",
+          outcome: "xdr_invalid",
+        }),
+      ]);
+    });
+
+    it("records network_error metrics when the RPC call fails", async () => {
+      const { TransactionBuilder } = require("@stellar/stellar-sdk");
+      jest
+        .spyOn(TransactionBuilder, "fromXDR")
+        .mockReturnValue({ toEnvelope: jest.fn() } as any);
+      sendTxMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const service = new StellarService();
+      await expect(service.submitTransaction("MOCKED_XDR")).rejects.toThrow(
+        /transaction submission failed/i,
+      );
+
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "submit_transaction",
+          outcome: "network_error",
+        }),
+      ]);
+    });
+  });
+
+  describe("StellarService.buildTransaction", () => {
+    it("records success metrics when Horizon returns the source account", async () => {
+      const { horizonServer } = require("../config/stellar");
+      const { TransactionBuilder } = require("@stellar/stellar-sdk");
+      (horizonServer.loadAccount as jest.Mock).mockResolvedValue({
+        accountId: () =>
+          "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        sequenceNumber: () => "1",
+      });
+      jest.spyOn(TransactionBuilder.prototype, "addOperation").mockReturnThis();
+      jest.spyOn(TransactionBuilder.prototype, "setTimeout").mockReturnThis();
+      jest
+        .spyOn(TransactionBuilder.prototype, "build")
+        .mockReturnValue({ toXDR: () => "MOCK_XDR" } as any);
+
+      const service = new StellarService();
+      const xdr = await service.buildTransaction(
+        "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        [],
+      );
+
+      expect(xdr).toBe("MOCK_XDR");
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "build_transaction",
+          outcome: "success",
+        }),
+      ]);
+    });
+
+    it("records network_error metrics when Horizon is unreachable", async () => {
+      const { horizonServer } = require("../config/stellar");
+      (horizonServer.loadAccount as jest.Mock).mockRejectedValue(
+        new Error("ECONNREFUSED"),
+      );
+
+      const service = new StellarService();
+      await expect(
+        service.buildTransaction("GABC1234VALIDSTELLARKEY000000000000000000000000000000", []),
+      ).rejects.toThrow();
+
+      expect(recorder.submissions).toEqual([
+        expect.objectContaining({
+          operation: "build_transaction",
+          outcome: "network_error",
+        }),
+      ]);
+    });
+  });
+});

--- a/backend/src/lib/metrics.ts
+++ b/backend/src/lib/metrics.ts
@@ -1,0 +1,150 @@
+import { Counter, Histogram, metrics } from "@opentelemetry/api";
+
+const METER_NAME = "amana-backend";
+
+export type StellarTransactionOutcome =
+  | "success"
+  | "rpc_error"
+  | "contract_panic"
+  | "xdr_invalid"
+  | "network_error";
+
+export type StellarRpcMethod =
+  | "sendTransaction"
+  | "simulateTransaction"
+  | "prepareTransaction"
+  | "getAccount";
+
+export type StellarRpcOutcome = "success" | "error";
+
+export interface StellarMetricsRecorder {
+  recordTransactionSubmission(
+    operation: string,
+    outcome: StellarTransactionOutcome,
+    durationMs: number,
+  ): void;
+  recordRpcCall(
+    rpcMethod: StellarRpcMethod,
+    outcome: StellarRpcOutcome,
+    durationMs: number,
+  ): void;
+}
+
+let submissionCounter: Counter | undefined;
+let submissionDuration: Histogram | undefined;
+let rpcDuration: Histogram | undefined;
+let customRecorder: StellarMetricsRecorder | null = null;
+
+function getMeter() {
+  return metrics.getMeter(METER_NAME);
+}
+
+function getSubmissionCounter(): Counter {
+  if (!submissionCounter) {
+    submissionCounter = getMeter().createCounter(
+      "stellar_transaction_submissions_total",
+      {
+        description: "Total Stellar transaction submission attempts",
+      },
+    );
+  }
+  return submissionCounter;
+}
+
+function getSubmissionDuration(): Histogram {
+  if (!submissionDuration) {
+    submissionDuration = getMeter().createHistogram(
+      "stellar_transaction_duration_ms",
+      {
+        description: "Stellar transaction submission latency in milliseconds",
+        unit: "ms",
+      },
+    );
+  }
+  return submissionDuration;
+}
+
+function getRpcDuration(): Histogram {
+  if (!rpcDuration) {
+    rpcDuration = getMeter().createHistogram("stellar_rpc_duration_ms", {
+      description: "Stellar Soroban RPC call latency in milliseconds",
+      unit: "ms",
+    });
+  }
+  return rpcDuration;
+}
+
+export function recordTransactionSubmission(
+  operation: string,
+  outcome: StellarTransactionOutcome,
+  durationMs: number,
+): void {
+  if (customRecorder) {
+    customRecorder.recordTransactionSubmission(operation, outcome, durationMs);
+    return;
+  }
+
+  const labels = { operation, outcome };
+  getSubmissionCounter().add(1, labels);
+  getSubmissionDuration().record(durationMs, labels);
+}
+
+export function recordRpcCall(
+  rpcMethod: StellarRpcMethod,
+  outcome: StellarRpcOutcome,
+  durationMs: number,
+): void {
+  if (customRecorder) {
+    customRecorder.recordRpcCall(rpcMethod, outcome, durationMs);
+    return;
+  }
+
+  getRpcDuration().record(durationMs, { rpc_method: rpcMethod, outcome });
+}
+
+export function classifySubmissionError(error: unknown): StellarTransactionOutcome {
+  if (!(error instanceof Error)) {
+    return "network_error";
+  }
+
+  const message = error.message;
+  if (/invalid transaction xdr|xdr/i.test(message)) {
+    return "xdr_invalid";
+  }
+  if (/contract panic/i.test(message)) {
+    return "contract_panic";
+  }
+  if (/rpc error/i.test(message)) {
+    return "rpc_error";
+  }
+  return "network_error";
+}
+
+export async function withRpcMetrics<T>(
+  rpcMethod: StellarRpcMethod,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = performance.now();
+  try {
+    const result = await fn();
+    recordRpcCall(rpcMethod, "success", performance.now() - start);
+    return result;
+  } catch (error) {
+    recordRpcCall(rpcMethod, "error", performance.now() - start);
+    throw error;
+  }
+}
+
+/** Vitest/Jest-only hook to assert metric emissions without a live Prometheus endpoint. */
+export function __setMetricsRecorderForTests(
+  recorder: StellarMetricsRecorder | null,
+): void {
+  customRecorder = recorder;
+}
+
+export function __resetMetricsForTests(): void {
+  customRecorder = null;
+  submissionCounter = undefined;
+  submissionDuration = undefined;
+  rpcDuration = undefined;
+}

--- a/backend/src/services/contract.service.ts
+++ b/backend/src/services/contract.service.ts
@@ -1,6 +1,7 @@
 import { Trade } from "@prisma/client";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { env } from "../config/env";
+import { withRpcMetrics } from "../lib/metrics";
 import { retryAsync } from "../lib/retry";
 import { TOKEN_CONFIG } from "../config/token";
 
@@ -75,21 +76,27 @@ async function getRpcAccount(
   server: StellarSdk.rpc.Server,
   accountId: string,
 ): Promise<StellarSdk.Account> {
-  return retryAsync(() => server.getAccount(accountId));
+  return withRpcMetrics("getAccount", () =>
+    retryAsync(() => server.getAccount(accountId)),
+  );
 }
 
 async function prepareRpcTransaction(
   server: StellarSdk.rpc.Server,
   transaction: StellarSdk.Transaction,
 ): Promise<StellarSdk.Transaction> {
-  return retryAsync(() => server.prepareTransaction(transaction));
+  return withRpcMetrics("prepareTransaction", () =>
+    retryAsync(() => server.prepareTransaction(transaction)),
+  );
 }
 
 async function simulateRpcTransaction(
   server: StellarSdk.rpc.Server,
   transaction: StellarSdk.Transaction,
 ): Promise<StellarSdk.rpc.Api.SimulateTransactionResponse> {
-  return retryAsync(() => server.simulateTransaction(transaction));
+  return withRpcMetrics("simulateTransaction", () =>
+    retryAsync(() => server.simulateTransaction(transaction)),
+  );
 }
 
 function getEscrowContractId(): string {

--- a/backend/src/services/stellar.service.ts
+++ b/backend/src/services/stellar.service.ts
@@ -8,6 +8,10 @@ import { retryAsync } from "../lib/retry";
 import { appLogger } from "../middleware/logger";
 import { TracingHelper } from "../config/tracing";
 import { TOKEN_CONFIG } from "../config/token";
+import {
+  classifySubmissionError,
+  recordTransactionSubmission,
+} from "../lib/metrics";
 
 export class StellarService {
   private horizonServer: Horizon.Server;
@@ -109,6 +113,7 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
   }
 
   public async buildTransaction(sourceAccount: string, operations: xdr.Operation[]): Promise<string> {
+    const start = performance.now();
     try {
       // Load source account from Horizon to get sequence number
       const account = await this.horizonServer.loadAccount(sourceAccount);
@@ -129,8 +134,18 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
       
       // Build and return transaction.toXDR() as base64 string
       const transaction = transactionBuilder.build();
+      recordTransactionSubmission(
+        "build_transaction",
+        "success",
+        performance.now() - start,
+      );
       return transaction.toXDR();
     } catch (error: any) {
+      recordTransactionSubmission(
+        "build_transaction",
+        classifySubmissionError(error),
+        performance.now() - start,
+      );
       if (error.response && error.response.status === 404) {
         appLogger.error({ error, sourceAccount }, "Source account not found");
         throw new Error("Source account does not exist");
@@ -145,64 +160,140 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
   }
 
   public async submitTransaction(signedXdr: string): Promise<rpc.Api.SendTransactionResponse> {
-    try {
-      // Parse XDR into Transaction object
-      const transaction = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase);
-      
-      // Call sorobanRpc.sendTransaction(transaction)
-      const response = await this.sorobanRpc.sendTransaction(transaction as any);
-      
-      // Log transaction hash for debugging
-      appLogger.info({
-        provider: "stellar",
-        status: response.status === 'ERROR' ? "authorization_failed" : "provider_response",
-        timestamp: new Date().toISOString(),
-        hash: response.hash
-      }, "Transaction submitted");
-      
-      // Check response status
-      if (response.status === 'ERROR') {
-        // Differentiate between RPC errors and contract panics
-        if (response.errorResult) {
-          // Contract panic - execution failure
-          const errorMessage = this.parseContractError(response.errorResult);
-          appLogger.error({ 
-            errorMessage,
+    return TracingHelper.withSpan(
+      "stellar.submit_transaction",
+      async (span) => {
+        const start = performance.now();
+        span.setAttributes({
+          "stellar.operation": "submit_transaction",
+          "stellar.network": this.networkPassphrase,
+        });
+
+        try {
+          const transaction = TransactionBuilder.fromXDR(
+            signedXdr,
+            this.networkPassphrase,
+          );
+
+          const response = await this.sorobanRpc.sendTransaction(transaction as any);
+
+          if (!response?.status) {
+            recordTransactionSubmission(
+              "submit_transaction",
+              "rpc_error",
+              performance.now() - start,
+            );
+            span.setAttributes({
+              "stellar.transaction.outcome": "rpc_error",
+            });
+            appLogger.error({
+              response,
+              provider: "stellar",
+              status: "authorization_failed",
+              timestamp: new Date().toISOString(),
+            }, "RPC Error");
+            throw new Error("RPC Error: invalid response");
+          }
+
+          appLogger.info({
             provider: "stellar",
-            status: "authorization_denied",
-            timestamp: new Date().toISOString()
-          }, "Contract Panic");
-          throw new Error(`Contract Panic: ${errorMessage}`);
-        } else {
-          // RPC error - infrastructure failure
-          appLogger.error({ 
-            response,
-            provider: "stellar",
-            status: "authorization_failed",
-            timestamp: new Date().toISOString()
-          }, "RPC Error");
-          throw new Error(`RPC Error: ${response.status}`);
+            status: response.status === "ERROR" ? "authorization_failed" : "provider_response",
+            timestamp: new Date().toISOString(),
+            hash: response.hash,
+          }, "Transaction submitted");
+
+          if (response.status === "ERROR") {
+            if (response.errorResult) {
+              const errorMessage = this.parseContractError(response.errorResult);
+              recordTransactionSubmission(
+                "submit_transaction",
+                "contract_panic",
+                performance.now() - start,
+              );
+              span.setAttributes({
+                "stellar.transaction.outcome": "contract_panic",
+                "stellar.transaction.hash": response.hash ?? "unknown",
+              });
+              appLogger.error({
+                errorMessage,
+                provider: "stellar",
+                status: "authorization_denied",
+                timestamp: new Date().toISOString(),
+              }, "Contract Panic");
+              throw new Error(`Contract Panic: ${errorMessage}`);
+            }
+
+            recordTransactionSubmission(
+              "submit_transaction",
+              "rpc_error",
+              performance.now() - start,
+            );
+            span.setAttributes({
+              "stellar.transaction.outcome": "rpc_error",
+              "stellar.transaction.hash": response.hash ?? "unknown",
+            });
+            appLogger.error({
+              response,
+              provider: "stellar",
+              status: "authorization_failed",
+              timestamp: new Date().toISOString(),
+            }, "RPC Error");
+            throw new Error(`RPC Error: ${response.status}`);
+          }
+
+          recordTransactionSubmission(
+            "submit_transaction",
+            "success",
+            performance.now() - start,
+          );
+          span.setAttributes({
+            "stellar.transaction.outcome": "success",
+            "stellar.transaction.hash": response.hash ?? "unknown",
+          });
+          return response;
+        } catch (error: any) {
+          const outcome = classifySubmissionError(error);
+          if (
+            outcome !== "contract_panic" &&
+            outcome !== "rpc_error"
+          ) {
+            recordTransactionSubmission(
+              "submit_transaction",
+              outcome,
+              performance.now() - start,
+            );
+          }
+
+          span.setAttributes({
+            "stellar.transaction.outcome": outcome,
+          });
+
+          if (error.message && error.message.includes("XDR")) {
+            appLogger.error({ error }, "Invalid transaction XDR");
+            throw new Error(`Invalid transaction XDR: ${error.message}`);
+          }
+
+          if (
+            error.message &&
+            (error.message.includes("RPC Error:") ||
+              error.message.includes("Contract Panic:"))
+          ) {
+            throw error;
+          }
+
+          appLogger.error({ error }, "Transaction submission failed");
+          throw new Error(
+            `Transaction submission failed: ${error.message || "Unknown error"}`,
+          );
         }
-      }
-      
-      // Return response on success
-      return response;
-    } catch (error: any) {
-      // Handle XDR parsing errors
-      if (error.message && error.message.includes('XDR')) {
-        appLogger.error({ error }, "Invalid transaction XDR");
-        throw new Error(`Invalid transaction XDR: ${error.message}`);
-      }
-      
-      // Re-throw if already a formatted error
-      if (error.message && (error.message.includes('RPC Error:') || error.message.includes('Contract Panic:'))) {
-        throw error;
-      }
-      
-      // Handle network/timeout errors
-      appLogger.error({ error }, "Transaction submission failed");
-      throw new Error(`Transaction submission failed: ${error.message || 'Unknown error'}`);
-    }
+      },
+      {
+        attributes: {
+          "service.name": "stellar",
+          "operation.type": "external_service",
+        },
+      },
+    );
   }
 
   private parseContractError(errorResult: any): string {


### PR DESCRIPTION
## Summary

Adds OpenTelemetry Prometheus metrics for Stellar transaction submission outcomes and Soroban RPC latency, building on the existing OTel/Prometheus exporter setup.

## Purpose / Motivation

The backend already exported auto-instrumented HTTP metrics but had no visibility into blockchain transaction success rates or Soroban RPC latency. Issue #521 closes that gap so operators can monitor settlement reliability and diagnose slow or failing contract interactions.

## Changes Made

- Added `backend/src/lib/metrics.ts` with OTel counters/histograms:
  - `stellar_transaction_submissions_total` — labeled by `operation` and `outcome` (`success`, `rpc_error`, `contract_panic`, `xdr_invalid`, `network_error`)
  - `stellar_transaction_duration_ms` — submission latency histogram with the same labels
  - `stellar_rpc_duration_ms` — Soroban RPC latency histogram labeled by `rpc_method` and `outcome`
- Instrumented `StellarService.submitTransaction` and `buildTransaction` with metrics + tracing spans
- Wrapped Soroban RPC helpers in `contract.service.ts` (`getAccount`, `simulateTransaction`, `prepareTransaction`) with latency metrics
- Added regression tests in `backend/src/__tests__/metrics.stellar.test.ts`
- Hardened `submitTransaction` to reject malformed RPC responses (missing `status`) as `rpc_error`

## How to Test

1. Start the backend with Prometheus enabled:
   ```bash
   cd backend
   PROMETHEUS_PORT=9464 npm run dev
   ```
2. Trigger a trade flow that builds unsigned XDR (e.g. `POST /trades`, `POST /trades/:id/deposit`) and confirm RPC latency metrics appear.
3. If you have a signed XDR, call `StellarService.submitTransaction` (or a future submit endpoint) and verify outcome counters increment.
4. Scrape metrics:
   ```bash
   curl -s localhost:9464/metrics | grep stellar_
   ```
   Expected: lines for `stellar_transaction_submissions_total`, `stellar_transaction_duration_ms`, and `stellar_rpc_duration_ms`.
5. Run unit tests:
   ```bash
   cd backend && npm test -- --testPathPatterns=metrics.stellar
   ```

## Screenshots (if applicable)

N/A — backend observability only.

## Breaking Changes

- None.

## Related Issues

Closes KingFRANKHOOD/Amana#521

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)