### PR TITLE
fix: backend idempotency waits for parallel in-flight requests

### DIFF
--- a/backend/src/__tests__/idempotency.middleware.test.ts
+++ b/backend/src/__tests__/idempotency.middleware.test.ts
@@ -58,6 +58,11 @@ function createRes() {
       this.emit("finish");
       return this;
     }),
+    send: jest.fn(function send(this: any, body: unknown) {
+      this.body = body;
+      this.emit("finish");
+      return this;
+    }),
   } as unknown as Response & EventEmitter & { body?: unknown };
 
   return { res, headers };
@@ -137,6 +142,26 @@ describe("idempotencyMiddleware", () => {
     expect(redisMock.del).toHaveBeenCalledWith("idempotency:lock:POST:/trades:idem-1");
   });
 
+  it("caches successful responses sent via res.send", async () => {
+    const req = createReq();
+    const { res, headers } = createRes();
+
+    await idempotencyMiddleware(req, res, () => {
+      res.status(201).send({ ok: true });
+    });
+
+    await Promise.resolve();
+
+    expect(redisMock.set).toHaveBeenCalledWith(
+      "idempotency:POST:/trades:idem-1",
+      expect.stringContaining('"body":{"ok":true}'),
+      "EX",
+      86400,
+    );
+    expect(headers["X-Idempotency-Cache"]).not.toBe("HIT");
+    expect(redisMock.del).toHaveBeenCalledWith("idempotency:lock:POST:/trades:idem-1");
+  });
+
   it("serves in-flight duplicate request from replay cache without duplicate side effects", async () => {
     let sideEffects = 0;
     let cachedPayload: string | null = null;
@@ -181,6 +206,69 @@ describe("idempotencyMiddleware", () => {
       setTimeout(() => {
         res1.status(201).json({ tradeId: "created-once" });
       }, 10);
+    });
+
+    const next2 = jest.fn(() => {
+      sideEffects += 1;
+    });
+
+    await Promise.all([
+      idempotencyMiddleware(req1, res1, next1),
+      idempotencyMiddleware(req2, res2, next2),
+    ]);
+
+    expect(sideEffects).toBe(1);
+    expect(next1).toHaveBeenCalledTimes(1);
+    expect(next2).not.toHaveBeenCalled();
+    expect(res2.status).toHaveBeenCalledWith(201);
+    expect((res2 as any).body).toEqual({ tradeId: "created-once" });
+    expect(headers2["X-Idempotency-Cache"]).toBe("HIT");
+  });
+
+  it("waits for a long-running in-flight request before returning a replay", async () => {
+    let sideEffects = 0;
+    let cachedPayload: string | null = null;
+    let lockHeld = false;
+
+    redisMock.get.mockImplementation(async (key: string) => {
+      if (key === "idempotency:POST:/trades:idem-1") {
+        return cachedPayload as any;
+      }
+      return null as any;
+    });
+
+    redisMock.set.mockImplementation(async (key: string, value: string, mode: string) => {
+      if (key === "idempotency:lock:POST:/trades:idem-1" && mode === "NX") {
+        if (lockHeld) return null as any;
+        lockHeld = true;
+        return "OK" as any;
+      }
+
+      if (key === "idempotency:POST:/trades:idem-1") {
+        cachedPayload = value;
+        return "OK" as any;
+      }
+
+      return "OK" as any;
+    });
+
+    redisMock.del.mockImplementation(async (key: string) => {
+      if (key === "idempotency:lock:POST:/trades:idem-1") {
+        lockHeld = false;
+      }
+      return 1 as any;
+    });
+
+    const req1 = createReq();
+    const req2 = createReq();
+    const { res: res1 } = createRes();
+    const { res: res2, headers: headers2 } = createRes();
+
+    const next1 = jest.fn(() => {
+      sideEffects += 1;
+      setTimeout(() => {
+        res1.status(201).json({ tradeId: "created-once" });
+      }, 1200);
     });
 
     const next2 = jest.fn(() => {

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -6,14 +6,16 @@ import { alertService } from "../services/alert.service";
 const IDEMPOTENCY_TTL = 60 * 60 * 24; // 24 hours
 const IDEMPOTENCY_LOCK_TTL = 30; // 30 seconds
 const IN_PROGRESS_POLL_MS = 25;
-const IN_PROGRESS_MAX_POLLS = 40;
+const IDEMPOTENCY_IN_PROGRESS_MAX_WAIT_MS = IDEMPOTENCY_LOCK_TTL * 1000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function waitForCachedResponse(cacheKey: string): Promise<string | null> {
-  for (let i = 0; i < IN_PROGRESS_MAX_POLLS; i += 1) {
+  const deadline = Date.now() + IDEMPOTENCY_IN_PROGRESS_MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
     await sleep(IN_PROGRESS_POLL_MS);
     const cached = await redis.get(cacheKey);
     if (cached) {
@@ -95,10 +97,11 @@ export const idempotencyMiddleware = async (
     res.once("finish", releaseLock);
     res.once("close", releaseLock);
 
-    // Intercept res.json to cache the response
+    // Intercept res.json and res.send to cache successful responses regardless of Express helper used.
     const originalJson = res.json.bind(res);
-    res.json = (body: any) => {
-      // Only cache successful responses
+    const originalSend = (res.send as any)?.bind(res);
+
+    const cacheResponse = (body: any) => {
       if (res.statusCode >= 200 && res.statusCode < 300) {
         const responseData = {
           status: res.statusCode,
@@ -108,9 +111,19 @@ export const idempotencyMiddleware = async (
         redis.set(cacheKey, JSON.stringify(responseData), "EX", IDEMPOTENCY_TTL)
           .catch(err => appLogger.error({ err }, "Failed to cache idempotent response"));
       }
-      
+    };
+
+    res.json = (body: any) => {
+      cacheResponse(body);
       return originalJson(body);
     };
+
+    if (typeof originalSend === "function") {
+      res.send = (body: any) => {
+        cacheResponse(body);
+        return originalSend(body);
+      };
+    }
 
     next();
   } catch (error) {


### PR DESCRIPTION
Closes #542

---

Extends backend idempotency middleware to wait for long-running in-flight requests and caches successful responses sent via res.send, avoiding duplicate side effects for parallel duplicate requests.