### PR TITLE
fix: address auth replay, log injection, outbox race, and dispute ide…

### DIFF
--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -52,14 +52,13 @@ export class AuthService {
   static async verifySignatureAndIssueJWT(walletAddress: string, signedChallenge: string): Promise<string> {
     try {
       const key = `${CHALLENGE_PREFIX}${walletAddress.toLowerCase()}`;
-      const challenge = await redis.get(key);
+      // Atomic get-and-delete prevents replay: a concurrent request that calls
+      // getdel after us will receive null even before we finish verification.
+      const challenge = await (redis as any).getdel(key);
 
       if (!challenge) {
         throw new AppError(ErrorCode.AUTH_ERROR, 'Challenge expired or invalid. Request new challenge.', 401);
       }
-
-      // Replay protection: delete immediately after fetch
-      await redis.del(key);
 
       const publicKey = Keypair.fromPublicKey(walletAddress);
       let isValid = false;

--- a/backend/src/services/dispute.service.ts
+++ b/backend/src/services/dispute.service.ts
@@ -207,6 +207,12 @@ export class DisputeService {
         );
       }
 
+      // Idempotency: a retry after a network timeout should succeed silently
+      // when the first request already applied the transition.
+      if (dispute.status === newStatus) {
+        return toDisputeResponse(dispute);
+      }
+
       assertValidTransition(dispute.status, newStatus);
 
       const applied = await applyDisputeStatusTransition(

--- a/backend/src/services/eventListener.service.ts
+++ b/backend/src/services/eventListener.service.ts
@@ -279,10 +279,20 @@ export class EventListenerService {
       eventId: event.eventId,
     };
 
-    const existing = await this.prisma.chainEventOutbox.findUnique({
-      where: {
-        ledgerSequence_contractId_eventId: key,
+    // Atomic upsert: concurrent poll cycles racing on the same event all get
+    // back the single canonical record without a non-atomic check-then-create.
+    const record = await this.prisma.chainEventOutbox.upsert({
+      where: { ledgerSequence_contractId_eventId: key },
+      create: {
+        ledgerSequence: event.ledgerSequence,
+        contractId: event.contractId,
+        eventId: event.eventId,
+        eventType: event.eventType,
+        tradeId: event.tradeId,
+        payload: event.data as Prisma.JsonObject,
+        status: "PENDING",
       },
+      update: {},
       select: {
         id: true,
         status: true,
@@ -290,50 +300,7 @@ export class EventListenerService {
         nextAttemptAt: true,
       },
     });
-
-    if (existing) {
-      return existing as OutboxRecord;
-    }
-
-    try {
-      const created = await this.prisma.chainEventOutbox.create({
-        data: {
-          ledgerSequence: event.ledgerSequence,
-          contractId: event.contractId,
-          eventId: event.eventId,
-          eventType: event.eventType,
-          tradeId: event.tradeId,
-          payload: event.data as Prisma.JsonObject,
-          status: "PENDING",
-        },
-        select: {
-          id: true,
-          status: true,
-          attempts: true,
-          nextAttemptAt: true,
-        },
-      });
-      return created as OutboxRecord;
-    } catch (error) {
-      if (!isPrismaUniqueConstraintError(error)) {
-        throw error;
-      }
-      const concurrent = await this.prisma.chainEventOutbox.findUnique({
-        where: {
-          ledgerSequence_contractId_eventId: key,
-        },
-        select: {
-          id: true,
-          status: true,
-          attempts: true,
-          nextAttemptAt: true,
-        },
-      });
-      if (!concurrent) {
-        throw error;
-      }
-      return concurrent as OutboxRecord;
-    }
+    return record as OutboxRecord;
   }
 
   private isOutboxReadyForAttempt(outbox: OutboxRecord): boolean {
@@ -354,6 +321,16 @@ export class EventListenerService {
   private async processOutboxEventAtomically(outboxId: number, event: ParsedEvent): Promise<void> {
     try {
       await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        // Re-read status inside the transaction: if a concurrent worker already
+        // committed PROCESSED, skip dispatch to prevent duplicate event handling.
+        const current = await tx.chainEventOutbox.findUnique({
+          where: { id: outboxId },
+          select: { status: true },
+        });
+        if (current?.status === "PROCESSED") {
+          return;
+        }
+
         await dispatchEvent(tx, event);
         await tx.processedEvent.create({
           data: {

--- a/backend/src/services/trade.service.ts
+++ b/backend/src/services/trade.service.ts
@@ -19,6 +19,10 @@ function sha256(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+function sanitizeLogField(value: string, maxLength = 200): string {
+  return String(value).replace(/[\r\n\t]/g, "_").slice(0, maxLength);
+}
+
 export interface CreatePendingTradeInput {
   tradeId: string;
   buyerAddress: string;
@@ -71,16 +75,16 @@ export class TradeService {
   async createPendingTrade(input: CreatePendingTradeInput): Promise<Trade> {
     appLogger.info({
       requestId: undefined, // Will be filled by context if available
-      userId: input.buyerAddress,
-      paymentId: input.tradeId,
+      userId: sanitizeLogField(input.buyerAddress),
+      paymentId: sanitizeLogField(input.tradeId),
       provider: "stellar",
       status: "authorization_started",
       timestamp: new Date().toISOString()
     }, "Payment authorization started");
 
     TracingHelper.addEvent("authorization_started", {
-      paymentId: input.tradeId,
-      userId: input.buyerAddress
+      paymentId: sanitizeLogField(input.tradeId),
+      userId: sanitizeLogField(input.buyerAddress)
     });
 
     return this.prisma.trade.create({


### PR DESCRIPTION
…mpotency

[CRITICAL] Auth: Challenge verification vulnerable to replay attack (non-atomic get+del) Fixes #679

[MEDIUM] TradeService: Log injection via user-controlled tradeId in structured logs Fixes #682

[CRITICAL] EventListener: Race condition in outbox record creation allows duplicate processing Fixes #677

[MEDIUM] DisputeService: Missing idempotency on dispute resolution - duplicate resolutions possible Fixes #701