### PR TITLE
feat: stellar account creation route with keypair generation and friendbot funding

### DIFF
--- a/backend/src/__tests__/stellar.account.create.test.ts
+++ b/backend/src/__tests__/stellar.account.create.test.ts
@@ -1,0 +1,93 @@
+import request from "supertest";
+import { createApp } from "../app";
+import express from "express";
+
+// Mock Keypair so we get deterministic values
+const MOCK_PUBLIC_KEY = "GDDD3FRCH55BSYNKISYY242HQNIBOH35CQP42NSJABR62XK2JOV5MED6";
+const MOCK_SECRET = "SCZANGBA568CEBM44VKXRP22KO6J53ZVACQZ4WFWRSYTH3BQMVQN4YL";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    Keypair: {
+      ...actual.Keypair,
+      random: jest.fn().mockReturnValue({
+        publicKey: () => MOCK_PUBLIC_KEY,
+        secret: () => MOCK_SECRET,
+      }),
+    },
+  };
+});
+
+const mockAxiosGet = jest.fn();
+jest.mock("axios", () => ({
+  get: (...args: any[]) => mockAxiosGet(...args),
+}));
+
+// Mock encrypt so tests don't depend on JWT_SECRET value
+jest.mock("../lib/crypto", () => ({
+  encrypt: jest.fn().mockReturnValue("encrypted-secret-key"),
+  decrypt: jest.fn(),
+}));
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: {},
+  sorobanRpcClient: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+describe("POST /stellar/account/create", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockAxiosGet.mockReset();
+    app = createApp();
+  });
+
+  it("creates an account and returns publicKey and encryptedSecretKey", async () => {
+    const res = await request(app).post("/stellar/account/create").send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body.publicKey).toBe(MOCK_PUBLIC_KEY);
+    expect(res.body.encryptedSecretKey).toBe("encrypted-secret-key");
+    expect(res.body.funded).toBe(false);
+  });
+
+  it("funds the account via friendbot on testnet when fund=true", async () => {
+    mockAxiosGet.mockResolvedValue({ status: 200, data: {} });
+
+    const res = await request(app)
+      .post("/stellar/account/create")
+      .send({ fund: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.publicKey).toBe(MOCK_PUBLIC_KEY);
+    expect(res.body.funded).toBe(true);
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      "https://friendbot.stellar.org",
+      expect.objectContaining({ params: { addr: MOCK_PUBLIC_KEY } })
+    );
+  });
+
+  it("still returns 201 if friendbot fails (funded=false)", async () => {
+    mockAxiosGet.mockRejectedValue(new Error("Friendbot unavailable"));
+
+    const res = await request(app)
+      .post("/stellar/account/create")
+      .send({ fund: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.publicKey).toBe(MOCK_PUBLIC_KEY);
+    expect(res.body.funded).toBe(false);
+    expect(res.body.encryptedSecretKey).toBe("encrypted-secret-key");
+  });
+
+  it("does not call friendbot when fund is not set", async () => {
+    const res = await request(app).post("/stellar/account/create").send({});
+
+    expect(res.status).toBe(201);
+    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(res.body.funded).toBe(false);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -26,6 +26,7 @@ import { stellarFeesRoutes } from "./routes/stellar.fees";
 import { stellarTxStatusRoutes } from "./routes/stellar.tx.status";
 import { stellarAssetRoutes } from "./routes/stellar.asset";
 import { stellarAccountBalanceRoutes } from "./routes/stellar.account.balance";
+import { stellarAccountCreateRoutes } from "./routes/stellar.account.create";
 import { webhooksRoutes } from "./routes/webhooks.routes";
 import { env } from "./config/env";
 
@@ -139,6 +140,7 @@ export function createApp(): express.Application {
   app.use("/stellar/fees", stellarFeesRoutes);
   app.use("/stellar/tx", stellarTxStatusRoutes);
   app.use("/stellar/assets", stellarAssetRoutes);
+  app.use("/stellar/account", stellarAccountCreateRoutes);
   app.use("/stellar/account", stellarAccountBalanceRoutes);
 
   // Treasury management

--- a/backend/src/lib/crypto.ts
+++ b/backend/src/lib/crypto.ts
@@ -1,0 +1,38 @@
+import crypto from "crypto";
+import { env } from "../config/env";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+// Derive a 32-byte key from JWT_SECRET so no extra env var is needed.
+function deriveKey(): Buffer {
+  return crypto.createHash("sha256").update(env.JWT_SECRET).digest();
+}
+
+/**
+ * Encrypts plaintext with AES-256-GCM.
+ * Returns a base64 string of the form: iv(12B) + ciphertext + authTag(16B).
+ */
+export function encrypt(plaintext: string): string {
+  const key = deriveKey();
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, encrypted, tag]).toString("base64");
+}
+
+/**
+ * Decrypts a base64 blob produced by `encrypt`.
+ */
+export function decrypt(blob: string): string {
+  const key = deriveKey();
+  const buf = Buffer.from(blob, "base64");
+  const iv = buf.subarray(0, IV_LENGTH);
+  const tag = buf.subarray(buf.length - TAG_LENGTH);
+  const ciphertext = buf.subarray(IV_LENGTH, buf.length - TAG_LENGTH);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}

--- a/backend/src/routes/stellar.account.create.ts
+++ b/backend/src/routes/stellar.account.create.ts
@@ -1,0 +1,56 @@
+import { Router, Request, Response } from "express";
+import { Keypair } from "@stellar/stellar-sdk";
+import axios from "axios";
+import { env } from "../config/env";
+import { appLogger } from "../middleware/logger";
+import { encrypt } from "../lib/crypto";
+
+const FRIENDBOT_URL = "https://friendbot.stellar.org";
+
+async function fundViaFriendbot(publicKey: string): Promise<void> {
+  await axios.get(FRIENDBOT_URL, { params: { addr: publicKey }, timeout: 15_000 });
+}
+
+export function createStellarAccountCreateRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /stellar/account/create
+   *
+   * Body (all optional):
+   *   { fund?: boolean }
+   *
+   * fund=true on testnet triggers a friendbot airdrop.
+   * On mainnet, fund is ignored (no automatic funding available).
+   *
+   * Returns:
+   *   { publicKey, encryptedSecretKey, funded }
+   */
+  router.post("/", async (req: Request, res: Response) => {
+    const fund = req.body?.fund === true;
+    const isTestnet = env.STELLAR_NETWORK === "testnet";
+
+    const keypair = Keypair.random();
+    const publicKey = keypair.publicKey();
+    const encryptedSecretKey = encrypt(keypair.secret());
+
+    let funded = false;
+
+    if (fund && isTestnet) {
+      try {
+        await fundViaFriendbot(publicKey);
+        funded = true;
+      } catch (error) {
+        appLogger.warn({ error, publicKey }, "Friendbot funding failed; account still created");
+      }
+    } else if (fund && !isTestnet) {
+      appLogger.info({ publicKey }, "Mainnet account created without automatic funding");
+    }
+
+    res.status(201).json({ publicKey, encryptedSecretKey, funded });
+  });
+
+  return router;
+}
+
+export const stellarAccountCreateRoutes = createStellarAccountCreateRouter();


### PR DESCRIPTION
## Summary

- Add `POST /stellar/account/create` endpoint that generates a Stellar keypair server-side, encrypts the secret key with AES-256-GCM, and returns `{ publicKey, encryptedSecretKey, funded }`
- Optionally fund the new account via Stellar friendbot when `fund: true` is sent on testnet; mainnet requests with `fund: true` create the keypair without funding
- Friendbot failures are non-fatal — the endpoint still returns 201 with `funded: false` so callers are never blocked
- Add `lib/crypto.ts` with `encrypt`/`decrypt` helpers (AES-256-GCM, key derived from `JWT_SECRET`, IV + ciphertext + auth tag packed into a single base64 blob)

## Changes

- `backend/src/lib/crypto.ts` — AES-256-GCM encrypt/decrypt utilities
- `backend/src/routes/stellar.account.create.ts` — `POST /stellar/account/create` route handler
- `backend/src/app.ts` — registers the new route at `/stellar/account` (before the balance `:address` handler)
- `backend/src/__tests__/stellar.account.create.test.ts` — tests: creation, testnet funding, friendbot failure graceful degradation, no friendbot when fund omitted

## Test plan

- [ ] `cd backend && npx jest stellar.account.create` — all 4 tests pass
- [ ] `POST /stellar/account/create {}` returns `{ publicKey, encryptedSecretKey, funded: false }`
- [ ] `POST /stellar/account/create { "fund": true }` on testnet returns `funded: true` after friendbot call
- [ ] Full backend test suite shows no regressions



closes #709