### PR TITLE
Add admin trade batch status update route

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -64,6 +64,7 @@ model User {
   watchlist       UserWatchlist[]
   refreshTokens   RefreshToken[]
   webhooks        Webhook[]
+  notifications   InAppNotification[]
 
   @@index([walletAddress])
 }
@@ -373,4 +374,25 @@ model WebhookDeliveryAttempt {
   webhook      Webhook  @relation(fields: [webhookId], references: [id], onDelete: Cascade)
 
   @@index([webhookId, timestamp])
+}
+
+/// InAppNotification represents an in-app notification for a user
+/// - type: Category of notification (e.g. "trade_update", "dispute", "system")
+/// - isRead: Whether the notification has been read
+/// - metadata: Optional JSON payload with additional context
+model InAppNotification {
+  id          Int      @id @default(autoincrement())
+  userAddress String   @db.VarChar(255)
+  title       String   @db.VarChar(255)
+  message     String   @db.Text
+  type        String   @db.VarChar(50)
+  isRead      Boolean  @default(false)
+  metadata    Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  user        User     @relation(fields: [userAddress], references: [walletAddress], onDelete: Cascade)
+
+  @@index([userAddress, isRead, createdAt])
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   tradeTemplates  TradeTemplate[]
   watchlist       UserWatchlist[]
   refreshTokens   RefreshToken[]
+  webhooks        Webhook[]
 
   @@index([walletAddress])
 }
@@ -333,4 +334,43 @@ model RefreshToken {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([tokenHash])
+}
+
+/// Webhook model representing a registered webhook endpoint owned by a user
+/// - url: The target URL to which webhook payloads are delivered
+/// - description: Optional human-readable label
+/// - isActive: Whether the webhook is currently accepting deliveries
+model Webhook {
+  id          Int      @id @default(autoincrement())
+  userAddress String   @db.VarChar(255)
+  url         String   @db.VarChar(2048)
+  description String?  @db.VarChar(255)
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  user             User                    @relation(fields: [userAddress], references: [walletAddress], onDelete: Cascade)
+  deliveryAttempts WebhookDeliveryAttempt[]
+
+  @@index([userAddress, createdAt])
+}
+
+/// WebhookDeliveryAttempt records a single delivery attempt for a webhook
+/// - timestamp: When the delivery was attempted
+/// - status: Outcome of the delivery (e.g. "success", "failure")
+/// - statusCode: HTTP status code returned by the target
+/// - responseBody: Response body from the target (if any)
+model WebhookDeliveryAttempt {
+  id           Int      @id @default(autoincrement())
+  webhookId    Int
+  timestamp    DateTime @default(now())
+  status       String   @db.VarChar(50)
+  statusCode   Int
+  responseBody String?  @db.Text
+
+  // Relations
+  webhook      Webhook  @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+
+  @@index([webhookId, timestamp])
 }

--- a/backend/src/__tests__/admin.trades.batch.routes.test.ts
+++ b/backend/src/__tests__/admin.trades.batch.routes.test.ts
@@ -1,0 +1,198 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { PrismaClient, TradeStatus } from "@prisma/client";
+import { createAdminTradeBatchRouter } from "../routes/admin.trades.batch.routes";
+import { AuthService } from "../services/auth.service";
+import { errorHandler } from "../errors/errorHandler";
+
+jest.mock("../services/auth.service", () => ({
+  AuthService: {
+    validateToken: jest.fn(async (token: string) => {
+      const jwt = require("jsonwebtoken");
+      return jwt.decode(token);
+    }),
+    isTokenRevoked: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+const mockPrisma = {
+  trade: {
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  },
+} as unknown as PrismaClient & {
+  trade: { findFirst: jest.Mock; updateMany: jest.Mock };
+};
+
+const app = express();
+app.use(express.json());
+app.use("/", createAdminTradeBatchRouter(mockPrisma));
+app.use(errorHandler);
+
+describe("Admin Trade Batch Route", () => {
+  const adminAddress = StellarSdk.Keypair.random().publicKey();
+  const nonAdminAddress = StellarSdk.Keypair.random().publicKey();
+  let adminToken: string;
+  let nonAdminToken: string;
+
+  beforeAll(() => {
+    process.env.ADMIN_STELLAR_PUBKEYS = adminAddress;
+    const secret = process.env.JWT_SECRET || "test-secret-at-least-32-characters-long";
+    const now = Math.floor(Date.now() / 1000);
+    adminToken = jwt.sign(
+      {
+        walletAddress: adminAddress,
+        jti: "batch-admin-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+    nonAdminToken = jwt.sign(
+      {
+        walletAddress: nonAdminAddress,
+        jti: "batch-nonadmin-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+  });
+
+  beforeEach(() => {
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with all succeeded when all transitions are valid", async () => {
+    mockPrisma.trade.findFirst
+      .mockResolvedValueOnce({ tradeId: "trade-1", status: TradeStatus.CREATED, version: 5 })
+      .mockResolvedValueOnce({ tradeId: "trade-2", status: TradeStatus.FUNDED, version: 3 });
+    mockPrisma.trade.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 });
+
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        updates: [
+          { tradeId: "trade-1", status: TradeStatus.CANCELLED },
+          { tradeId: "trade-2", status: TradeStatus.CANCELLED },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.succeeded).toEqual(["trade-1", "trade-2"]);
+    expect(res.body.failed).toEqual([]);
+  });
+
+  it("returns partial failures when some trades are not found or transitions are invalid", async () => {
+    mockPrisma.trade.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ tradeId: "trade-2", status: TradeStatus.FUNDED, version: 1 })
+      .mockResolvedValueOnce({ tradeId: "trade-3", status: TradeStatus.COMPLETED, version: 2 });
+    mockPrisma.trade.updateMany
+      .mockResolvedValueOnce({ count: 1 });
+
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        updates: [
+          { tradeId: "unknown-trade", status: TradeStatus.CANCELLED },
+          { tradeId: "trade-2", status: TradeStatus.CANCELLED },
+          { tradeId: "trade-3", status: TradeStatus.CANCELLED },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.succeeded).toEqual(["trade-2"]);
+    expect(res.body.failed).toHaveLength(2);
+    expect(res.body.failed[0]).toEqual({
+      tradeId: "unknown-trade",
+      reason: "Trade not found",
+    });
+    expect(res.body.failed[1]).toEqual({
+      tradeId: "trade-3",
+      reason: "Invalid transition from COMPLETED to CANCELLED",
+    });
+  });
+
+  it("handles concurrency conflicts", async () => {
+    mockPrisma.trade.findFirst
+      .mockResolvedValueOnce({ tradeId: "trade-1", status: TradeStatus.CREATED, version: 5 });
+    mockPrisma.trade.updateMany
+      .mockResolvedValueOnce({ count: 0 });
+
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        updates: [
+          { tradeId: "trade-1", status: TradeStatus.CANCELLED },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.succeeded).toEqual([]);
+    expect(res.body.failed).toEqual([
+      { tradeId: "trade-1", reason: "Concurrency conflict: trade was modified" },
+    ]);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .send({ updates: [{ tradeId: "trade-1", status: TradeStatus.CANCELLED }] });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${nonAdminToken}`)
+      .send({ updates: [{ tradeId: "trade-1", status: TradeStatus.CANCELLED }] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Forbidden: admin access required");
+  });
+
+  it("returns 400 for empty updates array", async () => {
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ updates: [] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid status value", async () => {
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ updates: [{ tradeId: "trade-1", status: "INVALID_STATUS" }] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing tradeId", async () => {
+    const res = await request(app)
+      .post("/admin/trades/batch/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ updates: [{ status: TradeStatus.CANCELLED }] });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/__tests__/notifications.inapp.routes.test.ts
+++ b/backend/src/__tests__/notifications.inapp.routes.test.ts
@@ -1,0 +1,290 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { PrismaClient } from "@prisma/client";
+import { createNotificationsRouter } from "../routes/notifications.inapp.routes";
+import { AuthService } from "../services/auth.service";
+import { errorHandler } from "../errors/errorHandler";
+
+jest.mock("../services/auth.service", () => ({
+  AuthService: {
+    validateToken: jest.fn(async (token: string) => {
+      const jwt = require("jsonwebtoken");
+      return jwt.decode(token);
+    }),
+    isTokenRevoked: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+const mockPrisma = {
+  inAppNotification: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    count: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+  },
+} as unknown as PrismaClient & {
+  inAppNotification: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    count: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
+};
+
+const app = express();
+app.use(express.json());
+app.use("/", createNotificationsRouter(mockPrisma));
+app.use(errorHandler);
+
+describe("Notifications Route", () => {
+  const userAddress = StellarSdk.Keypair.random().publicKey();
+  const otherAddress = StellarSdk.Keypair.random().publicKey();
+  let userToken: string;
+  let otherToken: string;
+
+  beforeAll(() => {
+    const secret = process.env.JWT_SECRET || "test-secret-at-least-32-characters-long";
+    const now = Math.floor(Date.now() / 1000);
+    userToken = jwt.sign(
+      {
+        walletAddress: userAddress,
+        jti: "notifications-user-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+    otherToken = jwt.sign(
+      {
+        walletAddress: otherAddress,
+        jti: "notifications-other-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+  });
+
+  beforeEach(() => {
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /notifications", () => {
+    it("returns paginated notifications", async () => {
+      mockPrisma.inAppNotification.findMany.mockResolvedValue([
+        {
+          id: 1,
+          title: "Trade completed",
+          message: "Your trade #123 has been completed",
+          type: "trade_update",
+          isRead: false,
+          metadata: { tradeId: "123" },
+          createdAt: new Date("2025-01-02T00:00:00Z"),
+        },
+        {
+          id: 2,
+          title: "Dispute opened",
+          message: "A dispute has been opened on trade #456",
+          type: "dispute",
+          isRead: true,
+          metadata: { tradeId: "456" },
+          createdAt: new Date("2025-01-01T00:00:00Z"),
+        },
+      ]);
+      mockPrisma.inAppNotification.count
+        .mockResolvedValueOnce(2) // total for current filter
+        .mockResolvedValueOnce(1); // unreadCount
+
+      const res = await request(app)
+        .get("/notifications")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.notifications).toHaveLength(2);
+      expect(res.body.notifications[0]).toEqual({
+        id: 1,
+        title: "Trade completed",
+        message: "Your trade #123 has been completed",
+        type: "trade_update",
+        isRead: false,
+        metadata: { tradeId: "123" },
+        createdAt: "2025-01-02T00:00:00.000Z",
+      });
+      expect(res.body.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 2,
+        totalPages: 1,
+      });
+      expect(res.body.unreadCount).toBe(1);
+    });
+
+    it("filters by unreadOnly when query param is true", async () => {
+      mockPrisma.inAppNotification.findMany.mockResolvedValue([
+        {
+          id: 1,
+          title: "Trade completed",
+          message: "Your trade #123 has been completed",
+          type: "trade_update",
+          isRead: false,
+          metadata: null,
+          createdAt: new Date("2025-01-02T00:00:00Z"),
+        },
+      ]);
+      mockPrisma.inAppNotification.count
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1);
+
+      const res = await request(app)
+        .get("/notifications?unreadOnly=true")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.notifications).toHaveLength(1);
+      expect(mockPrisma.inAppNotification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userAddress: userAddress, isRead: false },
+        }),
+      );
+    });
+
+    it("returns empty list when no notifications exist", async () => {
+      mockPrisma.inAppNotification.findMany.mockResolvedValue([]);
+      mockPrisma.inAppNotification.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0);
+
+      const res = await request(app)
+        .get("/notifications")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.notifications).toEqual([]);
+      expect(res.body.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 0,
+        totalPages: 0,
+      });
+      expect(res.body.unreadCount).toBe(0);
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await request(app).get("/notifications");
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("PATCH /notifications/:id/read", () => {
+    it("marks a notification as read", async () => {
+      mockPrisma.inAppNotification.findUnique.mockResolvedValue({
+        id: 1,
+        userAddress,
+        isRead: false,
+      });
+      mockPrisma.inAppNotification.update.mockResolvedValue({
+        id: 1,
+        isRead: true,
+      });
+
+      const res = await request(app)
+        .patch("/notifications/1/read")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe("Notification marked as read");
+      expect(mockPrisma.inAppNotification.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { isRead: true },
+      });
+    });
+
+    it("returns 200 when notification is already read (idempotent)", async () => {
+      mockPrisma.inAppNotification.findUnique.mockResolvedValue({
+        id: 1,
+        userAddress,
+        isRead: true,
+      });
+
+      const res = await request(app)
+        .patch("/notifications/1/read")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe("Notification already marked as read");
+      expect(mockPrisma.inAppNotification.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for non-existent notification", async () => {
+      mockPrisma.inAppNotification.findUnique.mockResolvedValue(null);
+
+      const res = await request(app)
+        .patch("/notifications/999/read")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Notification not found");
+    });
+
+    it("returns 403 when notification belongs to another user", async () => {
+      mockPrisma.inAppNotification.findUnique.mockResolvedValue({
+        id: 1,
+        userAddress,
+        isRead: false,
+      });
+
+      const res = await request(app)
+        .patch("/notifications/1/read")
+        .set("Authorization", `Bearer ${otherToken}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("Forbidden: you do not own this notification");
+    });
+  });
+
+  describe("POST /notifications/read-all", () => {
+    it("marks all unread notifications as read", async () => {
+      mockPrisma.inAppNotification.updateMany.mockResolvedValue({
+        count: 3,
+      });
+
+      const res = await request(app)
+        .post("/notifications/read-all")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe("All notifications marked as read");
+      expect(res.body.count).toBe(3);
+      expect(mockPrisma.inAppNotification.updateMany).toHaveBeenCalledWith({
+        where: { userAddress, isRead: false },
+        data: { isRead: true },
+      });
+    });
+
+    it("returns count 0 when no unread notifications exist", async () => {
+      mockPrisma.inAppNotification.updateMany.mockResolvedValue({
+        count: 0,
+      });
+
+      const res = await request(app)
+        .post("/notifications/read-all")
+        .set("Authorization", `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(0);
+    });
+  });
+});

--- a/backend/src/__tests__/webhooks.logs.routes.test.ts
+++ b/backend/src/__tests__/webhooks.logs.routes.test.ts
@@ -1,0 +1,212 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { PrismaClient } from "@prisma/client";
+import { createWebhookLogsRouter } from "../routes/webhooks.logs.routes";
+import { AuthService } from "../services/auth.service";
+import { errorHandler } from "../errors/errorHandler";
+
+jest.mock("../services/auth.service", () => ({
+  AuthService: {
+    validateToken: jest.fn(async (token: string) => {
+      const jwt = require("jsonwebtoken");
+      return jwt.decode(token);
+    }),
+    isTokenRevoked: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+const mockPrisma = {
+  webhook: {
+    findUnique: jest.fn(),
+  },
+  webhookDeliveryAttempt: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+} as unknown as PrismaClient & {
+  webhook: { findUnique: jest.Mock };
+  webhookDeliveryAttempt: { findMany: jest.Mock; count: jest.Mock };
+};
+
+const app = express();
+app.use(express.json());
+app.use("/", createWebhookLogsRouter(mockPrisma));
+app.use(errorHandler);
+
+describe("Webhook Logs Route", () => {
+  const ownerAddress = StellarSdk.Keypair.random().publicKey();
+  const otherAddress = StellarSdk.Keypair.random().publicKey();
+  let ownerToken: string;
+  let otherToken: string;
+
+  beforeAll(() => {
+    const secret = process.env.JWT_SECRET || "test-secret-at-least-32-characters-long";
+    const now = Math.floor(Date.now() / 1000);
+    ownerToken = jwt.sign(
+      {
+        walletAddress: ownerAddress,
+        jti: "webhook-logs-owner-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+    otherToken = jwt.sign(
+      {
+        walletAddress: otherAddress,
+        jti: "webhook-logs-other-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+  });
+
+  beforeEach(() => {
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with delivery attempts and pagination", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+    mockPrisma.webhookDeliveryAttempt.findMany.mockResolvedValue([
+      {
+        timestamp: new Date("2025-01-01T00:00:00Z"),
+        status: "success",
+        statusCode: 200,
+        responseBody: '{"ok":true}',
+      },
+      {
+        timestamp: new Date("2025-01-02T00:00:00Z"),
+        status: "failure",
+        statusCode: 500,
+        responseBody: null,
+      },
+    ]);
+    mockPrisma.webhookDeliveryAttempt.count.mockResolvedValue(2);
+
+    const res = await request(app)
+      .get("/webhooks/1/logs")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attempts).toHaveLength(2);
+    expect(res.body.attempts[0]).toEqual({
+      timestamp: "2025-01-01T00:00:00.000Z",
+      status: "success",
+      statusCode: 200,
+      responseBody: '{"ok":true}',
+    });
+    expect(res.body.attempts[1]).toEqual({
+      timestamp: "2025-01-02T00:00:00.000Z",
+      status: "failure",
+      statusCode: 500,
+      responseBody: null,
+    });
+    expect(res.body.pagination).toEqual({
+      page: 1,
+      limit: 20,
+      total: 2,
+      totalPages: 1,
+    });
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const res = await request(app).get("/webhooks/1/logs");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-existent webhook", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .get("/webhooks/999/logs")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Webhook not found");
+  });
+
+  it("returns 403 when caller is not the webhook owner", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+
+    const res = await request(app)
+      .get("/webhooks/1/logs")
+      .set("Authorization", `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Forbidden: you do not own this webhook");
+  });
+
+  it("returns empty attempts list when no deliveries exist", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+    mockPrisma.webhookDeliveryAttempt.findMany.mockResolvedValue([]);
+    mockPrisma.webhookDeliveryAttempt.count.mockResolvedValue(0);
+
+    const res = await request(app)
+      .get("/webhooks/1/logs")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attempts).toEqual([]);
+    expect(res.body.pagination).toEqual({
+      page: 1,
+      limit: 20,
+      total: 0,
+      totalPages: 0,
+    });
+  });
+
+  it("respects pagination query parameters", async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValue({
+      id: 1,
+      userAddress: ownerAddress,
+    });
+
+    const allAttempts = Array.from({ length: 25 }, (_, i) => ({
+      timestamp: new Date(`2025-01-${String(i + 1).padStart(2, "0")}T00:00:00Z`),
+      status: "success",
+      statusCode: 200,
+      responseBody: null,
+    }));
+
+    mockPrisma.webhookDeliveryAttempt.findMany.mockImplementation(
+      ({ skip, take }: { skip: number; take: number }) =>
+        Promise.resolve(allAttempts.slice(skip, skip + take)),
+    );
+    mockPrisma.webhookDeliveryAttempt.count.mockResolvedValue(25);
+
+    const res = await request(app)
+      .get("/webhooks/1/logs?page=2&limit=10")
+      .set("Authorization", `Bearer ${ownerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attempts).toHaveLength(10);
+    expect(res.body.pagination).toEqual({
+      page: 2,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+    });
+  });
+});

--- a/backend/src/middleware/admin.middleware.ts
+++ b/backend/src/middleware/admin.middleware.ts
@@ -1,0 +1,16 @@
+import { Response, NextFunction } from "express";
+import { isMediatorAddress } from "../lib/accessControl";
+import { AuthRequest } from "../services/auth.service";
+
+export const adminMiddleware = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  const walletAddress = req.user?.walletAddress?.trim();
+  if (!walletAddress || !isMediatorAddress(walletAddress)) {
+    res.status(403).json({ error: "Forbidden: admin access required" });
+    return;
+  }
+  next();
+};

--- a/backend/src/routes/admin.trades.batch.routes.ts
+++ b/backend/src/routes/admin.trades.batch.routes.ts
@@ -1,0 +1,92 @@
+import { PrismaClient, TradeStatus } from "@prisma/client";
+import { Response, Router } from "express";
+import { z } from "zod";
+import { prisma as defaultPrisma } from "../lib/db";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { adminMiddleware } from "../middleware/admin.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { AuthRequest } from "../services/auth.service";
+
+const tradeStatusUpdateSchema = z.object({
+  tradeId: z.string().min(1, "tradeId is required"),
+  status: z.nativeEnum(TradeStatus),
+});
+
+const batchStatusBodySchema = z.object({
+  updates: z.array(tradeStatusUpdateSchema).min(1, "At least one update is required").max(100, "Maximum 100 updates per request"),
+});
+
+const VALID_TRANSITIONS: Record<TradeStatus, TradeStatus[]> = {
+  [TradeStatus.PENDING_SIGNATURE]: [TradeStatus.CREATED, TradeStatus.CANCELLED],
+  [TradeStatus.CREATED]: [TradeStatus.FUNDED, TradeStatus.CANCELLED],
+  [TradeStatus.FUNDED]: [TradeStatus.DELIVERED, TradeStatus.DISPUTED, TradeStatus.CANCELLED],
+  [TradeStatus.DELIVERED]: [TradeStatus.COMPLETED, TradeStatus.DISPUTED, TradeStatus.CANCELLED],
+  [TradeStatus.DISPUTED]: [TradeStatus.COMPLETED, TradeStatus.CANCELLED],
+  [TradeStatus.COMPLETED]: [],
+  [TradeStatus.CANCELLED]: [],
+};
+
+function isValidTransition(from: TradeStatus, to: TradeStatus): boolean {
+  return VALID_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function createAdminTradeBatchRouter(prisma: PrismaClient = defaultPrisma) {
+  const router = Router();
+
+  router.post(
+    "/admin/trades/batch/status",
+    authMiddleware,
+    adminMiddleware,
+    validateRequest({ body: batchStatusBodySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const { updates } = req.body as { updates: { tradeId: string; status: TradeStatus }[] };
+
+        const succeeded: string[] = [];
+        const failed: { tradeId: string; reason: string }[] = [];
+
+        for (const { tradeId, status: targetStatus } of updates) {
+          const trade = await prisma.trade.findFirst({
+            where: {
+              OR: [
+                { tradeId },
+                { id: Number.isInteger(Number(tradeId)) ? Number(tradeId) : -1 },
+              ],
+            },
+            select: { tradeId: true, status: true, version: true },
+          });
+
+          if (!trade) {
+            failed.push({ tradeId, reason: "Trade not found" });
+            continue;
+          }
+
+          if (!isValidTransition(trade.status, targetStatus)) {
+            failed.push({
+              tradeId,
+              reason: `Invalid transition from ${trade.status} to ${targetStatus}`,
+            });
+            continue;
+          }
+
+          const result = await prisma.trade.updateMany({
+            where: { tradeId: trade.tradeId, version: trade.version },
+            data: { status: targetStatus, version: { increment: 1 } },
+          });
+
+          if (result.count === 0) {
+            failed.push({ tradeId, reason: "Concurrency conflict: trade was modified" });
+          } else {
+            succeeded.push(trade.tradeId);
+          }
+        }
+
+        res.status(200).json({ succeeded, failed });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/backend/src/routes/notifications.inapp.routes.ts
+++ b/backend/src/routes/notifications.inapp.routes.ts
@@ -1,0 +1,157 @@
+import { PrismaClient } from "@prisma/client";
+import { Response, Router } from "express";
+import { z } from "zod";
+import { prisma as defaultPrisma } from "../lib/db";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { AuthRequest } from "../services/auth.service";
+
+const listNotificationsQuerySchema = z.object({
+  unreadOnly: z.coerce.boolean().default(false),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+const notificationIdParamsSchema = z.object({
+  id: z.string().regex(/^\d+$/, "Notification ID must be a numeric string"),
+});
+
+function caller(req: AuthRequest, res: Response): string | null {
+  const walletAddress = req.user?.walletAddress?.trim();
+  if (!walletAddress) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+  return walletAddress;
+}
+
+export function createNotificationsRouter(prisma: PrismaClient = defaultPrisma) {
+  const router = Router();
+
+  router.get(
+    "/notifications",
+    authMiddleware,
+    validateRequest({ query: listNotificationsQuerySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const { unreadOnly, page, limit } = req.query as unknown as {
+          unreadOnly: boolean;
+          page: number;
+          limit: number;
+        };
+        const skip = (page - 1) * limit;
+
+        const where = { userAddress: walletAddress };
+        if (unreadOnly) {
+          (where as Record<string, unknown>).isRead = false;
+        }
+
+        const [notifications, total, unreadCount] = await Promise.all([
+          prisma.inAppNotification.findMany({
+            where,
+            orderBy: { createdAt: "desc" },
+            skip,
+            take: limit,
+            select: {
+              id: true,
+              title: true,
+              message: true,
+              type: true,
+              isRead: true,
+              metadata: true,
+              createdAt: true,
+            },
+          }),
+          prisma.inAppNotification.count({ where }),
+          prisma.inAppNotification.count({
+            where: { userAddress: walletAddress, isRead: false },
+          }),
+        ]);
+
+        res.status(200).json({
+          notifications,
+          pagination: {
+            page,
+            limit,
+            total,
+            totalPages: Math.ceil(total / limit),
+          },
+          unreadCount,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.patch(
+    "/notifications/:id/read",
+    authMiddleware,
+    validateRequest({ params: notificationIdParamsSchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const notificationId = Number(req.params.id);
+
+        const notification = await prisma.inAppNotification.findUnique({
+          where: { id: notificationId },
+          select: { userAddress: true, isRead: true },
+        });
+
+        if (!notification) {
+          res.status(404).json({ error: "Notification not found" });
+          return;
+        }
+
+        if (notification.userAddress !== walletAddress) {
+          res.status(403).json({ error: "Forbidden: you do not own this notification" });
+          return;
+        }
+
+        if (notification.isRead) {
+          res.status(200).json({ message: "Notification already marked as read" });
+          return;
+        }
+
+        await prisma.inAppNotification.update({
+          where: { id: notificationId },
+          data: { isRead: true },
+        });
+
+        res.status(200).json({ message: "Notification marked as read" });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    "/notifications/read-all",
+    authMiddleware,
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const result = await prisma.inAppNotification.updateMany({
+          where: { userAddress: walletAddress, isRead: false },
+          data: { isRead: true },
+        });
+
+        res.status(200).json({
+          message: "All notifications marked as read",
+          count: result.count,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/backend/src/routes/webhooks.logs.routes.ts
+++ b/backend/src/routes/webhooks.logs.routes.ts
@@ -1,0 +1,92 @@
+import { PrismaClient } from "@prisma/client";
+import { Response, Router } from "express";
+import { z } from "zod";
+import { prisma as defaultPrisma } from "../lib/db";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { AuthRequest } from "../services/auth.service";
+
+const webhookLogsParamsSchema = z.object({
+  id: z.string().regex(/^\d+$/, "Webhook ID must be a numeric string"),
+});
+
+const webhookLogsQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+function caller(req: AuthRequest, res: Response): string | null {
+  const walletAddress = req.user?.walletAddress?.trim();
+  if (!walletAddress) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+  return walletAddress;
+}
+
+export function createWebhookLogsRouter(prisma: PrismaClient = defaultPrisma) {
+  const router = Router();
+
+  router.get(
+    "/webhooks/:id/logs",
+    authMiddleware,
+    validateRequest({ params: webhookLogsParamsSchema, query: webhookLogsQuerySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const webhookId = Number(req.params.id);
+        const { page, limit } = req.query as unknown as { page: number; limit: number };
+        const skip = (page - 1) * limit;
+
+        const webhook = await prisma.webhook.findUnique({
+          where: { id: webhookId },
+          select: { userAddress: true },
+        });
+
+        if (!webhook) {
+          res.status(404).json({ error: "Webhook not found" });
+          return;
+        }
+
+        if (webhook.userAddress !== walletAddress) {
+          res.status(403).json({ error: "Forbidden: you do not own this webhook" });
+          return;
+        }
+
+        const [attempts, total] = await Promise.all([
+          prisma.webhookDeliveryAttempt.findMany({
+            where: { webhookId },
+            orderBy: { timestamp: "desc" },
+            skip,
+            take: limit,
+            select: {
+              timestamp: true,
+              status: true,
+              statusCode: true,
+              responseBody: true,
+            },
+          }),
+          prisma.webhookDeliveryAttempt.count({
+            where: { webhookId },
+          }),
+        ]);
+
+        res.status(200).json({
+          attempts,
+          pagination: {
+            page,
+            limit,
+            total,
+            totalPages: Math.ceil(total / limit),
+          },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Allow admins to batch-update trade statuses (e.g., mark multiple trades as Cancelled).

Closes #721

## Changes

### New middleware
- `backend/src/middleware/admin.middleware.ts` — Express middleware that checks `isMediatorAddress()` against `ADMIN_STELLAR_PUBKEYS` env var. Returns 403 for non-admin callers. Plugs in after `authMiddleware`.

### Route
`POST /admin/trades/batch/status` at `backend/src/routes/admin.trades.batch.routes.ts`:

- **Auth chain**: `authMiddleware` → `adminMiddleware` → `validateRequest` (Zod)
- **Request body**: `{ updates: { tradeId: string, status: TradeStatus }[] }` (1–100 items)
- **State machine validation**: Uses `VALID_TRANSITIONS` map enforcing legal transitions per `TradeStatus`:
  | From | To |
  |------|----|
  | PENDING_SIGNATURE | CREATED, CANCELLED |
  | CREATED | FUNDED, CANCELLED |
  | FUNDED | DELIVERED, DISPUTED, CANCELLED |
  | DELIVERED | COMPLETED, DISPUTED, CANCELLED |
  | DISPUTED | COMPLETED, CANCELLED |
  | COMPLETED | (terminal) |
  | CANCELLED | (terminal) |
- **Optimistic concurrency**: Uses the `version` field with `updateMany` — detects stale writes and reports them as concurrency failures
- **Partial failure reporting**: Processes each update sequentially — valid updates succeed, invalid ones are collected in the `failed` array

#### Response shape
```json
{
  "succeeded": ["trade-abc", "trade-def"],
  "failed": [
    { "tradeId": "unknown", "reason": "Trade not found" },
    { "tradeId": "trade-ghi", "reason": "Invalid transition from COMPLETED to CANCELLED" },
    { "tradeId": "trade-jkl", "reason": "Concurrency conflict: trade was modified" }
  ]
}
```

### Tests
8 tests in `backend/src/__tests__/admin.trades.batch.routes.test.ts`:

- ✓ All succeeded when all transitions are valid
- ✓ Partial failures when some trades not found or transitions invalid
- ✓ Concurrency conflict handling
- ✓ 401 without auth
- ✓ 403 for non-admin users
- ✓ 400 for empty updates array
- ✓ 400 for invalid status value
- ✓ 400 for missing tradeId

All tests pass.