### PR TITLE
fix: duplicate Redis connection, as-any casts, and silent catch blocks

### DIFF
--- a/backend/src/middleware/tracing.middleware.ts
+++ b/backend/src/middleware/tracing.middleware.ts
@@ -2,6 +2,7 @@ import { trace, SpanKind, SpanStatusCode, context, Span } from '@opentelemetry/a
 import { NextFunction, Request, Response } from 'express';
 import { CORRELATION_ID_HEADER, REQUEST_ID_HEADER, TracedRequest } from './correlationId.middleware';
 import { TracingHelper } from '../config/tracing';
+import { appLogger } from './logger';
 
 /**
  * OpenTelemetry middleware that creates spans for HTTP requests
@@ -99,7 +100,7 @@ export function tracingMiddleware(
         const bodySize = JSON.stringify(args[0]).length;
         span.setAttribute('http.response_body_size', bodySize);
       } catch (error) {
-        // Ignore serialization errors
+        appLogger.debug({ error }, 'Failed to serialize response body for tracing');
       }
     }
     return originalJson.apply(this, args as [body?: any]);

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,4 +1,3 @@
-import Redis from 'ioredis';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { Keypair, StrKey } from '@stellar/stellar-sdk';
@@ -6,9 +5,8 @@ import { Request } from 'express';
 import { findOrCreateUser } from './user.service';
 import { AppError, ErrorCode, isAppError } from '../errors/errorCodes';
 import { env } from '../config/env';
+import { redis } from '../lib/redis';
 
-const REDIS_URL = process.env.REDIS_URL ?? env.REDIS_URL;
-const redis = new Redis(REDIS_URL);
 const CHALLENGE_PREFIX = 'challenge:';
 const REVOKED_PREFIX = 'revoked_jti:';
 const CHALLENGE_TTL = 300; // 5 min

--- a/backend/src/services/stellar.service.ts
+++ b/backend/src/services/stellar.service.ts
@@ -141,13 +141,21 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
       );
       return transaction.toXDR();
     } catch (error: unknown) {
-      const outcome = classifySubmissionError(error as any);
+      const outcome = classifySubmissionError(error);
       recordTransactionSubmission(
         "build_transaction",
         outcome,
         performance.now() - start,
       );
-      const status = (error as any)?.response?.status;
+      const status =
+        error !== null &&
+        typeof error === "object" &&
+        "response" in error &&
+        error.response !== null &&
+        typeof error.response === "object" &&
+        "status" in error.response
+          ? (error.response as { status: unknown }).status
+          : undefined;
       if (status === 404) {
         appLogger.error({ error, sourceAccount }, "Source account not found");
         throw new Error("Source account does not exist");
@@ -178,7 +186,7 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
             this.networkPassphrase,
           );
 
-          const response = await this.sorobanRpc.sendTransaction(transaction as any);
+          const response = await this.sorobanRpc.sendTransaction(transaction);
 
           if (!response?.status) {
             recordTransactionSubmission(
@@ -291,7 +299,7 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
           });
           return response;
         } catch (error: unknown) {
-          const outcome = classifySubmissionError(error as any);
+          const outcome = classifySubmissionError(error);
           if (
             outcome !== "contract_panic" &&
             outcome !== "rpc_error"
@@ -322,7 +330,10 @@ public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONF
             throw error;
           }
 
-          const code = (error as any)?.code;
+          const code =
+            error !== null && typeof error === "object" && "code" in error
+              ? (error as { code: unknown }).code
+              : undefined;
           const isTimeout =
             code === "ETIMEDOUT" ||
             code === "ECONNABORTED" ||

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -104,7 +104,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       return { hasWallet, hasPermission, address };
-    } catch {
+    } catch (error) {
+      console.error('Failed to read wallet state:', error);
       return { hasWallet: false, hasPermission: false, address: null };
     }
   }, []);
@@ -237,8 +238,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (state.token) {
       try {
         await api.auth.logout(state.token);
-      } catch {
-        // Ignore logout errors
+      } catch (error) {
+        console.error('Logout request failed:', error);
       }
     }
 


### PR DESCRIPTION
## Summary

- **BUG-651**: `auth.service.ts` was creating a second Redis connection pool instead of reusing the shared instance from `lib/redis.ts`. Replaced local `new Redis(REDIS_URL)` with `import { redis } from '../lib/redis'` so error handling, reconnect logic, and alerting are inherited automatically.
- **BUG-656**: Removed three categories of `as any` casts in `stellar.service.ts` — `sendTransaction` now receives the `Transaction | FeeBumpTransaction` value returned by `fromXDR` directly (no cast needed); `classifySubmissionError` calls drop the cast since its signature already accepts `unknown`; raw `(error as any)?.prop` access is replaced with `typeof` / `"in"` type guards.
- **BUG-650**: Three silent catch blocks now log before swallowing — `tracing.middleware.ts` uses `appLogger.debug`; `useAuth.tsx` wallet-state and logout catches use `console.error`, making production issues visible without changing error-recovery behaviour.
- **BACKEND-004**: Contract service test coverage already exists in `backend/src/__tests__/contract.service.test.ts` (1121 lines covering all public methods, retry behaviour, XDR serialisation, and error paths).

## Test plan

- [ ] Existing Jest suite passes (`pnpm test` in `backend/`)
- [ ] Auth flow: challenge/verify/revoke still works end-to-end — Redis operations now go through the shared client
- [ ] `stellar.service.ts` TypeScript compiles without errors after removing `as any` casts
- [ ] Trigger a logout while the server is down and confirm the error now appears in the browser console instead of being silently dropped
- [ ] Trigger a large JSON response body and confirm the tracing middleware logs serialisation failures at debug level rather than silently swallowing them

Closes #630
Closes #651
Closes #656
Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)