### PR TITLE
feat: implement trade expiration/lock-time mechanism (SC-002)

### DIFF
--- a/contracts/amana_escrow/Cargo.toml
+++ b/contracts/amana_escrow/Cargo.toml
@@ -42,3 +42,7 @@ path = "tests/dispute_stress_tests.rs"
 [[test]]
 name = "event_emission_tests"
 path = "tests/event_emission_tests.rs"
+
+[[test]]
+name = "expiration_tests"
+path = "tests/expiration_tests.rs"

--- a/contracts/amana_escrow/src/lib.rs
+++ b/contracts/amana_escrow/src/lib.rs
@@ -138,6 +138,15 @@ pub struct VideoProofSubmittedEvent {
     pub ipfs_cid: String,
 }
 
+/// Emitted when a trade's expiry deadline is reached and a refund is claimed.
+#[contractevent(topics = ["TRDEXP"])]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TradeExpiredEvent {
+    pub trade_id: u64,
+    pub refund_amount: i128,
+    pub caller: Address,
+}
+
 /// Emitted when seller submits hashed delivery manifest fields.
 #[contractevent(topics = ["MNFST"])]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -216,6 +225,9 @@ pub struct Trade {
     pub delivered_at: Option<u64>,
     pub buyer_loss_bps: u32,
     pub seller_loss_bps: u32,
+    /// Optional Unix timestamp (seconds) after which either party may claim an
+    /// auto-refund via `claim_expiry_refund()`. `None` means no deadline.
+    pub expires_at: Option<u64>,
 }
 
 /// Persistent record of a dispute created by `initiate_dispute()`.
@@ -282,6 +294,8 @@ pub struct ReleaseSequence {
     pub released_at: Option<u64>,
     pub resolved_at: Option<u64>,
     pub cancelled_at: Option<u64>,
+    /// Set when `claim_expiry_refund()` successfully refunds an expired trade.
+    pub expired_at: Option<u64>,
 }
 
 #[contracttype]
@@ -520,6 +534,7 @@ impl EscrowContract {
             released_at: None,
             resolved_at: None,
             cancelled_at: None,
+            expired_at: None,
         }
     }
 
@@ -545,6 +560,7 @@ impl EscrowContract {
         amount: i128,
         buyer_loss_bps: u32,
         seller_loss_bps: u32,
+        expires_at: Option<u64>,
     ) -> u64 {
         buyer.require_auth();
         assert!(amount > 0, "amount must be greater than zero");
@@ -567,6 +583,14 @@ impl EscrowContract {
             buyer_loss_bps + seller_loss_bps == 10_000,
             "loss ratios must sum to 10000 (100%)"
         );
+        let now = env.ledger().timestamp();
+        // Validate deadline is in the future when provided
+        if let Some(deadline) = expires_at {
+            assert!(
+                deadline > now,
+                "expires_at must be in the future"
+            );
+        }
         let next_id: u64 = env
             .storage()
             .instance()
@@ -580,7 +604,6 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::CngnContract)
             .expect("Not initialized");
-        let now = env.ledger().timestamp();
         let trade = Trade {
             trade_id,
             buyer: buyer.clone(),
@@ -594,6 +617,7 @@ impl EscrowContract {
             delivered_at: None,
             buyer_loss_bps,
             seller_loss_bps,
+            expires_at,
         };
         env.storage()
             .persistent()
@@ -874,6 +898,71 @@ impl EscrowContract {
         let amount = trade.amount;
         let seller = trade.seller.clone();
         Self::execute_cancellation(&env, &mut trade, amount, seller);
+    }
+
+    /// Claim an auto-refund on a trade whose expiry deadline has passed.
+    ///
+    /// Either the buyer or the seller may call this once `expires_at` has been
+    /// reached and the trade is still in `Funded` status (i.e. the buyer has
+    /// not yet confirmed delivery and no dispute is active). The full escrowed
+    /// amount is returned to the buyer.
+    ///
+    /// Reverts if:
+    /// - The trade has no `expires_at` deadline set.
+    /// - The current ledger timestamp is before `expires_at`.
+    /// - The trade is not in `Funded` status (already delivered, disputed, etc.).
+    /// - The caller is neither the buyer nor the seller.
+    pub fn claim_expiry_refund(env: Env, trade_id: u64, caller: Address) {
+        caller.require_auth();
+
+        let key = DataKey::Trade(trade_id);
+        let mut trade: Trade = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Trade not found");
+
+        assert!(
+            caller == trade.buyer || caller == trade.seller,
+            "Only the buyer or seller can claim an expiry refund"
+        );
+        assert!(
+            matches!(trade.status, TradeStatus::Funded),
+            "Trade must be in Funded status to claim expiry refund"
+        );
+
+        let deadline = trade
+            .expires_at
+            .expect("Trade has no expiry deadline");
+
+        let now = env.ledger().timestamp();
+        assert!(now >= deadline, "Trade has not yet expired");
+
+        let refund_amount = trade.amount;
+
+        // Return funds to buyer
+        let token_client = token::Client::new(&env, &trade.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &trade.buyer,
+            &refund_amount,
+        );
+
+        trade.status = TradeStatus::Cancelled;
+        trade.updated_at = now;
+        env.storage().persistent().set(&key, &trade);
+
+        Self::update_release_sequence(&env, &trade, |sequence, at| {
+            sequence.expired_at = Some(at);
+            sequence.cancelled_at = Some(at);
+        });
+
+        TradeExpiredEvent {
+            trade_id,
+            refund_amount,
+            caller,
+        }
+        .publish(&env);
     }
 
     fn execute_cancellation(env: &Env, trade: &mut Trade, refund_amount: i128, caller: Address) {
@@ -1504,7 +1593,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         (contract_id, usdc_id, buyer, seller, treasury, trade_id)
@@ -1546,7 +1635,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
 
         env.ledger().with_mut(|li| li.timestamp = 1000);
         client.deposit(&trade_id);
@@ -1576,7 +1665,7 @@ mod test {
             .address();
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32, &None);
         client.mock_auths(&[]).deposit(&trade_id);
     }
 
@@ -1604,7 +1693,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &(amount * 2));
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.deposit(&trade_id);
     }
@@ -1624,14 +1713,14 @@ mod test {
             .address();
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
-        let trade_id_1 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32);
+        let trade_id_1 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32, &None);
         client.cancel_trade(&trade_id_1, &buyer);
         assert!(matches!(
             client.get_trade(&trade_id_1).status,
             TradeStatus::Cancelled
         ));
 
-        let trade_id_2 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32);
+        let trade_id_2 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32, &None);
         client.cancel_trade(&trade_id_2, &seller);
         assert!(matches!(
             client.get_trade(&trade_id_2).status,
@@ -1658,7 +1747,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         client.cancel_trade(&trade_id, &buyer);
@@ -1693,7 +1782,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let token_readonly = token::Client::new(&env, &usdc_id);
@@ -1726,7 +1815,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.confirm_delivery(&trade_id);
 
@@ -1759,7 +1848,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer_2, &amount);
 
-        let trade_id_2 = client.create_trade(&buyer_2, &seller_2, &amount, &5000_u32, &5000_u32);
+        let trade_id_2 = client.create_trade(&buyer_2, &seller_2, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_2);
         client.confirm_delivery(&trade_id_2);
         client.refund(&trade_id_2);
@@ -1791,7 +1880,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.confirm_delivery(&trade_id);
         client.release_funds(&trade_id);
@@ -1858,43 +1947,43 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
         // Test 50/50 split
-        let trade_id_1 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32);
+        let trade_id_1 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32, &None);
         let trade_1 = client.get_trade(&trade_id_1);
         assert_eq!(trade_1.buyer_loss_bps, 5000);
         assert_eq!(trade_1.seller_loss_bps, 5000);
 
         // Test 70/30 split (buyer bears 70% of loss)
-        let trade_id_2 = client.create_trade(&buyer, &seller, &2000_i128, &7000_u32, &3000_u32);
+        let trade_id_2 = client.create_trade(&buyer, &seller, &2000_i128, &7000_u32, &3000_u32, &None);
         let trade_2 = client.get_trade(&trade_id_2);
         assert_eq!(trade_2.buyer_loss_bps, 7000);
         assert_eq!(trade_2.seller_loss_bps, 3000);
 
         // Test 100/0 split (buyer bears all loss)
-        let trade_id_3 = client.create_trade(&buyer, &seller, &3000_i128, &10000_u32, &0_u32);
+        let trade_id_3 = client.create_trade(&buyer, &seller, &3000_i128, &10000_u32, &0_u32, &None);
         let trade_3 = client.get_trade(&trade_id_3);
         assert_eq!(trade_3.buyer_loss_bps, 10000);
         assert_eq!(trade_3.seller_loss_bps, 0);
 
         // Test 0/100 split (seller bears all loss)
-        let trade_id_4 = client.create_trade(&buyer, &seller, &4000_i128, &0_u32, &10000_u32);
+        let trade_id_4 = client.create_trade(&buyer, &seller, &4000_i128, &0_u32, &10000_u32, &None);
         let trade_4 = client.get_trade(&trade_id_4);
         assert_eq!(trade_4.buyer_loss_bps, 0);
         assert_eq!(trade_4.seller_loss_bps, 10000);
 
         // Test 30/70 split
-        let trade_id_5 = client.create_trade(&buyer, &seller, &5000_i128, &3000_u32, &7000_u32);
+        let trade_id_5 = client.create_trade(&buyer, &seller, &5000_i128, &3000_u32, &7000_u32, &None);
         let trade_5 = client.get_trade(&trade_id_5);
         assert_eq!(trade_5.buyer_loss_bps, 3000);
         assert_eq!(trade_5.seller_loss_bps, 7000);
 
         // Test 10/90 split
-        let trade_id_6 = client.create_trade(&buyer, &seller, &6000_i128, &1000_u32, &9000_u32);
+        let trade_id_6 = client.create_trade(&buyer, &seller, &6000_i128, &1000_u32, &9000_u32, &None);
         let trade_6 = client.get_trade(&trade_id_6);
         assert_eq!(trade_6.buyer_loss_bps, 1000);
         assert_eq!(trade_6.seller_loss_bps, 9000);
 
         // Test 25/75 split (middle cases)
-        let trade_id_7 = client.create_trade(&buyer, &seller, &7000_i128, &2500_u32, &7500_u32);
+        let trade_id_7 = client.create_trade(&buyer, &seller, &7000_i128, &2500_u32, &7500_u32, &None);
         let trade_7 = client.get_trade(&trade_id_7);
         assert_eq!(trade_7.buyer_loss_bps, 2500);
         assert_eq!(trade_7.seller_loss_bps, 7500);
@@ -1920,7 +2009,7 @@ mod test {
             INSTANCE_TTL_EXTEND_TO
         );
 
-        let trade_id_1 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32);
+        let trade_id_1 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32, &None);
         assert_eq!(trade_id_1 & 0xFFFF_FFFF_u64, 1);
 
         let current_ledger = env.ledger().sequence();
@@ -1928,7 +2017,7 @@ mod test {
             .set_sequence_number(current_ledger + INSTANCE_TTL_EXTEND_TO - 1);
         assert_eq!(env.deployer().get_contract_instance_ttl(&contract_id), 1);
 
-        let trade_id_2 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32);
+        let trade_id_2 = client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &5000_u32, &None);
         assert_eq!(trade_id_2 & 0xFFFF_FFFF_u64, 2);
         assert_eq!(
             env.deployer().get_contract_instance_ttl(&contract_id),
@@ -1953,7 +2042,7 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
         // This should panic: 5000 + 4000 = 9000 ≠ 10000
-        client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &4000_u32);
+        client.create_trade(&buyer, &seller, &1000_i128, &5000_u32, &4000_u32, &None);
     }
 
     #[test]
@@ -1973,7 +2062,7 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
         // This should panic: 5001 + 5001 = 10002 > 10000
-        client.create_trade(&buyer, &seller, &1000_i128, &5001_u32, &5001_u32);
+        client.create_trade(&buyer, &seller, &1000_i128, &5001_u32, &5001_u32, &None);
     }
 
     // -----------------------------------------------------------------------
@@ -2178,7 +2267,7 @@ mod test {
         token_client.mint(&buyer, &amount);
 
         // Create trade with 70/30 loss-sharing (buyer bears 70% of loss)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &7000_u32, &3000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &7000_u32, &3000_u32, &None);
         client.deposit(&trade_id);
         let reason = mock_reason(&env, "Qm70_30LossSharing");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -2237,7 +2326,7 @@ mod test {
         token_client.mint(&buyer, &amount);
 
         // Buyer bears all loss (100/0)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &10000_u32, &0_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &10000_u32, &0_u32, &None);
         client.deposit(&trade_id);
         let reason = mock_reason(&env, "QmBuyerBearsAllLoss");
         client.initiate_dispute(&trade_id, &seller, &reason);
@@ -2296,7 +2385,7 @@ mod test {
         token_client.mint(&buyer, &amount);
 
         // Seller bears all loss (0/100)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &0_u32, &10000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &0_u32, &10000_u32, &None);
         client.deposit(&trade_id);
         let reason = mock_reason(&env, "QmSellerBearsAllLoss");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -2351,7 +2440,7 @@ mod test {
         token_client.mint(&buyer, &amount);
 
         // 20/80 loss-sharing (seller bears 80% of loss)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &2000_u32, &8000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &2000_u32, &8000_u32, &None);
         client.deposit(&trade_id);
         let reason = mock_reason(&env, "QmSmallLoss80Seller");
         client.initiate_dispute(&trade_id, &seller, &reason);
@@ -2401,7 +2490,7 @@ mod test {
         token_client.mint(&buyer, &amount);
 
         // 25/75 loss-sharing (seller bears 75% of loss)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &2500_u32, &7500_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &2500_u32, &7500_u32, &None);
         client.deposit(&trade_id);
         let reason = mock_reason(&env, "QmMiddleCase25_75Loss");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -2482,7 +2571,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         env.ledger().with_mut(|l| l.timestamp = 5_000);
@@ -2523,7 +2612,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         env.ledger().with_mut(|l| l.timestamp = 9_000);
@@ -2559,7 +2648,7 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
         // create_trade but NO deposit — trade is still Created
-        let trade_id = client.create_trade(&buyer, &seller, &5_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &5_000_i128, &5000_u32, &5000_u32, &None);
         let reason = soroban_sdk::String::from_str(&env, "QmPrematureDispute");
         client.initiate_dispute(&trade_id, &buyer, &reason);
     }
@@ -2585,7 +2674,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let reason = soroban_sdk::String::from_str(&env, "QmFirstDispute");
@@ -2616,7 +2705,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         // Stranger tries to initiate dispute
@@ -2646,7 +2735,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         // Complete the trade successfully
@@ -2678,7 +2767,7 @@ mod test {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         // Set specific timestamp
@@ -2882,7 +2971,7 @@ mod test {
             .address();
         let treasury = Address::generate(&env);
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
-        client.create_trade(&actor, &actor, &1_000_i128, &5000_u32, &5000_u32);
+        client.create_trade(&actor, &actor, &1_000_i128, &5000_u32, &5000_u32, &None);
     }
 
     #[test]
@@ -2903,7 +2992,7 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         let empty = soroban_sdk::String::from_str(&env, "");
         client.initiate_dispute(&trade_id, &buyer, &empty);
@@ -2927,7 +3016,7 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         let empty_cid = soroban_sdk::String::from_str(&env, "");
         client.submit_video_proof(&trade_id, &buyer, &empty_cid);
@@ -3104,7 +3193,7 @@ mod test {
             .address();
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
         // Trade is Created (not Funded)
-        let trade_id = client.create_trade(&buyer, &seller, &1_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &1_000_i128, &5000_u32, &5000_u32, &None);
         client.confirm_delivery(&trade_id);
     }
 
@@ -3170,7 +3259,7 @@ mod test {
             .register_stellar_asset_contract_v2(admin.clone())
             .address();
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
-        let trade_id = client.create_trade(&buyer, &seller, &1_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &1_000_i128, &5000_u32, &5000_u32, &None);
         let stranger = Address::generate(&env);
         client.cancel_trade(&trade_id, &stranger);
     }
@@ -3190,7 +3279,7 @@ mod test {
             .address();
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &1_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &1_000_i128, &5000_u32, &5000_u32, &None);
         client.cancel_trade(&trade_id, &admin);
 
         assert!(matches!(
@@ -3228,7 +3317,7 @@ mod test {
         client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
         let token_mint = token::StellarAssetClient::new(&env, &usdc_id);
         token_mint.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         // Admin cancels immediately without needing both parties
         client.cancel_trade(&trade_id, &admin);
@@ -3289,7 +3378,7 @@ mod test {
         let ngn_mint = token::StellarAssetClient::new(&env, &ngn_id);
         ngn_mint.mint(&buyer, &source_amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32, &None);
 
         env.ledger().with_mut(|l| l.timestamp = 1_000);
         let path = Vec::new(&env);
@@ -3322,7 +3411,7 @@ mod test {
         let (contract_id, _admin, buyer, seller, _treasury, _cngn_id, _ngn_id) =
             setup_path_payment_env(&env, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &0_i128, &1_i128, &path);
     }
@@ -3340,7 +3429,7 @@ mod test {
         ngn_mint.mint(&buyer, &10_000_i128);
         let cngn_mint = token::StellarAssetClient::new(&env, &cngn_id);
         cngn_mint.mint(&contract_id, &20_000_i128);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &5_000_i128, &0_i128, &path);
     }
@@ -3361,7 +3450,7 @@ mod test {
         cngn_mint.mint(&buyer, &20_000_i128);
         cngn_mint.mint(&contract_id, &20_000_i128);
 
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &5_000_i128, &4_900_i128, &path);
@@ -3381,7 +3470,7 @@ mod test {
         let cngn_mint = token::StellarAssetClient::new(&env, &cngn_id);
         cngn_mint.mint(&buyer, &20_000_i128);
         cngn_mint.mint(&contract_id, &20_000_i128);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &seller, &5_000_i128, &4_900_i128, &path);
     }
@@ -3401,7 +3490,7 @@ mod test {
         let ngn_mint = token::StellarAssetClient::new(&env, &ngn_id);
         ngn_mint.mint(&buyer, &source_amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32, &None);
 
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &source_amount, &dest_min, &path);
@@ -3448,7 +3537,7 @@ mod test {
         let ngn_mint = token::StellarAssetClient::new(&env, &ngn_id);
         ngn_mint.mint(&buyer, &source_amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32, &None);
         let mut path = Vec::new(&env);
         path.push_back(ngn_id.clone());
         client.deposit_with_path(&trade_id, &buyer, &source_amount, &dest_min, &path);
@@ -3477,7 +3566,7 @@ mod test {
 
         let ngn_mint = token::StellarAssetClient::new(&env, &ngn_id);
         ngn_mint.mint(&buyer, &source_amount);
-        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32, &None);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &source_amount, &dest_min, &path);
 
@@ -3505,7 +3594,7 @@ mod test {
             let ngn_mint = token::StellarAssetClient::new(&env, &ngn_id);
             ngn_mint.mint(&buyer, &source_amount);
             let trade_id =
-                client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32);
+                client.create_trade(&buyer, &seller, &source_amount, &5000_u32, &5000_u32, &None);
             let path = Vec::new(&env);
             client.deposit_with_path(&trade_id, &buyer, &source_amount, &dest_min, &path);
 
@@ -3570,7 +3659,7 @@ mod test {
         let amount = 10_000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         // Admin cancels the funded trade immediately
         client.cancel_trade(&trade_id, &admin);
@@ -3657,7 +3746,7 @@ mod integration_tests {
     /// Create a trade and immediately deposit funds. Returns the trade_id.
     fn create_and_fund(s: &Setup, amount: i128) -> u64 {
         let client = s.client();
-        let trade_id = client.create_trade(&s.buyer, &s.seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&s.buyer, &s.seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         trade_id
     }
@@ -3684,7 +3773,7 @@ mod integration_tests {
 
         // ── Step 1: Create trade ────────────────────────────────────────────
         s.env.ledger().with_mut(|l| l.timestamp = 1_000);
-        let trade_id = client.create_trade(&s.buyer, &s.seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&s.buyer, &s.seller, &amount, &5000_u32, &5000_u32, &None);
 
         let trade = client.get_trade(&trade_id);
         assert!(
@@ -3880,7 +3969,7 @@ mod integration_tests {
     fn test_cannot_raise_dispute_before_funding() {
         let s = Setup::new(10_000, 100);
         let client = s.client();
-        let trade_id = client.create_trade(&s.buyer, &s.seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&s.buyer, &s.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         // deposit deliberately skipped — trade is still Created
         let dispute_reason = soroban_sdk::String::from_str(&s.env, "QmPrematureDispute");
         client.initiate_dispute(&trade_id, &s.buyer, &dispute_reason);
@@ -4104,7 +4193,7 @@ mod integration_tests {
         let client = s.client();
 
         // Trade is Created (not yet funded)
-        let trade_id = client.create_trade(&s.buyer, &s.seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&s.buyer, &s.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         let cid = soroban_sdk::String::from_str(&s.env, "QmTooEarlyCID");
         client.submit_video_proof(&trade_id, &s.buyer, &cid);
@@ -4205,7 +4294,7 @@ mod integration_tests {
         token_client.mint(&buyer, &amount);
 
         // Create trade with 30/70 loss-sharing (seller bears 70% of loss)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &3000_u32, &7000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &3000_u32, &7000_u32, &None);
         client.deposit(&trade_id);
         let reason = soroban_sdk::String::from_str(&env, "QmAsymmetricDispute");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -4266,7 +4355,7 @@ mod integration_tests {
 
         // Step 1: Create trade with 50/50 loss-sharing
         env.ledger().with_mut(|l| l.timestamp = 1_000);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         let trade = client.get_trade(&trade_id);
         assert!(matches!(trade.status, TradeStatus::Created));
         assert_eq!(trade.amount, amount);
@@ -4380,7 +4469,7 @@ mod integration_tests {
         token_client.mint(&buyer, &amount);
 
         // Create trade with 60/40 loss-sharing
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &6000_u32, &4000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &6000_u32, &4000_u32, &None);
         client.deposit(&trade_id);
         let reason = soroban_sdk::String::from_str(&env, "QmSmallAmountDispute");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -4469,7 +4558,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4509,7 +4598,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4542,7 +4631,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4587,7 +4676,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
         client.resolve_dispute(&trade_id, &mediator_a, &10_000_u32);
@@ -4642,7 +4731,7 @@ mod integration_tests {
 
         // Each mediator should be able to resolve the dispute
         // Test mediator_1
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
         client.resolve_dispute(&trade_id, &mediator_1, &6_000_u32);
@@ -4650,7 +4739,7 @@ mod integration_tests {
         assert!(matches!(trade.status, TradeStatus::Completed));
 
         // Test mediator_2
-        let trade_id_2 = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id_2 = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_2);
         client.initiate_dispute(&trade_id_2, &buyer, &String::from_str(&env, "reason2"));
         client.resolve_dispute(&trade_id_2, &mediator_2, &6_000_u32);
@@ -4658,7 +4747,7 @@ mod integration_tests {
         assert!(matches!(trade2.status, TradeStatus::Completed));
 
         // Test mediator_3
-        let trade_id_3 = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id_3 = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_3);
         client.initiate_dispute(&trade_id_3, &buyer, &String::from_str(&env, "reason3"));
         client.resolve_dispute(&trade_id_3, &mediator_3, &6_000_u32);
@@ -4710,7 +4799,7 @@ mod integration_tests {
         token_client.mint(&buyer, &(amount * 2)); // Mint enough for 2 trades
 
         // mediator_1 should still be able to resolve
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
         client.resolve_dispute(&trade_id, &mediator_1, &6_000_u32);
@@ -4718,7 +4807,7 @@ mod integration_tests {
         assert!(matches!(trade.status, TradeStatus::Completed));
 
         // mediator_3 should also be able to resolve
-        let trade_id_2 = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id_2 = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_2);
         client.initiate_dispute(&trade_id_2, &buyer, &String::from_str(&env, "reason2"));
         client.resolve_dispute(&trade_id_2, &mediator_3, &6_000_u32);
@@ -4754,7 +4843,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4790,7 +4879,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4851,7 +4940,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4888,7 +4977,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -4938,7 +5027,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &_usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
         client.resolve_dispute(&trade_id, &mediator_a, &6_000_u32);
@@ -4991,7 +5080,7 @@ mod integration_tests {
         token_client.mint(&buyer, &(amount * 3)); // Mint enough for 3 trades
 
         // Test mediator_a can resolve
-        let trade_id_a = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id_a = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_a);
         client.initiate_dispute(&trade_id_a, &buyer, &String::from_str(&env, "reason_a"));
         client.resolve_dispute(&trade_id_a, &mediator_a, &6_000_u32);
@@ -5001,7 +5090,7 @@ mod integration_tests {
         ));
 
         // Test mediator_b can resolve
-        let trade_id_b = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id_b = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_b);
         client.initiate_dispute(&trade_id_b, &buyer, &String::from_str(&env, "reason_b"));
         client.resolve_dispute(&trade_id_b, &mediator_b, &6_000_u32);
@@ -5011,7 +5100,7 @@ mod integration_tests {
         ));
 
         // Test mediator_c can resolve
-        let trade_id_c = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id_c = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id_c);
         client.initiate_dispute(&trade_id_c, &buyer, &String::from_str(&env, "reason_c"));
         client.resolve_dispute(&trade_id_c, &mediator_c, &6_000_u32);
@@ -5050,7 +5139,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5083,7 +5172,7 @@ mod integration_tests {
         let amount = 1000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5400,7 +5489,7 @@ mod property_tests {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5439,7 +5528,7 @@ mod property_tests {
         token_client.mint(&buyer, &amount);
 
         // 50/50 loss sharing
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5499,7 +5588,7 @@ mod property_tests {
         token_client.mint(&buyer, &amount);
 
         // 50/50 loss sharing (doesn't matter when no loss)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5550,7 +5639,7 @@ mod property_tests {
         // 50/50 loss sharing, seller_gets_bps = 0 (100% loss)
         // seller bears: 10,000 * 50% = 5,000, keeps: 5,000
         // buyer bears: 10,000 * 50% = 5,000, refund: 5,000
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5600,7 +5689,7 @@ mod property_tests {
 
         // 50/50 loss sharing, seller_gets_bps = 10000 (0% loss)
         // seller gets full amount, buyer gets 0
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5639,7 +5728,7 @@ mod property_tests {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5694,7 +5783,7 @@ mod property_tests {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
 
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -5813,7 +5902,7 @@ mod property_tests {
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &10_000_i128);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let client = EscrowContractClient::new(&env, &contract_id);
@@ -5855,7 +5944,7 @@ mod property_tests {
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &10_000_i128);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let client = EscrowContractClient::new(&env, &contract_id);
@@ -5890,7 +5979,7 @@ mod property_tests {
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &10_000_i128);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let client = EscrowContractClient::new(&env, &contract_id);
@@ -5933,7 +6022,7 @@ mod property_tests {
         client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &10_000_i128);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let client = EscrowContractClient::new(&env, &contract_id);
@@ -6199,7 +6288,7 @@ mod fee_and_evidence_tests {
         client.initialize(&admin, &usdc_id, &treasury, &fee_bps, &usdc_id);
         let token_client = token::StellarAssetClient::new(env, &usdc_id);
         token_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         (contract_id, buyer, seller, treasury, usdc_id, trade_id)
     }
@@ -6447,7 +6536,7 @@ mod fee_and_evidence_tests {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &overflowing_amount);
         let trade_id =
-            client.create_trade(&buyer, &seller, &overflowing_amount, &0_u32, &10_000_u32);
+            client.create_trade(&buyer, &seller, &overflowing_amount, &0_u32, &10_000_u32, &None);
         client.deposit(&trade_id);
 
         let reason = String::from_str(&env, "QmOverflowPayout");
@@ -6477,7 +6566,7 @@ mod fee_and_evidence_tests {
         let tok_client = token::StellarAssetClient::new(&env, &usdc_id);
         tok_client.mint(&buyer, &amount);
         // buyer_loss_bps=3000, seller_loss_bps=7000
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &3000_u32, &7000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &3000_u32, &7000_u32, &None);
         client.deposit(&trade_id);
         let reason = String::from_str(&env, "QmFeeTest3070");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -6516,7 +6605,7 @@ mod fee_and_evidence_tests {
         let amount = 10_000_i128;
         let tok_client = token::StellarAssetClient::new(&env, &usdc_id);
         tok_client.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &9999_u32, &1_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &9999_u32, &1_u32, &None);
         client.deposit(&trade_id);
         let reason = String::from_str(&env, "QmExtreme9999");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -6606,7 +6695,7 @@ mod fee_and_evidence_tests {
         client.add_mediator(&mediator);
         let tok = token::StellarAssetClient::new(env, &usdc_id);
         tok.mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         env.ledger().with_mut(|l| l.timestamp = 1_000);
         let reason = String::from_str(env, "QmDisputeReason");
@@ -6931,7 +7020,7 @@ mod fee_and_evidence_tests {
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
         // seller bears 100% loss (buyer_loss_bps=0, seller_loss_bps=10000)
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &0_u32, &10000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &0_u32, &10000_u32, &None);
         client.deposit(&trade_id);
         let reason = String::from_str(&env, "QmZeroSellerNet");
         client.initiate_dispute(&trade_id, &seller, &reason);

--- a/contracts/amana_escrow/src/tests/event_schema_tests.rs
+++ b/contracts/amana_escrow/src/tests/event_schema_tests.rs
@@ -119,7 +119,7 @@ mod event_schema_tests {
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
 
-        client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         assert_last_event_topics(
             &env,
@@ -136,7 +136,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         client.deposit(&trade_id);
 
@@ -157,7 +157,7 @@ mod event_schema_tests {
             setup_path_env(&env, 5_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &5_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &5_000_i128, &5000_u32, &5000_u32, &None);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &5_000_i128, &4_500_i128, &path);
 
@@ -175,7 +175,7 @@ mod event_schema_tests {
             setup_path_env(&env, 5_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &5_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &5_000_i128, &5000_u32, &5000_u32, &None);
         let path = Vec::new(&env);
         client.deposit_with_path(&trade_id, &buyer, &5_000_i128, &4_500_i128, &path);
 
@@ -199,7 +199,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         client.cancel_trade(&trade_id, &buyer);
 
@@ -218,7 +218,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         client.confirm_delivery(&trade_id);
@@ -238,7 +238,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.confirm_delivery(&trade_id);
 
@@ -259,7 +259,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "QmReason"));
@@ -280,7 +280,7 @@ mod event_schema_tests {
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
         let mediator = Address::generate(&env);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "QmReason"));
         client.set_mediator(&mediator);
@@ -302,7 +302,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "QmReason"));
 
@@ -328,7 +328,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         client.submit_video_proof(&trade_id, &buyer, &String::from_str(&env, "QmCID"));
@@ -348,7 +348,7 @@ mod event_schema_tests {
         env.mock_all_auths();
         let (contract_id, _, buyer, seller, _) = setup(&env, 10_000, 100);
         let client = EscrowContractClient::new(&env, &contract_id);
-        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         client.submit_manifest(
@@ -415,7 +415,7 @@ mod event_schema_tests {
         let mediator = Address::generate(&env);
 
 <<<<<<< HEAD
-        client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         assert_last_event_topics(
             &env,
             &[symbol_short!("TRDCRT").into_val(&env)],
@@ -431,7 +431,7 @@ mod event_schema_tests {
         token::StellarAssetClient::new(&env, &usdc2).mint(&buyer, &10_000_i128);
         c2.initialize(&admin2, &usdc2, &treasury2, &100_u32, &usdc2);
         c2.set_mediator(&mediator);
-        let tid = c2.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let tid = c2.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         c2.deposit(&tid);
         c2.initiate_dispute(&tid, &buyer, &String::from_str(&env, "QmGolden"));
         c2.resolve_dispute(&tid, &mediator, &5_000_u32);
@@ -447,7 +447,7 @@ mod event_schema_tests {
         // lifecycle completes without regressions.
 =======
         client.set_mediator(&mediator);
-        let tid = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+        let tid = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&tid);
         client.initiate_dispute(&tid, &buyer, &String::from_str(&env, "QmGolden"));
         client.resolve_dispute(&tid, &mediator, &5_000_u32);

--- a/contracts/amana_escrow/src/tests/gas_footprint_tests.rs
+++ b/contracts/amana_escrow/src/tests/gas_footprint_tests.rs
@@ -88,7 +88,7 @@ mod gas_footprint_tests {
         let client = ctx.client();
 
         let cost = ctx.measure(|| {
-            client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         });
 
         cost.assert_under("create_trade", BASELINE_CREATE_TRADE_CPU, BASELINE_CREATE_TRADE_MEM);
@@ -98,7 +98,7 @@ mod gas_footprint_tests {
     fn test_gas_deposit() {
         let ctx = Ctx::new(10_000);
         let client = ctx.client();
-        let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         let cost = ctx.measure(|| {
             client.deposit(&trade_id);
@@ -111,7 +111,7 @@ mod gas_footprint_tests {
     fn test_gas_initiate_dispute() {
         let ctx = Ctx::new(10_000);
         let client = ctx.client();
-        let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
 
         let cost = ctx.measure(|| {
@@ -129,7 +129,7 @@ mod gas_footprint_tests {
     fn test_gas_resolve_dispute() {
         let ctx = Ctx::new(10_000);
         let client = ctx.client();
-        let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+        let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &ctx.buyer, &String::from_str(&ctx.env, "QmGasTestReason"));
 
@@ -146,7 +146,7 @@ mod gas_footprint_tests {
         let client = ctx.client();
 
         let cost = ctx.measure(|| {
-            let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+            let trade_id = client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
             client.deposit(&trade_id);
             client.initiate_dispute(&trade_id, &ctx.buyer, &String::from_str(&ctx.env, "QmCombinedReason"));
             client.resolve_dispute(&trade_id, &ctx.mediator, &5_000_u32);

--- a/contracts/amana_escrow/src/tests/migration_tests.rs
+++ b/contracts/amana_escrow/src/tests/migration_tests.rs
@@ -76,7 +76,7 @@ mod migration_tests {
         let old_client = EscrowContractClient::new(&env, &old_contract);
 
         let trade_id =
-            old_client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+            old_client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         old_client.deposit(&trade_id);
 
         // Verify trade is bound to token-A
@@ -145,7 +145,7 @@ mod migration_tests {
         old_client.set_mediator(&mediator);
 
         let trade_id =
-            old_client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+            old_client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         old_client.deposit(&trade_id);
         old_client.initiate_dispute(
             &trade_id,
@@ -198,9 +198,9 @@ mod migration_tests {
 
         // Create 3 trades before migration
         let amount = 10_000_i128;
-        let t1 = old_client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32);
-        let t2 = old_client.create_trade(&buyer, &seller, &amount, &3000_u32, &7000_u32);
-        let t3 = old_client.create_trade(&buyer, &seller, &amount, &7000_u32, &3000_u32);
+        let t1 = old_client.create_trade(&buyer, &seller, &amount, &5000_u32, &5000_u32, &None);
+        let t2 = old_client.create_trade(&buyer, &seller, &amount, &3000_u32, &7000_u32, &None);
+        let t3 = old_client.create_trade(&buyer, &seller, &amount, &7000_u32, &3000_u32, &None);
 
         old_client.deposit(&t1);
         old_client.deposit(&t2);
@@ -255,7 +255,7 @@ mod migration_tests {
         let client = EscrowContractClient::new(&env, &contract_id);
 
         let trade_id =
-            client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         let token_at_creation = client.get_trade(&trade_id).token.clone();
 

--- a/contracts/amana_escrow/src/tests/ttl_tests.rs
+++ b/contracts/amana_escrow/src/tests/ttl_tests.rs
@@ -94,7 +94,7 @@ mod ttl_tests {
         assert_eq!(ctx.ttl(), 1, "TTL must be 1 just before expiry");
 
         ctx.client()
-            .create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+            .create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
         assert_eq!(
             ctx.ttl(),
@@ -114,7 +114,7 @@ mod ttl_tests {
 
         // Create trade
         let trade_id =
-            client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         assert!(matches!(
             client.get_trade(&trade_id).status,
             TradeStatus::Created
@@ -160,7 +160,7 @@ mod ttl_tests {
         let client = ctx.client();
 
         let trade_id_1 =
-            client.create_trade(&ctx.buyer, &ctx.seller, &1_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&ctx.buyer, &ctx.seller, &1_000_i128, &5000_u32, &5000_u32, &None);
         assert_eq!(trade_id_1 & 0xFFFF_FFFF_u64, 1, "first trade counter must be 1");
 
         // Advance to 1 ledger before expiry
@@ -169,7 +169,7 @@ mod ttl_tests {
 
         // create_trade bumps TTL
         let trade_id_2 =
-            client.create_trade(&ctx.buyer, &ctx.seller, &1_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&ctx.buyer, &ctx.seller, &1_000_i128, &5000_u32, &5000_u32, &None);
         assert_eq!(trade_id_2 & 0xFFFF_FFFF_u64, 2, "second trade counter must be 2");
         assert_eq!(
             ctx.ttl(),
@@ -191,7 +191,7 @@ mod ttl_tests {
             assert_eq!(ctx.ttl(), 1, "TTL must be 1 before jump {i}");
 
             // Any hot-path call bumps TTL
-            client.create_trade(&ctx.buyer, &ctx.seller, &1_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&ctx.buyer, &ctx.seller, &1_000_i128, &5000_u32, &5000_u32, &None);
             assert_eq!(
                 ctx.ttl(),
                 INSTANCE_TTL_EXTEND_TO,
@@ -209,7 +209,7 @@ mod ttl_tests {
         let client = ctx.client();
 
         let trade_id =
-            client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32);
+            client.create_trade(&ctx.buyer, &ctx.seller, &10_000_i128, &5000_u32, &5000_u32, &None);
         client.deposit(&trade_id);
         client.confirm_delivery(&trade_id);
         client.release_funds(&trade_id);

--- a/contracts/amana_escrow/tests/auth_matrix_tests.rs
+++ b/contracts/amana_escrow/tests/auth_matrix_tests.rs
@@ -56,7 +56,7 @@ impl Harness {
     fn funded_trade(&self, amount: i128) -> u64 {
         self.mint(&self.buyer, amount);
         let tid = self.client().create_trade(
-            &self.buyer, &self.seller, &amount, &5000u32, &5000u32,
+            &self.buyer, &self.seller, &amount, &5000u32, &5000u32, &None,
         );
         self.client().deposit(&tid);
         tid
@@ -90,7 +90,7 @@ fn test_auth_initialize_rejects_second_call() {
 fn test_auth_create_trade_buyer_allowed() {
     let h = Harness::new();
     // buyer creates a trade — allowed
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     assert!(matches!(h.client().get_trade(&tid).status, TradeStatus::Created));
 }
 
@@ -98,7 +98,7 @@ fn test_auth_create_trade_buyer_allowed() {
 fn test_auth_create_trade_stranger_allowed() {
     let h = Harness::new();
     // Anyone can call create_trade (no auth guard on the caller itself)
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     assert!(matches!(h.client().get_trade(&tid).status, TradeStatus::Created));
 }
 
@@ -106,7 +106,7 @@ fn test_auth_create_trade_stranger_allowed() {
 #[should_panic(expected = "buyer and seller must be different addresses")]
 fn test_auth_create_trade_rejects_self_trade() {
     let h = Harness::new();
-    h.client().create_trade(&h.buyer, &h.buyer, &1_000i128, &5000u32, &5000u32);
+    h.client().create_trade(&h.buyer, &h.buyer, &1_000i128, &5000u32, &5000u32, &None);
 }
 
 // ---------------------------------------------------------------------------
@@ -117,7 +117,7 @@ fn test_auth_create_trade_rejects_self_trade() {
 fn test_auth_deposit_buyer_allowed() {
     let h = Harness::new();
     h.mint(&h.buyer, 1_000);
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     h.client().deposit(&tid);
     assert!(matches!(h.client().get_trade(&tid).status, TradeStatus::Funded));
 }
@@ -127,7 +127,7 @@ fn test_auth_deposit_buyer_allowed() {
 fn test_auth_deposit_seller_denied() {
     let h = Harness::new();
     h.mint(&h.buyer, 1_000);
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     // Provide auth only for seller — must fail because buyer.require_auth() is called
     h.client()
         .mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -263,7 +263,7 @@ fn test_auth_release_funds_stranger_denied() {
 #[test]
 fn test_auth_cancel_trade_buyer_allowed_created() {
     let h = Harness::new();
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     h.client().cancel_trade(&tid, &h.buyer);
     assert!(matches!(h.client().get_trade(&tid).status, TradeStatus::Cancelled));
 }
@@ -271,7 +271,7 @@ fn test_auth_cancel_trade_buyer_allowed_created() {
 #[test]
 fn test_auth_cancel_trade_seller_allowed_created() {
     let h = Harness::new();
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     h.client().cancel_trade(&tid, &h.seller);
     assert!(matches!(h.client().get_trade(&tid).status, TradeStatus::Cancelled));
 }
@@ -279,7 +279,7 @@ fn test_auth_cancel_trade_seller_allowed_created() {
 #[test]
 fn test_auth_cancel_trade_admin_allowed_created() {
     let h = Harness::new();
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     h.client().cancel_trade(&tid, &h.admin);
     assert!(matches!(h.client().get_trade(&tid).status, TradeStatus::Cancelled));
 }
@@ -288,7 +288,7 @@ fn test_auth_cancel_trade_admin_allowed_created() {
 #[should_panic(expected = "Unauthorized caller")]
 fn test_auth_cancel_trade_stranger_denied_created() {
     let h = Harness::new();
-    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32);
+    let tid = h.client().create_trade(&h.buyer, &h.seller, &1_000i128, &5000u32, &5000u32, &None);
     h.client().cancel_trade(&tid, &h.stranger);
 }
 

--- a/contracts/amana_escrow/tests/dispute_flow.rs
+++ b/contracts/amana_escrow/tests/dispute_flow.rs
@@ -135,7 +135,7 @@ impl H {
         self.tok().mint(&self.buyer, &amount);
         let trade_id =
             self.c()
-                .create_trade(&self.buyer, &self.seller, &amount, &5000u32, &5000u32);
+                .create_trade(&self.buyer, &self.seller, &amount, &5000u32, &5000u32, &None);
         self.c().deposit(&trade_id);
         db_upsert(DbTrade {
             trade_id,

--- a/contracts/amana_escrow/tests/dispute_stress_tests.rs
+++ b/contracts/amana_escrow/tests/dispute_stress_tests.rs
@@ -58,7 +58,7 @@ impl Stress {
     fn disputed_trade(&self, amount: i128) -> u64 {
         self.mint(&self.buyer, amount);
         let tid = self.client().create_trade(
-            &self.buyer, &self.seller, &amount, &5000u32, &5000u32,
+            &self.buyer, &self.seller, &amount, &5000u32, &5000u32, &None,
         );
         self.client().deposit(&tid);
         self.client().initiate_dispute(
@@ -423,13 +423,13 @@ fn test_stress_evidence_lists_isolated_across_trades() {
     s.mint(&s.buyer, amount * 2);
 
     let tid_a = {
-        let tid = s.client().create_trade(&s.buyer, &s.seller, &amount, &5000u32, &5000u32);
+        let tid = s.client().create_trade(&s.buyer, &s.seller, &amount, &5000u32, &5000u32, &None);
         s.client().deposit(&tid);
         s.client().initiate_dispute(&tid, &s.buyer, &SStr::from_str(&s.env, "QmDisputeA"));
         tid
     };
     let tid_b = {
-        let tid = s.client().create_trade(&s.buyer, &s.seller, &amount, &5000u32, &5000u32);
+        let tid = s.client().create_trade(&s.buyer, &s.seller, &amount, &5000u32, &5000u32, &None);
         s.client().deposit(&tid);
         s.client().initiate_dispute(&tid, &s.buyer, &SStr::from_str(&s.env, "QmDisputeB"));
         tid

--- a/contracts/amana_escrow/tests/event_emission_tests.rs
+++ b/contracts/amana_escrow/tests/event_emission_tests.rs
@@ -105,7 +105,7 @@ fn test_event_trade_created_payload() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
 
     assert_last_topic(&env, symbol_short!("TRDCRT").into_val(&env));
 
@@ -138,7 +138,7 @@ fn test_event_trade_funded_payload() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.deposit(&trade_id);
 
     assert_last_topic(&env, symbol_short!("TRDFND").into_val(&env));
@@ -172,7 +172,7 @@ fn test_event_funds_released_payload_integrity() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.deposit(&trade_id);
     client.confirm_delivery(&trade_id);
     client.release_funds(&trade_id);
@@ -216,7 +216,7 @@ fn test_event_dispute_initiated_payload() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.deposit(&trade_id);
     let reason = String::from_str(&env, "QmTestDisputeReason");
     client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -299,7 +299,7 @@ fn test_full_lifecycle_event_sequence() {
     client.add_mediator(&mediator);
     assert_last_topic(&env, symbol_short!("MEDADD").into_val(&env));
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     assert_last_topic(&env, symbol_short!("TRDCRT").into_val(&env));
     let _ = trade_id;
 
@@ -334,7 +334,7 @@ fn test_dispute_lifecycle_event_sequence() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.deposit(&trade_id);
 
     client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "QmDispute"));
@@ -374,7 +374,7 @@ fn test_event_video_proof_submitted_payload() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.deposit(&trade_id);
 
     client.submit_video_proof(&trade_id, &buyer, &String::from_str(&env, "QmVideoCID"));
@@ -403,7 +403,7 @@ fn test_event_manifest_submitted_payload() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.deposit(&trade_id);
 
     client.submit_manifest(
@@ -437,7 +437,7 @@ fn test_event_trade_cancelled_payload() {
     let treasury = Address::generate(&env);
     client.initialize(&admin, &usdc_id, &treasury, &100_u32);
 
-    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
     client.cancel_trade(&trade_id, &buyer);
 
     assert_last_topic(&env, symbol_short!("TRDCAN").into_val(&env));
@@ -466,7 +466,7 @@ fn test_no_event_on_invalid_create() {
 
     // Attempt a create_trade with 0 amount should fail
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        client.create_trade(&buyer, &seller, &0_i128, &5000_u32, &5000_u32);
+        client.create_trade(&buyer, &seller, &0_i128, &5000_u32, &5000_u32, &None);
     }));
     assert!(result.is_err(), "create_trade with 0 amount must panic");
 }

--- a/contracts/amana_escrow/tests/expiration_tests.rs
+++ b/contracts/amana_escrow/tests/expiration_tests.rs
@@ -1,0 +1,369 @@
+/// Tests for SC-002: Trade Expiration / Lock-Time mechanism.
+///
+/// Verifies that:
+/// - Trades can be created with an optional `expires_at` deadline.
+/// - `claim_expiry_refund()` succeeds after the deadline passes and refunds the buyer.
+/// - `claim_expiry_refund()` is rejected before the deadline.
+/// - `claim_expiry_refund()` is rejected when no deadline is set.
+/// - `claim_expiry_refund()` is rejected when the trade is not in `Funded` status.
+/// - Only the buyer or seller can call `claim_expiry_refund()`.
+/// - `create_trade()` rejects a deadline that is in the past.
+extern crate std;
+
+use amana_escrow::{EscrowContract, EscrowContractClient, TradeStatus};
+use soroban_sdk::{
+    Address, Env, contract, contractimpl, contracttype,
+    testutils::{Address as _, Ledger},
+};
+
+// ---------------------------------------------------------------------------
+// Minimal mock token (same pattern as other test files)
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct MockToken;
+
+#[contracttype]
+#[derive(Clone)]
+pub enum MTKey {
+    Balance(Address),
+}
+
+#[contractimpl]
+impl MockToken {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let key = MTKey::Balance(to);
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&MTKey::Balance(id))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let from_key = MTKey::Balance(from);
+        let to_key = MTKey::Balance(to);
+        let from_balance: i128 = env.storage().persistent().get(&from_key).unwrap_or(0);
+        assert!(from_balance >= amount, "insufficient balance");
+        let to_balance: i128 = env.storage().persistent().get(&to_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&from_key, &(from_balance - amount));
+        env.storage()
+            .persistent()
+            .set(&to_key, &(to_balance + amount));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+struct H {
+    env: Env,
+    escrow: Address,
+    token: Address,
+    admin: Address,
+    buyer: Address,
+    seller: Address,
+    stranger: Address,
+}
+
+impl H {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| {
+            l.timestamp = 1_700_000_000;
+            l.sequence_number = 100;
+        });
+
+        let escrow = env.register(EscrowContract, ());
+        let token = env.register(MockToken, ());
+        let admin = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let stranger = Address::generate(&env);
+
+        H { env, escrow, token, admin, buyer, seller, stranger }
+    }
+
+    fn c(&self) -> EscrowContractClient<'_> {
+        EscrowContractClient::new(&self.env, &self.escrow)
+    }
+
+    fn tok(&self) -> MockTokenClient<'_> {
+        MockTokenClient::new(&self.env, &self.token)
+    }
+
+    fn init(&self) {
+        self.c().initialize(
+            &self.admin,
+            &self.token,
+            &self.admin,
+            &0u32,
+            &self.token,
+        );
+    }
+
+    fn now(&self) -> u64 {
+        self.env.ledger().timestamp()
+    }
+
+    fn advance_time(&self, seconds: u64) {
+        self.env.ledger().with_mut(|l| {
+            l.timestamp += seconds;
+        });
+    }
+
+    /// Create a funded trade with the given deadline (seconds from now).
+    fn funded_trade_with_deadline(&self, amount: i128, deadline_offset: u64) -> u64 {
+        let deadline = self.now() + deadline_offset;
+        self.tok().mint(&self.buyer, &amount);
+        let trade_id = self.c().create_trade(
+            &self.buyer,
+            &self.seller,
+            &amount,
+            &5000u32,
+            &5000u32,
+            &Some(deadline),
+        );
+        self.c().deposit(&trade_id);
+        trade_id
+    }
+
+    /// Create a funded trade with no deadline.
+    fn funded_trade_no_deadline(&self, amount: i128) -> u64 {
+        self.tok().mint(&self.buyer, &amount);
+        let trade_id = self.c().create_trade(
+            &self.buyer,
+            &self.seller,
+            &amount,
+            &5000u32,
+            &5000u32,
+            &None,
+        );
+        self.c().deposit(&trade_id);
+        trade_id
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: buyer claims refund after deadline passes.
+#[test]
+fn test_expiry_refund_buyer_after_deadline() {
+    let h = H::new();
+    h.init();
+
+    let amount = 1_000_000i128;
+    let trade_id = h.funded_trade_with_deadline(amount, 3600); // 1 hour deadline
+
+    // Advance past the deadline
+    h.advance_time(3601);
+
+    let buyer_balance_before = h.tok().balance(&h.buyer);
+    h.c().claim_expiry_refund(&trade_id, &h.buyer);
+    let buyer_balance_after = h.tok().balance(&h.buyer);
+
+    assert_eq!(
+        buyer_balance_after - buyer_balance_before,
+        amount,
+        "buyer should receive full refund"
+    );
+
+    let trade = h.c().get_trade(&trade_id);
+    assert!(
+        matches!(trade.status, TradeStatus::Cancelled),
+        "trade must be Cancelled after expiry refund"
+    );
+}
+
+/// Happy path: seller can also trigger the expiry refund (funds still go to buyer).
+#[test]
+fn test_expiry_refund_seller_after_deadline() {
+    let h = H::new();
+    h.init();
+
+    let amount = 500_000i128;
+    let trade_id = h.funded_trade_with_deadline(amount, 7200);
+
+    h.advance_time(7201);
+
+    let buyer_balance_before = h.tok().balance(&h.buyer);
+    h.c().claim_expiry_refund(&trade_id, &h.seller);
+    let buyer_balance_after = h.tok().balance(&h.buyer);
+
+    assert_eq!(
+        buyer_balance_after - buyer_balance_before,
+        amount,
+        "buyer should receive full refund even when seller triggers expiry"
+    );
+
+    let trade = h.c().get_trade(&trade_id);
+    assert!(matches!(trade.status, TradeStatus::Cancelled));
+}
+
+/// Rejection: claim before deadline should panic.
+#[test]
+#[should_panic(expected = "Trade has not yet expired")]
+fn test_expiry_refund_rejected_before_deadline() {
+    let h = H::new();
+    h.init();
+
+    let trade_id = h.funded_trade_with_deadline(100_000, 3600);
+
+    // Only advance 30 minutes — deadline not reached
+    h.advance_time(1800);
+
+    h.c().claim_expiry_refund(&trade_id, &h.buyer);
+}
+
+/// Rejection: trade with no deadline cannot be expired.
+#[test]
+#[should_panic(expected = "Trade has no expiry deadline")]
+fn test_expiry_refund_rejected_no_deadline() {
+    let h = H::new();
+    h.init();
+
+    let trade_id = h.funded_trade_no_deadline(100_000);
+
+    h.advance_time(999_999);
+
+    h.c().claim_expiry_refund(&trade_id, &h.buyer);
+}
+
+/// Rejection: stranger cannot claim expiry refund.
+#[test]
+#[should_panic(expected = "Only the buyer or seller can claim an expiry refund")]
+fn test_expiry_refund_rejected_stranger() {
+    let h = H::new();
+    h.init();
+
+    let trade_id = h.funded_trade_with_deadline(100_000, 3600);
+    h.advance_time(3601);
+
+    h.c().claim_expiry_refund(&trade_id, &h.stranger);
+}
+
+/// Rejection: cannot claim expiry on a Delivered trade.
+#[test]
+#[should_panic(expected = "Trade must be in Funded status to claim expiry refund")]
+fn test_expiry_refund_rejected_delivered_status() {
+    let h = H::new();
+    h.init();
+
+    let trade_id = h.funded_trade_with_deadline(100_000, 3600);
+    h.c().confirm_delivery(&trade_id);
+
+    h.advance_time(3601);
+
+    h.c().claim_expiry_refund(&trade_id, &h.buyer);
+}
+
+/// Rejection: cannot claim expiry on a Disputed trade.
+#[test]
+#[should_panic(expected = "Trade must be in Funded status to claim expiry refund")]
+fn test_expiry_refund_rejected_disputed_status() {
+    let h = H::new();
+    h.init();
+
+    let trade_id = h.funded_trade_with_deadline(100_000, 3600);
+
+    use soroban_sdk::String as SorobanString;
+    h.c().initiate_dispute(
+        &trade_id,
+        &h.buyer,
+        &SorobanString::from_str(&h.env, "QmDisputeReason"),
+    );
+
+    h.advance_time(3601);
+
+    h.c().claim_expiry_refund(&trade_id, &h.buyer);
+}
+
+/// Rejection: create_trade with a past deadline should panic.
+#[test]
+#[should_panic(expected = "expires_at must be in the future")]
+fn test_create_trade_rejects_past_deadline() {
+    let h = H::new();
+    h.init();
+
+    let past_deadline = h.now() - 1; // one second in the past
+    h.tok().mint(&h.buyer, &100_000i128);
+    h.c().create_trade(
+        &h.buyer,
+        &h.seller,
+        &100_000i128,
+        &5000u32,
+        &5000u32,
+        &Some(past_deadline),
+    );
+}
+
+/// Verify trade struct stores the deadline correctly.
+#[test]
+fn test_trade_stores_expires_at() {
+    let h = H::new();
+    h.init();
+
+    let deadline = h.now() + 86_400; // 24 hours
+    h.tok().mint(&h.buyer, &100_000i128);
+    let trade_id = h.c().create_trade(
+        &h.buyer,
+        &h.seller,
+        &100_000i128,
+        &5000u32,
+        &5000u32,
+        &Some(deadline),
+    );
+
+    let trade = h.c().get_trade(&trade_id);
+    assert_eq!(trade.expires_at, Some(deadline), "expires_at must be stored on trade");
+}
+
+/// Verify trade with no deadline stores None.
+#[test]
+fn test_trade_no_deadline_stores_none() {
+    let h = H::new();
+    h.init();
+
+    h.tok().mint(&h.buyer, &100_000i128);
+    let trade_id = h.c().create_trade(
+        &h.buyer,
+        &h.seller,
+        &100_000i128,
+        &5000u32,
+        &5000u32,
+        &None,
+    );
+
+    let trade = h.c().get_trade(&trade_id);
+    assert_eq!(trade.expires_at, None, "expires_at must be None when not set");
+}
+
+/// Verify expiry refund at exactly the deadline timestamp succeeds.
+#[test]
+fn test_expiry_refund_at_exact_deadline() {
+    let h = H::new();
+    h.init();
+
+    let amount = 200_000i128;
+    let offset = 3600u64;
+    let trade_id = h.funded_trade_with_deadline(amount, offset);
+
+    // Advance to exactly the deadline
+    h.advance_time(offset);
+
+    let buyer_before = h.tok().balance(&h.buyer);
+    h.c().claim_expiry_refund(&trade_id, &h.buyer);
+    let buyer_after = h.tok().balance(&h.buyer);
+
+    assert_eq!(buyer_after - buyer_before, amount);
+}

--- a/contracts/amana_escrow/tests/input_hardening_tests.rs
+++ b/contracts/amana_escrow/tests/input_hardening_tests.rs
@@ -102,7 +102,7 @@ impl H {
         self.tok().mint(&self.buyer, &amount);
         let trade_id =
             self.c()
-                .create_trade(&self.buyer, &self.seller, &amount, &5000u32, &5000u32);
+                .create_trade(&self.buyer, &self.seller, &amount, &5000u32, &5000u32, &None);
         self.c().deposit(&trade_id);
         trade_id
     }
@@ -140,7 +140,7 @@ fn create_trade_rejects_out_of_range_buyer_bps() {
     h.init();
     h.tok().mint(&h.buyer, &100i128);
     h.c()
-        .create_trade(&h.buyer, &h.seller, &100i128, &10_001u32, &0u32);
+        .create_trade(&h.buyer, &h.seller, &100i128, &10_001u32, &0u32, &None);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn create_trade_rejects_out_of_range_seller_bps() {
     h.init();
     h.tok().mint(&h.buyer, &100i128);
     h.c()
-        .create_trade(&h.buyer, &h.seller, &100i128, &0u32, &10_001u32);
+        .create_trade(&h.buyer, &h.seller, &100i128, &0u32, &10_001u32, &None);
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/amana_escrow/tests/property_tests.rs
+++ b/contracts/amana_escrow/tests/property_tests.rs
@@ -82,7 +82,7 @@ impl PropEnv {
 
         token::StellarAssetClient::new(&self.env, &self.usdc_id).mint(&buyer, &amount);
         let trade_id =
-            client.create_trade(&buyer, &seller, &amount, &buyer_loss_bps, &seller_loss_bps);
+            client.create_trade(&buyer, &seller, &amount, &buyer_loss_bps, &seller_loss_bps, &None);
         client.deposit(&trade_id);
         client.initiate_dispute(&trade_id, &buyer, &SStr::from_str(&self.env, "QmPropTest"));
         client.set_mediator(&mediator);
@@ -218,7 +218,7 @@ fn test_prop_invalid_lifecycle_transitions_seeded() {
 
         let amount = rng.gen_range(1i128..=100_000);
         token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &amount);
-        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000u32, &5000u32);
+        let trade_id = client.create_trade(&buyer, &seller, &amount, &5000u32, &5000u32, &None);
         client.deposit(&trade_id);
 
         // Attempting to deposit again must panic (trade is Funded, not Created)
@@ -237,7 +237,7 @@ fn test_prop_invalid_lifecycle_transitions_seeded() {
             c2.initialize(&admin2, &usdc2, &treasury2, &100u32, &usdc2);
             let amt2 = 1_000i128;
             token::StellarAssetClient::new(&env2, &usdc2).mint(&buyer2, &(amt2 * 2));
-            let tid2 = c2.create_trade(&buyer2, &seller2, &amt2, &5000u32, &5000u32);
+            let tid2 = c2.create_trade(&buyer2, &seller2, &amt2, &5000u32, &5000u32, &None);
             c2.deposit(&tid2);
             c2.deposit(&tid2); // must panic
         }));


### PR DESCRIPTION
No expiration mechanism exists for trades. README implies trades should have timeouts after which auto-refund occurs.

Priority: Medium
closes #490