### PR TITLE
fix: remove unused imports and add wallet-based rate limiting

### DIFF
--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -2,9 +2,9 @@ import { Router } from "express";
 import { authMiddleware } from "../middleware/auth.middleware";
 import { getMe, updateMe, getUserByAddress } from "../controllers/user.controller";
 import { RATE_LIMIT_CONFIG } from "../config/rateLimit";
-import { createIpRateLimiter } from "../lib/rateLimit";
+import { createWalletRateLimiter } from "../lib/rateLimit";
 
-const limiter = createIpRateLimiter(RATE_LIMIT_CONFIG.user);
+const limiter = createWalletRateLimiter(RATE_LIMIT_CONFIG.user);
 
 const router = Router();
 

--- a/backend/src/services/savings.service.ts
+++ b/backend/src/services/savings.service.ts
@@ -1,8 +1,5 @@
-import { Prisma, PrismaClient, Goal, Vault } from "@prisma/client";
+import { PrismaClient, Goal, Vault } from "@prisma/client";
 import { prisma as defaultPrisma } from "../lib/db";
-import * as StellarSdk from "@stellar/stellar-sdk";
-import { env } from "../config/env";
-import { TOKEN_BASE } from "../config/token";
 
 interface GoalAnalytics {
     goalId: string;

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,6 +1,6 @@
 import { getSupabaseClient } from "../lib/supabase";
 import { UpdateProfileInput, updateProfileSchema } from "../validators/user.validators";
-import { AppError, ErrorCode, isAppError } from "../errors/errorCodes";
+import { AppError, ErrorCode } from "../errors/errorCodes";
 import { StrKey } from "@stellar/stellar-sdk";
 
 /** 


### PR DESCRIPTION
Closes #693, closes #694, closes #697, closes #698

## Changes

### #697: Remove unused \isAppError\ import
- Removed unused \isAppError\ import from \user.service.ts\

### #698: Remove 4 unused imports
- Removed unused \Prisma\, \StellarSdk\, \env\, \TOKEN_BASE\ imports from \savings.service.ts\

### #693: IPFS retry/timeout/circuit breaker
- Already implemented in \ipfs.service.ts\ — retry with backoff, upload timeout, and circuit breaker are all in place

### #694: Wallet-based rate limiting
- Changed \user.routes.ts\ from IP-based (\createIpRateLimiter\) to wallet-based (\createWalletRateLimiter\) rate limiting, which falls back to IP when no auth is present