### PR TITLE
feat: add escrow release schedule, trustline management, and ledger info routes

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -457,6 +457,7 @@ model EscrowReleaseMilestone {
   milestoneIndex Int
   amountUsdc     String    @db.VarChar(100)
   dueAt          DateTime
+  conditionHash  String?   @db.VarChar(255)
   releasedAt     DateTime?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt

--- a/backend/src/__tests__/escrow.schedule.routes.test.ts
+++ b/backend/src/__tests__/escrow.schedule.routes.test.ts
@@ -1,0 +1,229 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { createEscrowScheduleRouter } from "../routes/escrow.schedule.routes";
+import { AuthService } from "../services/auth.service";
+import { errorHandler } from "../errors/errorHandler";
+
+jest.mock("../services/auth.service", () => ({
+  AuthService: {
+    validateToken: jest.fn(async (token: string) => {
+      const jwt = require("jsonwebtoken");
+      return jwt.decode(token);
+    }),
+    isTokenRevoked: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+describe("Escrow schedule route", () => {
+  const buyerAddress = StellarSdk.Keypair.random().publicKey();
+  const sellerAddress = StellarSdk.Keypair.random().publicKey();
+  let token: string;
+
+  const mockPrisma = {
+    trade: { findFirst: jest.fn() },
+    escrowReleaseMilestone: {
+      create: jest.fn(),
+      createMany: jest.fn(),
+      findMany: jest.fn(),
+      deleteMany: jest.fn(),
+      count: jest.fn(),
+    },
+  } as any;
+
+  const app = express();
+  app.use(express.json());
+  app.use("/trades", createEscrowScheduleRouter(mockPrisma));
+  app.use(errorHandler);
+
+  beforeAll(() => {
+    const now = Math.floor(Date.now() / 1000);
+    token = jwt.sign(
+      {
+        walletAddress: buyerAddress,
+        jti: "escrow-schedule-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      process.env.JWT_SECRET!,
+      { algorithm: "HS256" },
+    );
+  });
+
+  beforeEach(() => {
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+    jest.clearAllMocks();
+    mockPrisma.trade.findFirst.mockResolvedValue({
+      tradeId: "4294967297",
+      buyerAddress,
+      sellerAddress,
+      status: "FUNDED",
+    });
+  });
+
+  const validMilestones = [
+    {
+      milestoneIndex: 0,
+      amountUsdc: "5000.0000000",
+      dueAt: new Date(Date.now() + 86400000).toISOString(),
+      conditionHash: "0xabc123",
+    },
+    {
+      milestoneIndex: 1,
+      amountUsdc: "5000.0000000",
+      dueAt: new Date(Date.now() + 604800000).toISOString(),
+    },
+  ];
+
+  describe("POST /trades/:id/schedule", () => {
+    it("creates a release schedule for a funded trade", async () => {
+      mockPrisma.escrowReleaseMilestone.deleteMany.mockResolvedValue({ count: 0 });
+      mockPrisma.escrowReleaseMilestone.create
+        .mockResolvedValueOnce({
+          id: 1,
+          tradeId: "4294967297",
+          milestoneIndex: 0,
+          amountUsdc: "5000.0000000",
+          dueAt: new Date(Date.now() + 86400000),
+          conditionHash: "0xabc123",
+          releasedAt: null,
+        })
+        .mockResolvedValueOnce({
+          id: 2,
+          tradeId: "4294967297",
+          milestoneIndex: 1,
+          amountUsdc: "5000.0000000",
+          dueAt: new Date(Date.now() + 604800000),
+          conditionHash: null,
+          releasedAt: null,
+        });
+
+      const res = await request(app)
+        .post("/trades/4294967297/schedule")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ milestones: validMilestones });
+
+      expect(res.status).toBe(201);
+      expect(res.body.tradeId).toBe("4294967297");
+      expect(res.body.milestoneCount).toBe(2);
+      expect(res.body.milestones).toHaveLength(2);
+      expect(res.body.milestones[0].conditionHash).toBe("0xabc123");
+      expect(res.body.milestones[1].conditionHash).toBeNull();
+      expect(res.body.nextReleaseDate).toBeDefined();
+      expect(mockPrisma.escrowReleaseMilestone.deleteMany).toHaveBeenCalledWith({
+        where: { tradeId: "4294967297" },
+      });
+    });
+
+    it("returns 404 when trade is not found", async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post("/trades/9999999999/schedule")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ milestones: validMilestones });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Trade not found");
+    });
+
+    it("returns 400 when trade is not in CREATED or FUNDED status", async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue({
+        tradeId: "4294967297",
+        buyerAddress,
+        sellerAddress,
+        status: "COMPLETED",
+      });
+
+      const res = await request(app)
+        .post("/trades/4294967297/schedule")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ milestones: validMilestones });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("CREATED or FUNDED");
+    });
+
+    it("returns 400 for invalid milestone data", async () => {
+      const res = await request(app)
+        .post("/trades/4294967297/schedule")
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          milestones: [{ milestoneIndex: -1, amountUsdc: "bad", dueAt: "not-a-date" }],
+        });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when milestones array is empty", async () => {
+      const res = await request(app)
+        .post("/trades/4294967297/schedule")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ milestones: [] });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /trades/:id/schedule", () => {
+    it("returns the release schedule with next release date", async () => {
+      const futureDate = new Date(Date.now() + 86400000);
+      const pastDate = new Date(Date.now() - 86400000);
+
+      mockPrisma.escrowReleaseMilestone.findMany.mockResolvedValue([
+        {
+          milestoneIndex: 0,
+          amountUsdc: "5000.0000000",
+          dueAt: futureDate,
+          conditionHash: "0xabc123",
+          releasedAt: null,
+        },
+        {
+          milestoneIndex: 1,
+          amountUsdc: "5000.0000000",
+          dueAt: pastDate,
+          conditionHash: null,
+          releasedAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app)
+        .get("/trades/4294967297/schedule")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.tradeId).toBe("4294967297");
+      expect(res.body.milestoneCount).toBe(2);
+      expect(res.body.milestones).toHaveLength(2);
+      expect(res.body.nextReleaseDate).toBeDefined();
+      expect(res.body.milestones[0].released).toBe(false);
+      expect(res.body.milestones[1].released).toBe(true);
+    });
+
+    it("returns empty schedule when no milestones exist", async () => {
+      mockPrisma.escrowReleaseMilestone.findMany.mockResolvedValue([]);
+
+      const res = await request(app)
+        .get("/trades/4294967297/schedule")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.milestoneCount).toBe(0);
+      expect(res.body.milestones).toEqual([]);
+      expect(res.body.nextReleaseDate).toBeNull();
+    });
+
+    it("returns 404 when trade is not found", async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(null);
+
+      const res = await request(app)
+        .get("/trades/9999999999/schedule")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Trade not found");
+    });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,6 +14,7 @@ import { createTradeWatchlistRouter } from "./routes/trade.watchlist.routes";
 import { createTradeEvidenceRouter } from "./routes/trade.evidence.routes";
 import { createTradeExportRouter } from "./routes/trade.export.routes";
 import { createEscrowReleaseRouter } from "./routes/escrow.release.routes";
+import { createEscrowScheduleRouter } from "./routes/escrow.schedule.routes";
 import { createTradeManifestRouter } from "./routes/trade.manifest.routes";
 import { createManifestRouter } from "./routes/manifest.routes";
 import { createEvidenceRouter } from "./routes/evidence.routes";
@@ -125,6 +126,7 @@ export function createApp(): express.Application {
   app.use("/trades", createTradeWatchlistRouter());
   app.use("/trades", createTradeEvidenceRouter());
   app.use("/trades", createEscrowReleaseRouter());
+  app.use("/trades", createEscrowScheduleRouter());
   app.use("/trades", createTradeRouter());
 
   // Manifest: POST /trades/:id/manifest

--- a/backend/src/routes/escrow.schedule.routes.ts
+++ b/backend/src/routes/escrow.schedule.routes.ts
@@ -1,0 +1,198 @@
+import { PrismaClient, TradeStatus } from "@prisma/client";
+import { Response, Router } from "express";
+import { z } from "zod";
+import { prisma as defaultPrisma } from "../lib/db";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { AuthRequest } from "../services/auth.service";
+
+const scheduleParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+const milestoneSchema = z.object({
+  milestoneIndex: z.coerce.number().int().min(0),
+  amountUsdc: z.string().regex(/^\d+(\.\d{1,7})?$/, "Invalid USDC amount"),
+  dueAt: z.string().datetime({ message: "Invalid ISO date for dueAt" }),
+  conditionHash: z.string().max(64).optional(),
+});
+
+const createScheduleBodySchema = z.object({
+  milestones: z.array(milestoneSchema).min(1).max(100),
+});
+
+type SchedulePrisma = PrismaClient & {
+  escrowReleaseMilestone?: {
+    create: (args: any) => Promise<any>;
+    createMany: (args: any) => Promise<any>;
+    findMany: (args: any) => Promise<Array<{
+      milestoneIndex: number;
+      amountUsdc: string;
+      dueAt: Date;
+      conditionHash: string | null;
+      releasedAt: Date | null;
+    }>>;
+    deleteMany: (args: any) => Promise<any>;
+    count: (args: any) => Promise<number>;
+  };
+};
+
+function caller(req: AuthRequest, res: Response): string | null {
+  const walletAddress = req.user?.walletAddress?.trim();
+  if (!walletAddress) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+  return walletAddress;
+}
+
+function isBuyerOrSeller(trade: { buyerAddress: string; sellerAddress: string }, walletAddress: string): boolean {
+  return (
+    trade.buyerAddress.toLowerCase() === walletAddress.toLowerCase() ||
+    trade.sellerAddress.toLowerCase() === walletAddress.toLowerCase()
+  );
+}
+
+function tradeWhere(id: string) {
+  const numericId = Number(id);
+  const orConditions: Array<Record<string, unknown>> = [{ tradeId: id }];
+  if (Number.isInteger(numericId) && numericId > 0) {
+    orConditions.push({ id: numericId });
+  }
+  return { OR: orConditions };
+}
+
+export function createEscrowScheduleRouter(
+  prisma: SchedulePrisma = defaultPrisma as SchedulePrisma,
+) {
+  const router = Router();
+
+  router.post(
+    "/:id/schedule",
+    authMiddleware,
+    validateRequest({ params: scheduleParamsSchema, body: createScheduleBodySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const id = String(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
+        const { milestones } = req.body as z.infer<typeof createScheduleBodySchema>;
+
+        const trade = await prisma.trade.findFirst({ where: tradeWhere(id) });
+
+        if (!trade) {
+          res.status(404).json({ error: "Trade not found" });
+          return;
+        }
+
+        if (trade.status !== TradeStatus.CREATED && trade.status !== TradeStatus.FUNDED) {
+          res.status(400).json({
+            error: `Trade must be CREATED or FUNDED to set a release schedule (current: ${trade.status})`,
+          });
+          return;
+        }
+
+        if (!isBuyerOrSeller(trade, walletAddress)) {
+          res.status(403).json({ error: "Only the buyer or seller may set the release schedule" });
+          return;
+        }
+
+        if (!prisma.escrowReleaseMilestone) {
+          res.status(500).json({ error: "Release schedule store unavailable" });
+          return;
+        }
+
+        await prisma.escrowReleaseMilestone.deleteMany({
+          where: { tradeId: trade.tradeId },
+        });
+
+        const created = [];
+        for (let i = 0; i < milestones.length; i++) {
+          const m = milestones[i];
+          const record = await prisma.escrowReleaseMilestone.create({
+            data: {
+              tradeId: trade.tradeId,
+              milestoneIndex: m.milestoneIndex,
+              amountUsdc: m.amountUsdc,
+              dueAt: new Date(m.dueAt),
+              conditionHash: m.conditionHash ?? null,
+            },
+          });
+          created.push(record);
+        }
+
+        const now = new Date();
+        const nextMilestone = created.find((m) => m.dueAt > now);
+
+        res.status(201).json({
+          tradeId: trade.tradeId,
+          milestoneCount: created.length,
+          nextReleaseDate: nextMilestone ? nextMilestone.dueAt.toISOString() : null,
+          milestones: created.map((m) => ({
+            milestoneIndex: m.milestoneIndex,
+            amountUsdc: m.amountUsdc,
+            dueAt: m.dueAt.toISOString(),
+            conditionHash: m.conditionHash ?? null,
+            released: m.releasedAt !== null,
+          })),
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/:id/schedule",
+    authMiddleware,
+    validateRequest({ params: scheduleParamsSchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const walletAddress = caller(req, res);
+        if (!walletAddress) return;
+
+        const id = String(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
+
+        const trade = await prisma.trade.findFirst({ where: tradeWhere(id) });
+
+        if (!trade) {
+          res.status(404).json({ error: "Trade not found" });
+          return;
+        }
+
+        if (!prisma.escrowReleaseMilestone) {
+          res.status(500).json({ error: "Release schedule store unavailable" });
+          return;
+        }
+
+        const milestones = await prisma.escrowReleaseMilestone.findMany({
+          where: { tradeId: trade.tradeId },
+          orderBy: { milestoneIndex: "asc" },
+        });
+
+        const now = new Date();
+        const nextMilestone = milestones.find((m) => m.dueAt > now && !m.releasedAt);
+
+        res.json({
+          tradeId: trade.tradeId,
+          milestoneCount: milestones.length,
+          nextReleaseDate: nextMilestone ? nextMilestone.dueAt.toISOString() : null,
+          milestones: milestones.map((m) => ({
+            milestoneIndex: m.milestoneIndex,
+            amountUsdc: m.amountUsdc,
+            dueAt: m.dueAt.toISOString(),
+            conditionHash: m.conditionHash ?? null,
+            released: m.releasedAt !== null,
+          })),
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}
+
+export const escrowScheduleRoutes = createEscrowScheduleRouter();

--- a/routes-d/routes/stellar.ledger.ts
+++ b/routes-d/routes/stellar.ledger.ts
@@ -1,0 +1,49 @@
+import { Router, Request, Response } from "express";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+const STELLAR_NETWORK = process.env.STELLAR_NETWORK || "testnet";
+
+const HORIZON_URL =
+  STELLAR_NETWORK === "mainnet"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+
+export function createLedgerRouter(): Router {
+  const router = Router();
+
+  router.get("/ledger/latest", async (_req: Request, res: Response) => {
+    try {
+      const server = new StellarSdk.Horizon.Server(HORIZON_URL);
+
+      const ledgerResponse = await server
+        .ledgers()
+        .order("desc")
+        .limit(1)
+        .call();
+
+      if (!ledgerResponse.records || ledgerResponse.records.length === 0) {
+        res.status(503).json({ error: "No ledger data available" });
+        return;
+      }
+
+      const latest = ledgerResponse.records[0];
+
+      res.json({
+        sequence: latest.sequence,
+        hash: latest.hash,
+        closedAt: latest.closed_at,
+        totalOps: latest.total_operations,
+        protocolVersion: latest.protocol_version,
+        txCount: latest.successful_transaction_count,
+      });
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      res.status(502).json({
+        error: "Failed to fetch latest ledger from Stellar network",
+        details: msg,
+      });
+    }
+  });
+
+  return router;
+}

--- a/routes-d/routes/stellar.trustline.ts
+++ b/routes-d/routes/stellar.trustline.ts
@@ -1,0 +1,156 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+const STELLAR_NETWORK = process.env.STELLAR_NETWORK || "testnet";
+
+const networkPassphrase =
+  STELLAR_NETWORK === "mainnet"
+    ? StellarSdk.Networks.PUBLIC
+    : StellarSdk.Networks.TESTNET;
+
+const AssetSchema = z.object({
+  code: z.string().min(1).max(12),
+  issuer: z.string().regex(/^G[A-Z0-9]{55}$/, "Invalid Stellar public key"),
+});
+
+const AddTrustlineSchema = z.object({
+  sourceAccount: z.string().regex(/^G[A-Z0-9]{55}$/, "Invalid Stellar public key"),
+  asset: AssetSchema,
+  limit: z.string().regex(/^\d+(\.\d+)?$/, "Must be a positive decimal").optional(),
+});
+
+const RemoveTrustlineSchema = z.object({
+  sourceAccount: z.string().regex(/^G[A-Z0-9]{55}$/, "Invalid Stellar public key"),
+  asset: AssetSchema,
+});
+
+export function createTrustlineRouter(): Router {
+  const router = Router();
+
+  router.post("/trustline", async (req: Request, res: Response) => {
+    const parsed = AddTrustlineSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "Validation failed",
+        details: parsed.error.issues,
+      });
+      return;
+    }
+
+    const { sourceAccount, asset, limit } = parsed.data;
+
+    try {
+      const server = new StellarSdk.Horizon.Server(
+        STELLAR_NETWORK === "mainnet"
+          ? "https://horizon.stellar.org"
+          : "https://horizon-testnet.stellar.org"
+      );
+
+      const account = await server.loadAccount(sourceAccount);
+
+      const trustAsset = new StellarSdk.Asset(asset.code, asset.issuer);
+
+      const operation = StellarSdk.Operation.changeTrust({
+        asset: trustAsset,
+        limit: limit ?? undefined,
+      });
+
+      const builder = new StellarSdk.TransactionBuilder(account, {
+        fee: StellarSdk.BASE_FEE,
+        networkPassphrase,
+      });
+
+      builder.addOperation(operation);
+      builder.setTimeout(180);
+
+      const transaction = builder.build();
+
+      res.json({
+        envelopeXDR: transaction.toEnvelope().toXDR().toString("base64"),
+        networkPassphrase,
+      });
+    } catch (error: unknown) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "response" in error &&
+        (error as { response?: { status?: number } }).response?.status === 404
+      ) {
+        res.status(404).json({ error: "Source account not found" });
+        return;
+      }
+
+      const msg = error instanceof Error ? error.message : String(error);
+      res.status(502).json({
+        error: "Failed to build trustline transaction",
+        details: msg,
+      });
+    }
+  });
+
+  router.delete("/trustline", async (req: Request, res: Response) => {
+    const parsed = RemoveTrustlineSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "Validation failed",
+        details: parsed.error.issues,
+      });
+      return;
+    }
+
+    const { sourceAccount, asset } = parsed.data;
+
+    try {
+      const server = new StellarSdk.Horizon.Server(
+        STELLAR_NETWORK === "mainnet"
+          ? "https://horizon.stellar.org"
+          : "https://horizon-testnet.stellar.org"
+      );
+
+      const account = await server.loadAccount(sourceAccount);
+
+      const trustAsset = new StellarSdk.Asset(asset.code, asset.issuer);
+
+      const operation = StellarSdk.Operation.changeTrust({
+        asset: trustAsset,
+        limit: "0",
+      });
+
+      const builder = new StellarSdk.TransactionBuilder(account, {
+        fee: StellarSdk.BASE_FEE,
+        networkPassphrase,
+      });
+
+      builder.addOperation(operation);
+      builder.setTimeout(180);
+
+      const transaction = builder.build();
+
+      res.json({
+        envelopeXDR: transaction.toEnvelope().toXDR().toString("base64"),
+        networkPassphrase,
+      });
+    } catch (error: unknown) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "response" in error &&
+        (error as { response?: { status?: number } }).response?.status === 404
+      ) {
+        res.status(404).json({ error: "Source account not found" });
+        return;
+      }
+
+      const msg = error instanceof Error ? error.message : String(error);
+      res.status(502).json({
+        error: "Failed to build trustline transaction",
+        details: msg,
+      });
+    }
+  });
+
+  return router;
+}

--- a/routes-d/tests/stellar.ledger.test.ts
+++ b/routes-d/tests/stellar.ledger.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+const mockLedgerRecord = {
+  sequence: 123456,
+  hash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  closed_at: "2026-06-26T12:00:00Z",
+  total_operations: 42,
+  protocol_version: 22,
+  successful_transaction_count: 15,
+};
+
+const { mockCall } = vi.hoisted(() => {
+  const mockCall = vi.fn().mockResolvedValue({ records: [mockLedgerRecord] });
+  return { mockCall };
+});
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Horizon: {
+    Server: vi.fn(() => ({
+      ledgers: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      call: mockCall,
+    })),
+  },
+}));
+
+import { createLedgerRouter } from "../routes/stellar.ledger.js";
+
+function createApp() {
+  const app = express();
+  app.use("/stellar", createLedgerRouter());
+  return app;
+}
+
+describe("GET /stellar/ledger/latest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns latest ledger data", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stellar/ledger/latest");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sequence: 123456,
+      hash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      closedAt: "2026-06-26T12:00:00Z",
+      totalOps: 42,
+      protocolVersion: 22,
+      txCount: 15,
+    });
+  });
+
+  it("returns 502 when network error occurs", async () => {
+    mockCall.mockRejectedValueOnce(new Error("Network timeout"));
+
+    const app = createApp();
+    const res = await request(app).get("/stellar/ledger/latest");
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({
+      error: "Failed to fetch latest ledger from Stellar network",
+      details: "Network timeout",
+    });
+  });
+
+  it("returns 503 when no ledgers are available", async () => {
+    mockCall.mockResolvedValueOnce({ records: [] });
+
+    const app = createApp();
+    const res = await request(app).get("/stellar/ledger/latest");
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: "No ledger data available" });
+  });
+});

--- a/routes-d/tests/stellar.trustline.test.ts
+++ b/routes-d/tests/stellar.trustline.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createTrustlineRouter } from "../routes/stellar.trustline.js";
+
+vi.mock("@stellar/stellar-sdk", () => {
+  const mockAccount = {
+    accountId: () => "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    sequenceNumber: () => "1",
+    incrementSequenceNumber: () => {},
+  };
+
+  const mockTransactionBuilder = {
+    addOperation: vi.fn().mockReturnThis(),
+    addMemo: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: () => ({
+      toEnvelope: () => ({
+        toXDR: () => ({
+          toString: () => "bW9ja2VkLXhlci1kYXRh",
+        }),
+      }),
+    }),
+  };
+
+  return {
+    Networks: {
+      PUBLIC: "Public Global Stellar Network ; September 2015",
+      TESTNET: "Test SDF Network ; September 2015",
+    },
+    BASE_FEE: "100",
+    Asset: class MockAsset {
+      constructor(public code: string, public issuer: string) {}
+    },
+    Operation: {
+      changeTrust: vi.fn(({ asset, limit }) => ({
+        type: "changeTrust",
+        asset,
+        limit,
+      })),
+    },
+    TransactionBuilder: vi.fn(() => mockTransactionBuilder),
+    Horizon: {
+      Server: vi.fn(() => ({
+        loadAccount: vi.fn().mockResolvedValue(mockAccount),
+      })),
+    },
+  };
+});
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/stellar", createTrustlineRouter());
+  return app;
+}
+
+describe("POST /stellar/trustline", () => {
+  const VALID_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const VALID_KEY2 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+  const validBody = {
+    sourceAccount: VALID_KEY,
+    asset: { code: "USDC", issuer: VALID_KEY2 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns unsigned envelope for valid add trustline request", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("envelopeXDR");
+    expect(res.body).toHaveProperty("networkPassphrase");
+    expect(typeof res.body.envelopeXDR).toBe("string");
+    expect(res.body.envelopeXDR.length).toBeGreaterThan(0);
+  });
+
+  it("returns unsigned envelope when limit is provided", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send({ ...validBody, limit: "5000" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("envelopeXDR");
+  });
+
+  it("returns 400 for invalid sourceAccount", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send({ ...validBody, sourceAccount: "invalid" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Validation failed");
+    expect(res.body).toHaveProperty("details");
+  });
+
+  it("returns 400 for invalid asset code", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send({ ...validBody, asset: { code: "", issuer: VALID_KEY2 } });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Validation failed");
+  });
+
+  it("returns 400 for invalid asset issuer", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send({ ...validBody, asset: { code: "USDC", issuer: "bad-key" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Validation failed");
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send({ sourceAccount: VALID_KEY });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid limit format", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/stellar/trustline")
+      .send({ ...validBody, limit: "abc" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Validation failed");
+  });
+});
+
+describe("DELETE /stellar/trustline", () => {
+  const VALID_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const VALID_KEY2 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+  const validBody = {
+    sourceAccount: VALID_KEY,
+    asset: { code: "USDC", issuer: VALID_KEY2 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns unsigned envelope for remove trustline request", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .delete("/stellar/trustline")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("envelopeXDR");
+    expect(typeof res.body.envelopeXDR).toBe("string");
+    expect(res.body.envelopeXDR.length).toBeGreaterThan(0);
+  });
+
+  it("returns 400 for invalid sourceAccount", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .delete("/stellar/trustline")
+      .send({ ...validBody, sourceAccount: "invalid" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Validation failed");
+  });
+
+  it("returns 400 for invalid asset", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .delete("/stellar/trustline")
+      .send({ ...validBody, asset: { code: "", issuer: "bad" } });
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Implements three new routes:

### 1. Escrow Release Schedule Route (#712)
- POST `/trades/:id/schedule` - Create release schedule with milestone validation
- GET `/trades/:id/schedule` - Query schedule with next release date
- Zod validation for milestone amounts, intervals, and condition hashes
- Stores schedule using `EscrowReleaseMilestone` Prisma model

### 2. Trustline Management Route (#705)
- POST `/stellar/trustline` - Add/update trustline with optional limit
- DELETE `/stellar/trustline` - Remove trustline
- Validates asset code, issuer, and limit with Zod
- Returns unsigned `changeTrust` envelope for client signing

### 3. Stellar Ledger Info Route (#710)
- GET `/stellar/ledger/latest` - Query Horizon for latest ledger
- Returns `sequence`, `hash`, `closedAt`, `totalOps`, `protocolVersion`, `txCount`

### Additional Changes
- Added `conditionHash` field to `EscrowReleaseMilestone` Prisma model
- Mounted new schedule route in `app.ts`
- All routes include comprehensive test coverage

Closes #705
Closes #710
Closes #712