### PR TITLE
Add webhook delivery log viewing route

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   tradeTemplates  TradeTemplate[]
   watchlist       UserWatchlist[]
   refreshTokens   RefreshToken[]
+  webhooks        Webhook[]
 
   @@index([walletAddress])
 }
@@ -333,4 +334,43 @@ model RefreshToken {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([tokenHash])
+}
+
+/// Webhook model representing a registered webhook endpoint owned by a user
+/// - url: The target URL to which webhook payloads are delivered
+/// - description: Optional human-readable label
+/// - isActive: Whether the webhook is currently accepting deliveries
+model Webhook {
+  id          Int      @id @default(autoincrement())
+  userAddress String   @db.VarChar(255)
+  url         String   @db.VarChar(2048)
+  description String?  @db.VarChar(255)
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  user             User                    @relation(fields: [userAddress], references: [walletAddress], onDelete: Cascade)
+  deliveryAttempts WebhookDeliveryAttempt[]
+
+  @@index([userAddress, createdAt])
+}
+
+/// WebhookDeliveryAttempt records a single delivery attempt for a webhook
+/// - timestamp: When the delivery was attempted
+/// - status: Outcome of the delivery (e.g. "success", "failure")
+/// - statusCode: HTTP status code returned by the target
+/// - responseBody: Response body from the target (if any)
+model WebhookDeliveryAttempt {
+  id           Int      @id @default(autoincrement())
+  webhookId    Int
+  timestamp    DateTime @default(now())
+  status       String   @db.VarChar(50)
+  statusCode   Int
+  responseBody String?  @db.Text
+
+  // Relations
+  webhook      Webhook  @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+
+  @@index([webhookId, timestamp])
 }

--- a/backend/src/__tests__/webhooks.logs.routes.test.ts
+++ b/backend/src/__tests__/webhooks.logs.routes.test.ts
@@ -1,0 +1,212 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { PrismaClient } from "@prisma/client";
+import { createWebhookLogsRouter } from "../routes/webhooks.logs.routes";
+import { AuthService } from "../services/auth.service";
+import { errorHandler } from "../errors/errorHandler";
+
+jest.mock("../services/auth.service", () => ({
+  AuthService: {
+    validateToken: jest.fn(async (token: string) => {
+      const jwt = require("jsonwebtoken");
+      return jwt.decode(token);
+    }),
+    isTokenRevoked: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+const mockPrisma = {
+  webhook: {
+    findUnique: jest.fn(),
+  },
+  webhookDeliveryAttempt: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+} as unknown as PrismaClient & {
+  webhook: { findUnique: jest.Mock };
+  webhookDeliveryAttempt: { findMany: jest.Mock; count: jest.Mock };
+};
+
+const app = express();
+app.use(express.json());
+app.use("/", createWebhookLogsRouter(mockPrisma));
+app.use(errorHandler);
+
+describe("Webhook Logs Route", () => {
+  const ownerAddress = StellarSdk.Keypair.random().publicKey();
+  const otherAddress = StellarSdk.Keypair.random().publicKey();
+  let ownerToken: string;
+  let otherToken: string;
+
+  beforeAll(() => {
+    const secret = process.env.JWT_SECRET || "test-secret-at-least-32-characters-long";
+    const now = Math.floor(Date.now() / 1000);
+    ownerToken = jwt.sign(
+      {
+        walletAddress: ownerAddress,
+        jti: "webhook-logs-owner-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+    otherToken = jwt.sign(
+      {
+        walletAddress: otherAddress,
+        jti: "webhook-logs-other-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+  });
+
+  beforeEach(() => {
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with delivery attempts and pagination", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+    mockPrisma.webhookDeliveryAttempt.findMany.mockResolvedValue([
+      {
+        timestamp: new Date("2025-01-01T00:00:00Z"),
+        status: "success",
+        statusCode: 200,
+        responseBody: '{"ok":true}',
+      },
+      {
+        timestamp: new Date("2025-01-02T00:00:00Z"),
+        status: "failure",
+        statusCode: 500,
+        responseBody: null,
+      },
+    ]);
+    mockPrisma.webhookDeliveryAttempt.count.mockResolvedValue(2);
+
+    const res = await request(app)
+      .get("/webhooks/1/logs")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attempts).toHaveLength(2);
+    expect(res.body.attempts[0]).toEqual({
+      timestamp: "2025-01-01T00:00:00.000Z",
+      status: "success",
+      statusCode: 200,
+      responseBody: '{"ok":true}',
+    });
+    expect(res.body.attempts[1]).toEqual({
+      timestamp: "2025-01-02T00:00:00.000Z",
+      status: "failure",
+      statusCode: 500,
+      responseBody: null,
+    });
+    expect(res.body.pagination).toEqual({
+      page: 1,
+      limit: 20,
+      total: 2,
+      totalPages: 1,
+    });
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const res = await request(app).get("/webhooks/1/logs");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-existent webhook", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .get("/webhooks/999/logs")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Webhook not found");
+  });
+
+  it("returns 403 when caller is not the webhook owner", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+
+    const res = await request(app)
+      .get("/webhooks/1/logs")
+      .set("Authorization", `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Forbidden: you do not own this webhook");
+  });
+
+  it("returns empty attempts list when no deliveries exist", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+    mockPrisma.webhookDeliveryAttempt.findMany.mockResolvedValue([]);
+    mockPrisma.webhookDeliveryAttempt.count.mockResolvedValue(0);
+
+    const res = await request(app)
+      .get("/webhooks/1/logs")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attempts).toEqual([]);
+    expect(res.body.pagination).toEqual({
+      page: 1,
+      limit: 20,
+      total: 0,
+      totalPages: 0,
+    });
+  });
+
+  it("respects pagination query parameters", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+
+    const allAttempts = Array.from({ length: 25 }, (_, i) => ({
+      timestamp: new Date(`2025-01-${String(i + 1).padStart(2, "0")}T00:00:00Z`),
+      status: "success",
+      statusCode: 200,
+      responseBody: null,
+    }));
+
+    mockPrisma.webhookDeliveryAttempt.findMany.mockImplementation(
+      ({ skip, take }: { skip: number; take: number }) =>
+        Promise.resolve(allAttempts.slice(skip, skip + take)),
+    );
+    mockPrisma.webhookDeliveryAttempt.count.mockResolvedValue(25);
+
+    const res = await request(app)
+      .get("/webhooks/1/logs?page=2&limit=10")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attempts).toHaveLength(10);
+    expect(res.body.pagination).toEqual({
+      page: 2,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+    });
+  });
+});

--- a/backend/src/routes/webhooks.logs.routes.ts
+++ b/backend/src/routes/webhooks.logs.routes.ts
@@ -1,0 +1,92 @@
+import { PrismaClient } from "@prisma/client";
+import { Response, Router } from "express";
+import { z } from "zod";
+import { prisma as defaultPrisma } from "../lib/db";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { AuthRequest } from "../services/auth.service";
+
+const webhookLogsParamsSchema = z.object({
+  id: z.string().regex(/^\d+$/, "Webhook ID must be a numeric string"),
+});
+
+const webhookLogsQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+function caller(req: AuthRequest, res: Response): string | null {
+  const walletAddress = req.user?.walletAddress?.trim();
+  if (!walletAddress) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+  return walletAddress;
+}
+
+export function createWebhookLogsRouter(prisma: PrismaClient = defaultPrisma) {
+  const router = Router();
+
+  router.get(
+    "/webhooks/:id/logs",
+    authMiddleware,
+    validateRequest({ params: webhookLogsParamsSchema, query: webhookLogsQuerySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const webhookId = Number(req.params.id);
+        const { page, limit } = req.query as unknown as { page: number; limit: number };
+        const skip = (page - 1) * limit;
+
+        const webhook = await prisma.webhook.findUnique({
+          where: { id: webhookId },
+          select: { userAddress: true },
+        });
+
+        if (!webhook) {
+          res.status(404).json({ error: "Webhook not found" });
+          return;
+        }
+
+        if (webhook.userAddress !== walletAddress) {
+          res.status(403).json({ error: "Forbidden: you do not own this webhook" });
+          return;
+        }
+
+        const [attempts, total] = await Promise.all([
+          prisma.webhookDeliveryAttempt.findMany({
+            where: { webhookId },
+            orderBy: { timestamp: "desc" },
+            skip,
+            take: limit,
+            select: {
+              timestamp: true,
+              status: true,
+              statusCode: true,
+              responseBody: true,
+            },
+          }),
+          prisma.webhookDeliveryAttempt.count({
+            where: { webhookId },
+          }),
+        ]);
+
+        res.status(200).json({
+          attempts,
+          pagination: {
+            page,
+            limit,
+            total,
+            totalPages: Math.ceil(total / limit),
+          },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Return the delivery history for a registered webhook.

Closes #726

## Changes

### Database (Prisma schema)
- Added `Webhook` model with fields: id, userAddress, url, description, isActive, timestamps
- Added `WebhookDeliveryAttempt` model with fields: id, webhookId, timestamp, status, statusCode, responseBody
- Both models include proper relations (cascade delete) and indexes for query performance

### Route
- `GET /webhooks/:id/logs` — returns paginated delivery attempts for a registered webhook
- Requires authentication via `authMiddleware`
- Validates params (`:id` must be numeric) and query (`page`, `limit` with defaults and max constraints)
- Ownership enforcement: only the webhook owner (matched via `userAddress`) can view logs
- Returns 404 for non-existent webhook, 403 for unauthorized access

### Response shape
```json
{
  "attempts": [
    {
      "timestamp": "2025-01-01T00:00:00.000Z",
      "status": "success",
      "statusCode": 200,
      "responseBody": "{\"ok\":true}"
    }
  ],
  "pagination": {
    "page": 1,
    "limit": 20,
    "total": 2,
    "totalPages": 1
  }
}
```

### Tests
6 tests in `backend/src/__tests__/webhooks.logs.routes.test.ts`:
- ✓ Returns delivery attempts with pagination
- ✓ Returns 401 without Authorization header
- ✓ Returns 404 for non-existent webhook
- ✓ Returns 403 when caller is not the webhook owner
- ✓ Returns empty attempts list when no deliveries exist
- ✓ Respects pagination query parameters

All tests pass.