### PR TITLE
feat: stellar fee + tx status routes, circuit breaker integration, test fixes

### DIFF
--- a/backend/src/__tests__/ipfs.service.test.ts
+++ b/backend/src/__tests__/ipfs.service.test.ts
@@ -22,7 +22,6 @@ describe("IPFSService", () => {
     afterEach(() => {
         __resetPinataClient();
         __resetRetrySleepForTests();
-        IPFSService.__resetCircuitForTests();
         delete process.env.IPFS_UPLOAD_TIMEOUT_MS;
         delete process.env.IPFS_PINATA_CIRCUIT_FAILURE_THRESHOLD;
         delete process.env.IPFS_PINATA_CIRCUIT_COOLDOWN_MS;

--- a/backend/src/__tests__/stellar.fees.test.ts
+++ b/backend/src/__tests__/stellar.fees.test.ts
@@ -1,0 +1,84 @@
+import request from "supertest";
+import { createApp } from "../app";
+import express from "express";
+
+const mockFeeStats = jest.fn();
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: {
+    feeStats: mockFeeStats,
+  },
+  sorobanRpcClient: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+describe("GET /stellar/fees", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockFeeStats.mockReset();
+    app = createApp();
+  });
+
+  it("returns fee stats from Stellar network", async () => {
+    mockFeeStats.mockResolvedValue({
+      last_ledger: "12345",
+      last_ledger_base_fee: "100",
+      fee_charged: {
+        max: "1000",
+        min: "100",
+        mode: "100",
+        p10: "100",
+        p20: "100",
+        p30: "100",
+        p40: "100",
+        p50: "100",
+        p60: "100",
+        p70: "100",
+        p80: "100",
+        p90: "100",
+        p95: "100",
+        p99: "100",
+      },
+      max_fee: {
+        max: "10000",
+        min: "100",
+        mode: "100",
+        p10: "100",
+        p20: "100",
+        p30: "100",
+        p40: "100",
+        p50: "100",
+        p60: "100",
+        p70: "100",
+        p80: "100",
+        p90: "100",
+        p95: "100",
+        p99: "100",
+      },
+    });
+
+    const response = await request(app).get("/stellar/fees");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty("feeCharged");
+    expect(response.body).toHaveProperty("maxFee");
+    expect(response.body).toHaveProperty("ledger");
+    expect(response.body.ledger).toBe(12345);
+    expect(response.body).toHaveProperty("lastLedgerBaseFee");
+    expect(response.body.lastLedgerBaseFee).toBe(100);
+    expect(response.body.feeCharged).toHaveProperty("max");
+    expect(response.body.feeCharged).toHaveProperty("min");
+    expect(response.body.maxFee).toHaveProperty("max");
+    expect(response.body.maxFee).toHaveProperty("min");
+  });
+
+  it("returns 502 when Horizon fails", async () => {
+    mockFeeStats.mockRejectedValue(new Error("Horizon unavailable"));
+
+    const response = await request(app).get("/stellar/fees");
+
+    expect(response.status).toBe(502);
+    expect(response.body).toHaveProperty("error");
+  });
+});

--- a/backend/src/__tests__/stellar.tx.status.test.ts
+++ b/backend/src/__tests__/stellar.tx.status.test.ts
@@ -1,0 +1,102 @@
+import request from "supertest";
+import { createApp } from "../app";
+import express from "express";
+
+const mockTransactions = jest.fn();
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: {
+    transactions: mockTransactions,
+  },
+  sorobanRpcClient: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+describe("GET /stellar/tx/:hash/status", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockTransactions.mockReset();
+    app = createApp();
+  });
+
+  it("returns success status for a confirmed transaction", async () => {
+    const mockCall = jest.fn().mockResolvedValue({
+      id: "abc123",
+      successful: true,
+      ledger: 12345,
+      created_at: "2024-01-01T00:00:00Z",
+      result_xdr: "AAAA",
+    });
+    mockTransactions.mockReturnValue({
+      transaction: () => ({ call: mockCall }),
+    });
+
+    const response = await request(app).get(
+      "/stellar/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status"
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe("success");
+    expect(response.body.ledger).toBe(12345);
+    expect(response.body.hash).toBe("abc123");
+    expect(response.body).toHaveProperty("resultCodes");
+  });
+
+  it("returns failed status for a failed transaction", async () => {
+    const mockCall = jest.fn().mockResolvedValue({
+      id: "def456",
+      successful: false,
+      ledger: 12346,
+      created_at: "2024-01-01T00:00:00Z",
+      result_xdr: "AAAA",
+    });
+    mockTransactions.mockReturnValue({
+      transaction: () => ({ call: mockCall }),
+    });
+
+    const response = await request(app).get(
+      "/stellar/tx/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/status"
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe("failed");
+  });
+
+  it("returns 404 for unknown transaction hash", async () => {
+    const mockCall = jest.fn().mockRejectedValue({
+      response: { status: 404 },
+    });
+    mockTransactions.mockReturnValue({
+      transaction: () => ({ call: mockCall }),
+    });
+
+    const response = await request(app).get(
+      "/stellar/tx/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc/status"
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.status).toBe("pending");
+  });
+
+  it("returns 400 for invalid hash", async () => {
+    const response = await request(app).get("/stellar/tx/short/status");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty("error");
+  });
+
+  it("returns 502 on network error", async () => {
+    const mockCall = jest.fn().mockRejectedValue(new Error("Network failure"));
+    mockTransactions.mockReturnValue({
+      transaction: () => ({ call: mockCall }),
+    });
+
+    const response = await request(app).get(
+      "/stellar/tx/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd/status"
+    );
+
+    expect(response.status).toBe(502);
+    expect(response.body).toHaveProperty("error");
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,8 @@ import { disputeCategoryRoutes } from "./routes/disputeCategory.routes";
 import { createTreasuryRouter } from "./routes/treasury.routes";
 import userRoutes from "./routes/user.routes";
 import reputationRoutes from "./routes/reputation.routes";
+import { stellarFeesRoutes } from "./routes/stellar.fees";
+import { stellarTxStatusRoutes } from "./routes/stellar.tx.status";
 import { env } from "./config/env";
 
 /** Parse the CORS_ORIGINS env var into a usable allowlist.
@@ -123,6 +125,10 @@ export function createApp(): express.Application {
 
   // Dispute categories: CRUD /dispute-categories
   app.use("/dispute-categories", disputeCategoryRoutes);
+
+  // Stellar network endpoints
+  app.use("/stellar/fees", stellarFeesRoutes);
+  app.use("/stellar/tx", stellarTxStatusRoutes);
 
   // Treasury management
   app.use("/treasury", createTreasuryRouter());

--- a/backend/src/lib/circuitBreaker.ts
+++ b/backend/src/lib/circuitBreaker.ts
@@ -18,6 +18,15 @@ export class CircuitBreakerOpenError extends Error {
   }
 }
 
+const registry = new Map<string, CircuitBreaker>();
+
+export function getCircuitBreakerStates(): Array<{ name: string; state: CircuitState }> {
+  return Array.from(registry.entries()).map(([name, cb]) => ({
+    name,
+    state: cb.currentState,
+  }));
+}
+
 export class CircuitBreaker {
   private state: CircuitState = "CLOSED";
   private failureCount = 0;
@@ -37,10 +46,23 @@ export class CircuitBreaker {
     this.successThreshold = options.successThreshold ?? 2;
     this.cooldownMs = options.cooldownMs ?? 30_000;
     this.now = options.now ?? Date.now;
+    registry.set(name, this);
   }
 
   get currentState(): CircuitState {
     return this.state;
+  }
+
+  get failureCountValue(): number {
+    return this.failureCount;
+  }
+
+  get successCountValue(): number {
+    return this.successCount;
+  }
+
+  get openedAtValue(): number | null {
+    return this.openedAt;
   }
 
   async call<T>(operation: () => Promise<T>): Promise<T> {

--- a/backend/src/routes/stellar.fees.ts
+++ b/backend/src/routes/stellar.fees.ts
@@ -1,0 +1,29 @@
+import { Router, Request, Response } from "express";
+import { horizonServer } from "../config/stellar";
+import { appLogger } from "../middleware/logger";
+
+export function createStellarFeesRouter(): Router {
+  const router = Router();
+
+  router.get("/", async (req: Request, res: Response) => {
+    try {
+      const feeStats = await horizonServer.feeStats();
+
+      res.json({
+        feeCharged: feeStats.fee_charged,
+        maxFee: feeStats.max_fee,
+        ledger: parseInt(feeStats.last_ledger, 10),
+        lastLedgerBaseFee: parseInt(feeStats.last_ledger_base_fee, 10),
+      });
+    } catch (error) {
+      appLogger.error({ error }, "Failed to fetch Stellar fee stats");
+      res.status(502).json({
+        error: "Failed to fetch fee data from Stellar network",
+      });
+    }
+  });
+
+  return router;
+}
+
+export const stellarFeesRoutes = createStellarFeesRouter();

--- a/backend/src/routes/stellar.tx.status.ts
+++ b/backend/src/routes/stellar.tx.status.ts
@@ -1,0 +1,75 @@
+import { Router, Request, Response } from "express";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { horizonServer } from "../config/stellar";
+import { appLogger } from "../middleware/logger";
+
+function parseResultCodes(resultXdr: string): { transaction: string; operations: string[] } {
+  try {
+    const xdr = Buffer.from(resultXdr, "base64");
+    const result = StellarSdk.xdr.TransactionResult.fromXDR(xdr);
+    const resultCode = result.result().switch();
+    const transactionCode = StellarSdk.xdr.TransactionResultCode.name(resultCode);
+
+    const opResults = result.result().results() || [];
+    const operationCodes = opResults.map((op) => {
+      const opResult = op.tr().switch();
+      return StellarSdk.xdr.OperationType.name(opResult);
+    });
+
+    return {
+      transaction: transactionCode,
+      operations: operationCodes,
+    };
+  } catch {
+    return { transaction: "unknown", operations: [] };
+  }
+}
+
+export function createStellarTxStatusRouter(): Router {
+  const router = Router();
+
+  router.get("/:hash/status", async (req: Request, res: Response) => {
+    const { hash } = req.params;
+
+    if (!hash || hash.length !== 64) {
+      res.status(400).json({ error: "Invalid transaction hash" });
+      return;
+    }
+
+    try {
+      const txResponse = await horizonServer
+        .transactions()
+        .transaction(hash)
+        .call();
+
+      const resultCodes = parseResultCodes(txResponse.result_xdr);
+      const status = txResponse.successful ? "success" : "failed";
+
+      res.json({
+        status,
+        resultCodes,
+        ledger: txResponse.ledger,
+        hash: txResponse.id,
+        createdAt: txResponse.created_at,
+      });
+    } catch (error: any) {
+      if (error?.response?.status === 404) {
+        res.status(404).json({
+          status: "pending",
+          hash,
+          message: "Transaction not found on Stellar network (may still be pending)",
+        });
+        return;
+      }
+
+      appLogger.error({ error, hash }, "Failed to fetch transaction status");
+      res.status(502).json({
+        error: "Failed to fetch transaction status from Stellar network",
+      });
+    }
+  });
+
+  return router;
+}
+
+export const stellarTxStatusRoutes = createStellarTxStatusRouter();

--- a/backend/src/services/eventListener.service.ts
+++ b/backend/src/services/eventListener.service.ts
@@ -7,6 +7,10 @@ import {
 import { EventType, ParsedEvent } from "../types/events";
 import { dispatchEvent } from "./eventHandlers";
 import { appLogger } from "../middleware/logger";
+import {
+  CircuitBreaker,
+  CircuitBreakerOpenError,
+} from "../lib/circuitBreaker";
 
 type OutboxStatus = "PENDING" | "RETRYING" | "PROCESSED" | "DEAD_LETTER";
 
@@ -96,12 +100,18 @@ export class EventListenerService {
   private running: boolean = false;
   private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   private currentBackoffMs: number;
+  private stellarCircuit: CircuitBreaker;
 
   constructor(prisma: PrismaClient) {
     this.prisma = prisma;
     this.config = getEventListenerConfig();
     this.server = new StellarSdk.rpc.Server(this.config.rpcUrl);
     this.currentBackoffMs = this.config.backoffInitialMs;
+    this.stellarCircuit = new CircuitBreaker("stellar-rpc", {
+      failureThreshold: 3,
+      successThreshold: 2,
+      cooldownMs: 30_000,
+    });
   }
 
   /** Boot the polling loop. Loads recent processed ledgers from DB into memory. */
@@ -155,16 +165,18 @@ export class EventListenerService {
     try {
       const startLedger = this.lastLedger > 0 ? this.lastLedger + 1 : undefined;
 
-      const response = await this.server.getEvents({
-        startLedger,
-        filters: [
-          {
-            type: "contract",
-            contractIds: [this.config.contractId],
-          },
-        ],
-        limit: 100,
-      } as StellarSdk.rpc.Server.GetEventsRequest);
+      const response = await this.stellarCircuit.call(() =>
+        this.server.getEvents({
+          startLedger,
+          filters: [
+            {
+              type: "contract",
+              contractIds: [this.config.contractId],
+            },
+          ],
+          limit: 100,
+        } as StellarSdk.rpc.Server.GetEventsRequest),
+      );
 
       if (response.events && response.events.length > 0) {
         for (const rawEvent of response.events) {
@@ -175,7 +187,11 @@ export class EventListenerService {
       this.resetBackoff();
       this.scheduleNextPoll(this.config.pollIntervalMs);
     } catch (error) {
-      appLogger.error({ error }, "[EventListener] Poll failed");
+      if (error instanceof CircuitBreakerOpenError) {
+        appLogger.warn({}, "[EventListener] Circuit breaker open — skipping poll");
+      } else {
+        appLogger.error({ error }, "[EventListener] Poll failed");
+      }
       this.handleBackoff();
     }
   }

--- a/backend/src/services/health.service.ts
+++ b/backend/src/services/health.service.ts
@@ -5,6 +5,7 @@ import { env } from "../config/env";
 import { horizonServer } from "../config/stellar";
 import { getPinataClient } from "../config/ipfs";
 import { AlertService, alertService as defaultAlertService } from "./alert.service";
+import { getCircuitBreakerStates } from "../lib/circuitBreaker";
 
 interface HealthIndicatorResult {
   status: "up" | "down";
@@ -299,6 +300,16 @@ export class HealthService {
   }
 
   /**
+   * Check circuit breaker states for external service calls.
+   */
+  private checkCircuitBreakers(): Array<{ name: string; state: string }> {
+    return getCircuitBreakerStates().map((cb) => ({
+      name: cb.name,
+      state: cb.state,
+    }));
+  }
+
+  /**
    * Perform comprehensive health check
    * Returns detailed status for uptime integrations (Datadog, UptimeRobot, etc.)
    */
@@ -364,6 +375,8 @@ export class HealthService {
             .split(", ")
         : [];
 
+    const circuitBreakers = this.checkCircuitBreakers();
+
     return {
       status,
       timestamp,
@@ -384,6 +397,7 @@ export class HealthService {
         stellarNetwork: env.STELLAR_NETWORK,
         ipfsGateway: env.IPFS_GATEWAY_URL,
         missingEnvVars,
+        circuitBreakers,
       },
     };
   }

--- a/backend/src/services/ipfs.service.ts
+++ b/backend/src/services/ipfs.service.ts
@@ -4,6 +4,10 @@ import { retryAsync } from "../lib/retry";
 import { appLogger } from "../middleware/logger";
 import { TracingHelper } from "../config/tracing";
 import { env } from "../config/env";
+import {
+  CircuitBreaker,
+  CircuitBreakerOpenError,
+} from "../lib/circuitBreaker";
 
 export class ServiceUnavailableError extends Error {
     status = 503;
@@ -14,42 +18,18 @@ export class ServiceUnavailableError extends Error {
 }
 
 export class IPFSService {
-    private static pinataCircuit = { failures: 0, openUntil: 0 };
+    private pinataCircuit: CircuitBreaker;
+
+    constructor() {
+      this.pinataCircuit = new CircuitBreaker("pinata-ipfs", {
+        failureThreshold: env.IPFS_PINATA_CIRCUIT_FAILURE_THRESHOLD,
+        successThreshold: 2,
+        cooldownMs: env.IPFS_PINATA_CIRCUIT_COOLDOWN_MS,
+      });
+    }
 
     private getUploadTimeoutMs(): number {
         return env.IPFS_UPLOAD_TIMEOUT_MS;
-    }
-
-    private getCircuitThreshold(): number {
-        return env.IPFS_PINATA_CIRCUIT_FAILURE_THRESHOLD;
-    }
-
-    private getCircuitCooldownMs(): number {
-        return env.IPFS_PINATA_CIRCUIT_COOLDOWN_MS;
-    }
-
-    private ensureCircuitClosed(): void {
-        if (IPFSService.pinataCircuit.openUntil > Date.now()) {
-            throw new ServiceUnavailableError("IPFS upload circuit is temporarily open");
-        }
-    }
-
-    private onUploadSuccess(): void {
-        IPFSService.pinataCircuit = { failures: 0, openUntil: 0 };
-    }
-
-    private onUploadFailure(): void {
-        const failures = IPFSService.pinataCircuit.failures + 1;
-        const threshold = this.getCircuitThreshold();
-        if (failures >= threshold) {
-            IPFSService.pinataCircuit = {
-                failures,
-                openUntil: Date.now() + this.getCircuitCooldownMs(),
-            };
-            return;
-        }
-
-        IPFSService.pinataCircuit = { failures, openUntil: 0 };
     }
 
     private async withTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
@@ -72,79 +52,85 @@ export class IPFSService {
      * @returns The IPFS CID string
      */
     async uploadFile(buffer: Buffer, filename: string): Promise<string> {
-        this.ensureCircuitClosed();
-        const pinata = getPinataClient();
+        try {
+          return await this.pinataCircuit.call(async () => {
+            const pinata = getPinataClient();
 
-        return TracingHelper.withSpan(
-            "ipfs.upload_file",
-            async (span) => {
-                span.setAttributes({
-                    'ipfs.operation': 'upload_file',
-                    'ipfs.filename': filename,
-                    'ipfs.file_size': buffer.length,
-                });
-
-                const stream = Readable.from(buffer) as unknown as NodeJS.ReadableStream & { path: string };
-                stream.path = filename;
-
-                TracingHelper.addEvent('ipfs_upload_start', { filename, size: buffer.length });
-
-                try {
-                    const timeoutMs = this.getUploadTimeoutMs();
-                    const result = await retryAsync(() =>
-                        this.withTimeout(
-                            pinata.pinFileToIPFS(stream, {
-                                pinataMetadata: { name: filename },
-                                pinataOptions: { cidVersion: 1 },
-                            }),
-                            timeoutMs,
-                        )
-                    );
-
+            return TracingHelper.withSpan(
+                "ipfs.upload_file",
+                async (span) => {
                     span.setAttributes({
-                        'ipfs.cid': result.IpfsHash,
-                        'ipfs.upload_success': true,
+                        'ipfs.operation': 'upload_file',
+                        'ipfs.filename': filename,
+                        'ipfs.file_size': buffer.length,
                     });
 
-                    TracingHelper.addEvent('ipfs_upload_success', { 
-                        cid: result.IpfsHash,
-                        filename 
-                    });
+                    const stream = Readable.from(buffer) as unknown as NodeJS.ReadableStream & { path: string };
+                    stream.path = filename;
 
-                    appLogger.info(
-                        { 
-                            cid: result.IpfsHash, 
-                            filename, 
-                            size: buffer.length 
-                        }, 
-                        "[IPFSService] File uploaded successfully"
-                    );
+                    TracingHelper.addEvent('ipfs_upload_start', { filename, size: buffer.length });
 
-                    this.onUploadSuccess();
-                    return result.IpfsHash;
-                } catch (err) {
-                    span.setAttributes({
-                        'ipfs.upload_success': false,
-                        'ipfs.error': err instanceof Error ? err.message : 'Unknown error',
-                    });
+                    try {
+                        const timeoutMs = this.getUploadTimeoutMs();
+                        const result = await retryAsync(() =>
+                            this.withTimeout(
+                                pinata.pinFileToIPFS(stream, {
+                                    pinataMetadata: { name: filename },
+                                    pinataOptions: { cidVersion: 1 },
+                                }),
+                                timeoutMs,
+                            )
+                        );
 
-                    TracingHelper.addEvent('ipfs_upload_error', { 
-                        error: err instanceof Error ? err.message : 'Unknown error',
-                        filename 
-                    });
+                        span.setAttributes({
+                            'ipfs.cid': result.IpfsHash,
+                            'ipfs.upload_success': true,
+                        });
 
-                    this.onUploadFailure();
-                    appLogger.error({ err, filename }, "[IPFSService] Pinata upload failed");
-                    throw new ServiceUnavailableError();
+                        TracingHelper.addEvent('ipfs_upload_success', { 
+                            cid: result.IpfsHash,
+                            filename 
+                        });
+
+                        appLogger.info(
+                            { 
+                                cid: result.IpfsHash, 
+                                filename, 
+                                size: buffer.length 
+                            }, 
+                            "[IPFSService] File uploaded successfully"
+                        );
+
+                        return result.IpfsHash;
+                    } catch (err) {
+                        span.setAttributes({
+                            'ipfs.upload_success': false,
+                            'ipfs.error': err instanceof Error ? err.message : 'Unknown error',
+                        });
+
+                        TracingHelper.addEvent('ipfs_upload_error', { 
+                            error: err instanceof Error ? err.message : 'Unknown error',
+                            filename 
+                        });
+
+                        appLogger.error({ err, filename }, "[IPFSService] Pinata upload failed");
+                        throw new ServiceUnavailableError();
+                    }
+                },
+                {
+                    attributes: {
+                        'service.name': 'ipfs',
+                        'operation.type': 'external_service',
+                    }
                 }
-            },
-            {
-                attributes: {
-                    'service.name': 'ipfs',
-                    'operation.type': 'external_service',
-                }
-            }
-        );
+            );
+          });
+        } catch (err) {
+          if (err instanceof CircuitBreakerOpenError) {
+            throw new ServiceUnavailableError("IPFS upload circuit is temporarily open");
+          }
+          throw err;
+        }
     }
 
     /**
@@ -153,9 +139,5 @@ export class IPFSService {
     getFileUrl(cid: string): string {
         const gateway = process.env.IPFS_GATEWAY_URL ?? env.IPFS_GATEWAY_URL;
         return `${gateway.replace(/\/$/, "")}/${cid}`;
-    }
-
-    static __resetCircuitForTests(): void {
-        IPFSService.pinataCircuit = { failures: 0, openUntil: 0 };
     }
 }

--- a/frontend/src/hooks/__tests__/useRetry.test.ts
+++ b/frontend/src/hooks/__tests__/useRetry.test.ts
@@ -3,7 +3,7 @@ import { useRetry } from "../useRetry";
 
 describe("useRetry", () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ advanceTimers: true });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

### Issues Resolved

- **Closes #708** - Create Stellar fee estimation route at `GET /stellar/fees`
- **Closes #707** - Create Stellar transaction status route at `GET /stellar/tx/:hash/status`
- **Closes #692** - Integrate circuit breaker for external calls (Stellar RPC, Pinata IPFS)
- **Closes #688** - Fix useRetry hook tests timeout

### Changes

#### New Routes
- `backend/src/routes/stellar.fees.ts` — Fetches `fee_charged`, `max_fee`, and `ledger` from Horizon `/fee_stats`
- `backend/src/routes/stellar.tx.status.ts` — Queries Horizon for transaction by hash, returns status/resultCodes/ledger
- Both routes mounted in `app.ts` under `/stellar/*`
- Tests for both routes in `backend/src/__tests__/`

#### Circuit Breaker Integration
- Added instance registry to `CircuitBreaker` for health check metrics
- Wrapped `server.getEvents()` in `eventListener.service.ts` with circuit breaker (threshold: 3 failures, 30s cooldown)
- Replaced manual Pinata circuit breaker in `ipfs.service.ts` with generic `CircuitBreaker` class
- Added `circuitBreakers` field to health check response via `getCircuitBreakerStates()`

#### Test Fix
- Changed `jest.useFakeTimers()` to `jest.useFakeTimers({ advanceTimers: true })` in `useRetry.test.ts` to fix async act() timeout issues