### PR TITLE
feat: stellar asset lookup, account balance routes, and MAX_TRADE_VALUE escrow guard

### DIFF
--- a/backend/src/__tests__/stellar.account.balance.test.ts
+++ b/backend/src/__tests__/stellar.account.balance.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import { createApp } from "../app";
+import express from "express";
+
+const mockLoadAccount = jest.fn();
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: {
+    loadAccount: mockLoadAccount,
+  },
+  sorobanRpcClient: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+const VALID_ADDRESS = "GDDD3FRCH55BSYNKISYY242HQNIBOH35CQP42NSJABR62XK2JOV5MED6";
+const MALFORMED_ADDRESS = "not-a-valid-stellar-address";
+
+const FUNDED_ACCOUNT_BALANCES = [
+  {
+    asset_type: "native",
+    balance: "100.0000000",
+  },
+  {
+    asset_type: "credit_alphanum4",
+    asset_code: "USDC",
+    asset_issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    balance: "50.0000000",
+    limit: "922337203685.4775807",
+  },
+];
+
+describe("GET /stellar/account/:address/balance", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockLoadAccount.mockReset();
+    app = createApp();
+  });
+
+  it("returns balances for a funded account", async () => {
+    mockLoadAccount.mockResolvedValue({ balances: FUNDED_ACCOUNT_BALANCES });
+
+    const res = await request(app).get(`/stellar/account/${VALID_ADDRESS}/balance`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.address).toBe(VALID_ADDRESS);
+    expect(res.body.balances).toHaveLength(2);
+
+    const xlm = res.body.balances.find((b: any) => b.assetCode === "XLM");
+    expect(xlm).toBeDefined();
+    expect(xlm.assetType).toBe("native");
+    expect(xlm.issuer).toBeNull();
+    expect(xlm.balance).toBe("100.0000000");
+
+    const usdc = res.body.balances.find((b: any) => b.assetCode === "USDC");
+    expect(usdc).toBeDefined();
+    expect(usdc.issuer).toBeTruthy();
+    expect(usdc.limit).toBeTruthy();
+  });
+
+  it("returns 200 with empty balances for an unfunded account", async () => {
+    mockLoadAccount.mockRejectedValue({ response: { status: 404 } });
+
+    const res = await request(app).get(`/stellar/account/${VALID_ADDRESS}/balance`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.address).toBe(VALID_ADDRESS);
+    expect(res.body.balances).toHaveLength(0);
+  });
+
+  it("returns 400 for a malformed address", async () => {
+    const res = await request(app).get(`/stellar/account/${MALFORMED_ADDRESS}/balance`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 502 when Horizon fails with a non-404 error", async () => {
+    mockLoadAccount.mockRejectedValue(new Error("Network timeout"));
+
+    const res = await request(app).get(`/stellar/account/${VALID_ADDRESS}/balance`);
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty("error");
+  });
+});

--- a/backend/src/__tests__/stellar.asset.test.ts
+++ b/backend/src/__tests__/stellar.asset.test.ts
@@ -1,0 +1,145 @@
+import request from "supertest";
+import { createApp } from "../app";
+import express from "express";
+
+const mockAssets = jest.fn();
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: {
+    assets: mockAssets,
+  },
+  sorobanRpcClient: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+jest.mock("../lib/cache", () => ({
+  cacheGet: jest.fn().mockResolvedValue(null),
+  cacheSet: jest.fn().mockResolvedValue(undefined),
+}));
+
+const KNOWN_ISSUER = "GDDD3FRCH55BSYNKISYY242HQNIBOH35CQP42NSJABR62XK2JOV5MED6";
+
+const makeAssetRecord = (code: string, issuer: string) => ({
+  asset_code: code,
+  asset_issuer: issuer,
+  amount: "1000000",
+  flags: { auth_required: false, auth_revocable: false, auth_clawback_enabled: false },
+  accounts: { authorized: 42 },
+});
+
+function buildMockChain(records: any[]) {
+  const call = jest.fn().mockResolvedValue({ records });
+  const forIssuer = jest.fn().mockReturnValue({ limit: () => ({ call }) });
+  const forCode = jest.fn().mockReturnValue({ forIssuer, limit: () => ({ call }) });
+  const limit = jest.fn().mockReturnValue({ call });
+  return { call, forIssuer, forCode, limit };
+}
+
+describe("GET /stellar/assets", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockAssets.mockReset();
+    app = createApp();
+  });
+
+  it("returns a list of assets", async () => {
+    const record = makeAssetRecord("USDC", KNOWN_ISSUER);
+    const chain = buildMockChain([record]);
+    mockAssets.mockReturnValue(chain);
+
+    const res = await request(app).get("/stellar/assets");
+
+    expect(res.status).toBe(200);
+    expect(res.body.assets).toHaveLength(1);
+    expect(res.body.assets[0].code).toBe("USDC");
+    expect(res.body.assets[0].issuer).toBe(KNOWN_ISSUER);
+    expect(res.body.assets[0].supply).toBe("1000000");
+    expect(res.body.assets[0]).toHaveProperty("authRequired");
+    expect(res.body.assets[0]).toHaveProperty("numAccounts");
+  });
+
+  it("filters by issuer when ?issuer= is provided", async () => {
+    const record = makeAssetRecord("USDC", KNOWN_ISSUER);
+    const call = jest.fn().mockResolvedValue({ records: [record] });
+    const forIssuerChain = { limit: () => ({ call }) };
+    const forIssuer = jest.fn().mockReturnValue(forIssuerChain);
+    mockAssets.mockReturnValue({ forIssuer, limit: () => ({ call }) });
+
+    const res = await request(app).get(`/stellar/assets?issuer=${KNOWN_ISSUER}`);
+
+    expect(res.status).toBe(200);
+    expect(forIssuer).toHaveBeenCalledWith(KNOWN_ISSUER);
+    expect(res.body.assets[0].issuer).toBe(KNOWN_ISSUER);
+  });
+
+  it("returns 502 when Horizon fails", async () => {
+    mockAssets.mockReturnValue({
+      limit: () => ({ call: jest.fn().mockRejectedValue(new Error("Horizon error")) }),
+    });
+
+    const res = await request(app).get("/stellar/assets");
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty("error");
+  });
+});
+
+describe("GET /stellar/assets/:code", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockAssets.mockReset();
+    app = createApp();
+  });
+
+  it("returns assets matching a known code", async () => {
+    const record = makeAssetRecord("USDC", KNOWN_ISSUER);
+    const call = jest.fn().mockResolvedValue({ records: [record] });
+    const forIssuer = jest.fn().mockReturnValue({ limit: () => ({ call }) });
+    const forCode = jest.fn().mockReturnValue({ forIssuer, limit: () => ({ call }) });
+    mockAssets.mockReturnValue({ forCode });
+
+    const res = await request(app).get("/stellar/assets/USDC");
+
+    expect(res.status).toBe(200);
+    expect(forCode).toHaveBeenCalledWith("USDC");
+    expect(res.body.assets[0].code).toBe("USDC");
+  });
+
+  it("returns 404 when no asset matches the code", async () => {
+    const call = jest.fn().mockResolvedValue({ records: [] });
+    const forCode = jest.fn().mockReturnValue({ limit: () => ({ call }) });
+    mockAssets.mockReturnValue({ forCode });
+
+    const res = await request(app).get("/stellar/assets/UNKNOWN");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("filters by issuer when ?issuer= is provided with code", async () => {
+    const record = makeAssetRecord("USDC", KNOWN_ISSUER);
+    const call = jest.fn().mockResolvedValue({ records: [record] });
+    const forIssuer = jest.fn().mockReturnValue({ limit: () => ({ call }) });
+    const forCode = jest.fn().mockReturnValue({ forIssuer, limit: () => ({ call }) });
+    mockAssets.mockReturnValue({ forCode });
+
+    const res = await request(app).get(`/stellar/assets/USDC?issuer=${KNOWN_ISSUER}`);
+
+    expect(res.status).toBe(200);
+    expect(forIssuer).toHaveBeenCalledWith(KNOWN_ISSUER);
+  });
+
+  it("returns 502 when Horizon fails on code lookup", async () => {
+    const forCode = jest.fn().mockReturnValue({
+      limit: () => ({ call: jest.fn().mockRejectedValue(new Error("Horizon error")) }),
+    });
+    mockAssets.mockReturnValue({ forCode });
+
+    const res = await request(app).get("/stellar/assets/USDC");
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty("error");
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,6 +24,8 @@ import userRoutes from "./routes/user.routes";
 import reputationRoutes from "./routes/reputation.routes";
 import { stellarFeesRoutes } from "./routes/stellar.fees";
 import { stellarTxStatusRoutes } from "./routes/stellar.tx.status";
+import { stellarAssetRoutes } from "./routes/stellar.asset";
+import { stellarAccountBalanceRoutes } from "./routes/stellar.account.balance";
 import { env } from "./config/env";
 
 /** Parse the CORS_ORIGINS env var into a usable allowlist.
@@ -135,6 +137,8 @@ export function createApp(): express.Application {
   // Stellar network endpoints
   app.use("/stellar/fees", stellarFeesRoutes);
   app.use("/stellar/tx", stellarTxStatusRoutes);
+  app.use("/stellar/assets", stellarAssetRoutes);
+  app.use("/stellar/account", stellarAccountBalanceRoutes);
 
   // Treasury management
   app.use("/treasury", createTreasuryRouter());

--- a/backend/src/lib/cache.ts
+++ b/backend/src/lib/cache.ts
@@ -1,0 +1,27 @@
+import { redis } from "./redis";
+import { appLogger } from "../middleware/logger";
+
+const DEFAULT_TTL_SECONDS = 300; // 5 minutes
+
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  try {
+    const value = await redis.get(key);
+    if (value === null) return null;
+    return JSON.parse(value) as T;
+  } catch (err) {
+    appLogger.warn({ err, key }, "Cache get failed");
+    return null;
+  }
+}
+
+export async function cacheSet(
+  key: string,
+  value: unknown,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS
+): Promise<void> {
+  try {
+    await redis.set(key, JSON.stringify(value), "EX", ttlSeconds);
+  } catch (err) {
+    appLogger.warn({ err, key }, "Cache set failed");
+  }
+}

--- a/backend/src/routes/stellar.account.balance.ts
+++ b/backend/src/routes/stellar.account.balance.ts
@@ -1,0 +1,66 @@
+import { Router, Request, Response } from "express";
+import { horizonServer } from "../config/stellar";
+import { appLogger } from "../middleware/logger";
+
+interface Balance {
+  assetType: string;
+  assetCode: string;
+  issuer: string | null;
+  balance: string;
+  limit: string | null;
+}
+
+function parseBalances(rawBalances: any[]): Balance[] {
+  return rawBalances.map((b) => {
+    if (b.asset_type === "native") {
+      return {
+        assetType: "native",
+        assetCode: "XLM",
+        issuer: null,
+        balance: b.balance,
+        limit: null,
+      };
+    }
+    return {
+      assetType: b.asset_type,
+      assetCode: b.asset_code ?? "",
+      issuer: b.asset_issuer ?? null,
+      balance: b.balance,
+      limit: b.limit ?? null,
+    };
+  });
+}
+
+export function createStellarAccountBalanceRouter(): Router {
+  const router = Router();
+
+  // GET /stellar/account/:address/balance
+  router.get("/:address/balance", async (req: Request, res: Response) => {
+    const address = req.params.address as string;
+
+    if (!address || address.length !== 56 || !address.startsWith("G")) {
+      res.status(400).json({ error: "Invalid Stellar account address" });
+      return;
+    }
+
+    try {
+      const account = await horizonServer.loadAccount(address);
+      const balances = parseBalances(account.balances);
+
+      res.json({ address, balances });
+    } catch (error: any) {
+      if (error?.response?.status === 404) {
+        // Account exists on the Stellar network but is not funded
+        res.json({ address, balances: [] });
+        return;
+      }
+
+      appLogger.error({ error, address }, "Failed to fetch account balances");
+      res.status(502).json({ error: "Failed to fetch account data from Stellar network" });
+    }
+  });
+
+  return router;
+}
+
+export const stellarAccountBalanceRoutes = createStellarAccountBalanceRouter();

--- a/backend/src/routes/stellar.asset.ts
+++ b/backend/src/routes/stellar.asset.ts
@@ -1,0 +1,96 @@
+import { Router, Request, Response } from "express";
+import { horizonServer } from "../config/stellar";
+import { appLogger } from "../middleware/logger";
+import { cacheGet, cacheSet } from "../lib/cache";
+
+const ASSET_CACHE_TTL = 300; // 5 minutes
+
+interface AssetRecord {
+  code: string;
+  issuer: string;
+  supply: string;
+  authRequired: boolean;
+  authRevocable: boolean;
+  authClawbackEnabled: boolean;
+  numAccounts: number;
+}
+
+function parseAsset(raw: any): AssetRecord {
+  return {
+    code: raw.asset_code ?? "XLM",
+    issuer: raw.asset_issuer ?? "",
+    supply: raw.amount ?? "0",
+    authRequired: raw.flags?.auth_required ?? false,
+    authRevocable: raw.flags?.auth_revocable ?? false,
+    authClawbackEnabled: raw.flags?.auth_clawback_enabled ?? false,
+    numAccounts: raw.accounts?.authorized ?? 0,
+  };
+}
+
+export function createStellarAssetRouter(): Router {
+  const router = Router();
+
+  // GET /stellar/assets?issuer=<address>
+  router.get("/", async (req: Request, res: Response) => {
+    const issuer = req.query.issuer as string | undefined;
+    const cacheKey = `stellar:assets:${issuer ?? "all"}`;
+
+    const cached = await cacheGet<AssetRecord[]>(cacheKey);
+    if (cached) {
+      res.json({ assets: cached, cached: true });
+      return;
+    }
+
+    try {
+      let builder = horizonServer.assets();
+      if (issuer) {
+        builder = builder.forIssuer(issuer);
+      }
+      const response = await builder.limit(200).call();
+      const assets = response.records.map(parseAsset);
+
+      await cacheSet(cacheKey, assets, ASSET_CACHE_TTL);
+      res.json({ assets, cached: false });
+    } catch (error) {
+      appLogger.error({ error, issuer }, "Failed to fetch Stellar assets");
+      res.status(502).json({ error: "Failed to fetch asset data from Stellar network" });
+    }
+  });
+
+  // GET /stellar/assets/:code?issuer=<address>
+  router.get("/:code", async (req: Request, res: Response) => {
+    const code = req.params.code as string;
+    const issuer = req.query.issuer as string | undefined;
+    const cacheKey = `stellar:assets:${code}:${issuer ?? "any"}`;
+
+    const cached = await cacheGet<AssetRecord[]>(cacheKey);
+    if (cached) {
+      res.json({ assets: cached, cached: true });
+      return;
+    }
+
+    try {
+      let builder = horizonServer.assets().forCode(code);
+      if (issuer) {
+        builder = builder.forIssuer(issuer);
+      }
+      const response = await builder.limit(200).call();
+      const assets = response.records.map(parseAsset);
+
+      if (assets.length === 0) {
+        res.status(404).json({ error: `No assets found with code '${code}'` });
+        return;
+      }
+
+      await cacheSet(cacheKey, assets, ASSET_CACHE_TTL);
+      res.json({ assets, cached: false });
+    } catch (error) {
+      appLogger.error({ error, code, issuer }, "Failed to fetch Stellar asset by code");
+      res.status(502).json({ error: "Failed to fetch asset data from Stellar network" });
+    }
+  });
+
+  return router;
+}
+
+export const stellarAssetRoutes = createStellarAssetRouter();

--- a/contracts/amana_escrow/src/lib.rs
+++ b/contracts/amana_escrow/src/lib.rs
@@ -27,6 +27,10 @@ pub const MAX_HASH_LEN: u32 = 256;
 /// `get_schema_version()` and run the matching migration. See SECURITY.md.
 pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 
+/// Maximum allowed trade amount in stroops (1 quadrillion stroops ≈ 1 billion USDC).
+/// Prevents overflow in fee/loss calculations and limits exposure per trade.
+pub const MAX_TRADE_VALUE: i128 = 1_000_000_000_000_000;
+
 fn checked_fee_amount(amount: i128, fee_bps: u32) -> i128 {
     amount
         .checked_mul(fee_bps as i128)
@@ -564,6 +568,10 @@ impl EscrowContract {
     ) -> u64 {
         buyer.require_auth();
         assert!(amount > 0, "amount must be greater than zero");
+        assert!(
+            amount <= MAX_TRADE_VALUE,
+            "TradeValueTooLarge"
+        );
         assert!(
             buyer != seller,
             "buyer and seller must be different addresses"

--- a/contracts/amana_escrow/src/tests/max_trade_value_tests.rs
+++ b/contracts/amana_escrow/src/tests/max_trade_value_tests.rs
@@ -1,0 +1,69 @@
+/// Tests for MAX_TRADE_VALUE constant and validation in create_trade()
+///
+/// Covers:
+///   1. Zero-value trade is rejected
+///   2. Trade at exactly MAX_TRADE_VALUE is accepted
+///   3. Trade above MAX_TRADE_VALUE is rejected with "TradeValueTooLarge"
+#[cfg(test)]
+mod max_trade_value_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
+    use soroban_sdk::{Address, Env, token};
+
+    use crate::{EscrowContract, EscrowContractClient, MAX_TRADE_VALUE};
+
+    fn setup_contract(env: &Env) -> (EscrowContractClient, Address, Address, Address) {
+        let contract_id = env.register(EscrowContract, ());
+        let client = EscrowContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let buyer = Address::generate(env);
+        let seller = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+
+        client.initialize(&admin, &token_id, &treasury, &0_u32, &token_id);
+
+        let token_client = token::StellarAssetClient::new(env, &token_id);
+        // Mint enough for the maximum-value test
+        token_client.mint(&buyer, &(MAX_TRADE_VALUE + 1));
+
+        (client, buyer, seller, token_id)
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be greater than zero")]
+    fn test_zero_amount_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, buyer, seller, _) = setup_contract(&env);
+        client.create_trade(&buyer, &seller, &0_i128, &5000_u32, &5000_u32, &None);
+    }
+
+    #[test]
+    fn test_max_trade_value_is_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, buyer, seller, _) = setup_contract(&env);
+        // Should not panic — exactly at the limit is allowed
+        let trade_id =
+            client.create_trade(&buyer, &seller, &MAX_TRADE_VALUE, &5000_u32, &5000_u32, &None);
+        assert!(trade_id > 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "TradeValueTooLarge")]
+    fn test_overflow_amount_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, buyer, seller, _) = setup_contract(&env);
+        client.create_trade(
+            &buyer,
+            &seller,
+            &(MAX_TRADE_VALUE + 1),
+            &5000_u32,
+            &5000_u32,
+            &None,
+        );
+    }
+}

--- a/contracts/amana_escrow/src/tests/mod.rs
+++ b/contracts/amana_escrow/src/tests/mod.rs
@@ -3,3 +3,4 @@ pub mod ttl_tests;
 pub mod gas_footprint_tests;
 pub mod migration_tests;
 pub mod bps_fuzz_tests;
+pub mod max_trade_value_tests;


### PR DESCRIPTION
## Summary

- Add `GET /stellar/assets` and `GET /stellar/assets/:code` endpoints that resolve Stellar asset metadata (code, issuer, supply, auth flags) via Horizon, with Redis caching (5-minute TTL) and optional `?issuer=` filter
- Add `GET /stellar/account/:address/balance` endpoint that returns all token balances (native XLM, USDC, issued assets) for a Stellar account; unfunded accounts return 200 with empty balances (not 404)
- Add `MAX_TRADE_VALUE = 1_000_000_000_000_000` constant to the escrow contract and validate it in `create_trade()`, reverting with `"TradeValueTooLarge"` if exceeded; zero-value trades continue to be rejected

## Changes

- `backend/src/lib/cache.ts` — new Redis-backed `cacheGet`/`cacheSet` helpers
- `backend/src/routes/stellar.asset.ts` — asset lookup route with issuer filter and cache
- `backend/src/routes/stellar.account.balance.ts` — account balance route with graceful unfunded handling
- `backend/src/app.ts` — registers the two new Stellar routes
- `backend/src/__tests__/stellar.asset.test.ts` — tests: known asset, unknown asset (404), issuer filter, Horizon 502
- `backend/src/__tests__/stellar.account.balance.test.ts` — tests: funded account, unfunded (200 + empty), malformed address (400), 502
- `contracts/amana_escrow/src/lib.rs` — `MAX_TRADE_VALUE` constant + validation in `create_trade()`
- `contracts/amana_escrow/src/tests/max_trade_value_tests.rs` — tests: zero rejection, max accepted, overflow rejected

## Test plan

- [ ] `cd backend && npx jest stellar.asset` — all asset route tests pass
- [ ] `cd backend && npx jest stellar.account.balance` — all account balance tests pass
- [ ] `cd contracts/amana_escrow && cargo test max_trade_value` — all three MAX_TRADE_VALUE tests pass
- [ ] Full backend test suite (`npx jest`) shows no regressions
- [ ] `GET /stellar/assets` returns asset list from Horizon testnet
- [ ] `GET /stellar/assets/USDC?issuer=<addr>` returns filtered results
- [ ] `GET /stellar/account/<funded-addr>/balance` returns XLM + token balances
- [ ] `GET /stellar/account/<unfunded-addr>/balance` returns `{ balances: [] }` with 200



closes #706       closes #704      closes #753