### PR TITLE
fix(contracts): resolve initialize() arity mismatch causing test failures (#532)

### DIFF
--- a/contracts/amana_escrow/Cargo.toml
+++ b/contracts/amana_escrow/Cargo.toml
@@ -42,3 +42,11 @@ path = "tests/dispute_stress_tests.rs"
 [[test]]
 name = "event_emission_tests"
 path = "tests/event_emission_tests.rs"
+
+[[test]]
+name = "input_hardening_tests"
+path = "tests/input_hardening_tests.rs"
+
+[[test]]
+name = "schema_version_tests"
+path = "tests/schema_version_tests.rs"

--- a/contracts/amana_escrow/tests/event_emission_tests.rs
+++ b/contracts/amana_escrow/tests/event_emission_tests.rs
@@ -37,7 +37,7 @@ fn setup(
         .register_stellar_asset_contract_v2(admin.clone())
         .address();
     token::StellarAssetClient::new(env, &usdc_id).mint(&buyer, &amount);
-    client.initialize(&admin, &usdc_id, &treasury, &fee_bps);
+    client.initialize(&admin, &usdc_id, &treasury, &fee_bps, &usdc_id);
     (contract_id, usdc_id, buyer, seller, treasury, mediator)
 }
 
@@ -103,7 +103,7 @@ fn test_event_trade_created_payload() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
 
@@ -136,7 +136,7 @@ fn test_event_trade_funded_payload() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.deposit(&trade_id);
@@ -170,7 +170,7 @@ fn test_event_funds_released_payload_integrity() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.deposit(&trade_id);
@@ -214,7 +214,7 @@ fn test_event_dispute_initiated_payload() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.deposit(&trade_id);
@@ -242,7 +242,7 @@ fn test_event_mediator_added_payload() {
     let usdc_id = env
         .register_stellar_asset_contract_v2(admin.clone())
         .address();
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     client.add_mediator(&mediator);
 
@@ -267,7 +267,7 @@ fn test_event_mediator_removed_payload() {
     let usdc_id = env
         .register_stellar_asset_contract_v2(admin.clone())
         .address();
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
     client.add_mediator(&mediator);
 
     client.remove_mediator(&mediator);
@@ -294,7 +294,7 @@ fn test_full_lifecycle_event_sequence() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     client.add_mediator(&mediator);
     assert_last_topic(&env, symbol_short!("MEDADD").into_val(&env));
@@ -332,7 +332,7 @@ fn test_dispute_lifecycle_event_sequence() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.deposit(&trade_id);
@@ -372,7 +372,7 @@ fn test_event_video_proof_submitted_payload() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.deposit(&trade_id);
@@ -401,7 +401,7 @@ fn test_event_manifest_submitted_payload() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.deposit(&trade_id);
@@ -435,7 +435,7 @@ fn test_event_trade_cancelled_payload() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32);
     client.cancel_trade(&trade_id, &buyer);
@@ -462,7 +462,7 @@ fn test_no_event_on_invalid_create() {
     token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
-    client.initialize(&admin, &usdc_id, &treasury, &100_u32);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
 
     // Attempt a create_trade with 0 amount should fail
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/contracts/amana_escrow/tests/input_hardening_tests.rs
+++ b/contracts/amana_escrow/tests/input_hardening_tests.rs
@@ -92,7 +92,7 @@ impl H {
 
     fn init(&self) {
         self.c()
-            .initialize(&self.admin, &self.token, &self.admin, &0u32);
+            .initialize(&self.admin, &self.token, &self.admin, &0u32, &self.token);
         self.c().set_mediator(&self.mediator);
     }
 

--- a/contracts/amana_escrow/tests/schema_version_tests.rs
+++ b/contracts/amana_escrow/tests/schema_version_tests.rs
@@ -16,7 +16,7 @@ fn setup() -> (Env, Address) {
     let admin = Address::generate(&env);
     let cngn = Address::generate(&env);
     let treasury = Address::generate(&env);
-    EscrowContractClient::new(&env, &escrow).initialize(&admin, &cngn, &treasury, &100u32);
+    EscrowContractClient::new(&env, &escrow).initialize(&admin, &cngn, &treasury, &100u32, &cngn);
     (env, escrow)
 }
 


### PR DESCRIPTION
## Summary

Fixes #532 — contract tests were failing to compile because `initialize()` was called with 4 arguments in 3 test files, but the function signature requires 5 (`source_token` was added for path payment support and never backfilled into these files).

## Root Cause

`EscrowContract::initialize()` signature:
```rust
pub fn initialize(env, admin, cngn_contract, treasury, fee_bps, source_token)
```

Three test files were calling it with only 4 args (missing `source_token`), causing a compile error on every platform.

## Changes

| File | Change |
|------|--------|
| `tests/input_hardening_tests.rs` | Added `&self.token` as `source_token` (1 call) |
| `tests/event_emission_tests.rs` | Added `&usdc_id` as `source_token` (13 calls) |
| `tests/schema_version_tests.rs` | Added `&cngn` as `source_token` (1 call) |
| `Cargo.toml` | Registered `input_hardening_tests` and `schema_version_tests` as `[[test]]` targets — they existed but were never compiled or run by `cargo test` |

## Validation

- All `initialize()` call sites across the entire `contracts/` tree verified to pass exactly 5 arguments
- No existing test logic was modified — only the missing argument was added
- CI gate: `cargo test --locked` in `contracts/amana_escrow/` will now compile and run all 8 integration test suites
closes #532 