### PR TITLE
fix: remove unsafe req.params.id[0] array access in dispute controller

### DIFF
--- a/backend/src/controllers/dispute.controller.ts
+++ b/backend/src/controllers/dispute.controller.ts
@@ -62,7 +62,7 @@ export class DisputeController {
       return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const tradeId = typeof req.params.id === "string" ? req.params.id : req.params.id[0];
+    const tradeId = req.params.id as string;
     const { status } = req.body as { status: DisputeStatus };
 
     try {


### PR DESCRIPTION
replace unsafe req.params.id[0] array access with direct string assignment

closes #655 