### PR TITLE
fix(docs): clarify PoD optionality and remove non-existent mobile fea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To provide a programmable safety net for regional commodity trading. Amana ensur
 
 - **Smart Escrow:** Secure funds holding using cNGN/stablecoins on the Stellar network.
 - **Dynamic Loss Sharing:** Negotiable risk-sharing ratios (e.g., 50/50, 70/30) hardcoded into every trade to handle transit accidents or theft.
-- **Proof-of-Delivery (PoD):** A mandatory video-based verification protocol involving the buyer and the driver to confirm the state of goods.
+- **Proof-of-Delivery (PoD):** An optional video-based verification protocol involving the buyer and the driver to confirm the state of goods. Video evidence can be submitted and stored on IPFS for dispute resolution.
 - **Volatility Protection:** Utilizes Stellar Path Payments to allow users to pay in local currency (NGN) while locking value in cNGN.
 - **Automated Settlement:** A flat 1% platform fee is automatically deducted upon successful trade completion.
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -17,13 +17,9 @@ Amana eliminates the "Trust Gap" between buyers and sellers using Soroban Smart 
 ## Mobile Features
 
 - Wallet-based authentication via Stellar Freighter
-- Trade discovery and real-time status tracking
-- Evidence capture and IPFS upload
-- Real-time push notifications for trade events
 - Secure token storage on device
 - Offline-aware state management
 - Mediator dispute resolution
-- Driver manifest and tracking
 
 ## Tech Stack
 


### PR DESCRIPTION
## PR summary
Closes #631 
Closes #637 
Closes #638 
Closes #639 

DOCS-002: Update README.md to clarify that Proof-of-Delivery (PoD) video verification is optional, not mandatory. The smart contract's confirm_delivery() function can be called without requiring submit_video_proof() first. Added clarification that video evidence can be optionally submitted and stored on IPFS for dispute resolution.

DOCS-003: Remove features from mobile/README.md that are not implemented:
- Trade discovery and real-time status tracking
- Evidence capture and IPFS upload
- Real-time push notifications for trade events
- Driver manifest and tracking

These features were promised in the mobile README but have no implementation, which misleads mobile contributors about the app's maturity.