### PR TITLE
Add escrow upgrade, buyer cancel, contract state route, and service errors

### DIFF
--- a/backend/src/__tests__/contract.state.routes.test.ts
+++ b/backend/src/__tests__/contract.state.routes.test.ts
@@ -1,0 +1,86 @@
+import express from "express";
+import request from "supertest";
+import { errorHandler } from "../middleware/errorHandler";
+import { createContractStateRouter } from "../routes/contract.state.routes";
+import { StellarError } from "../errors/service.errors";
+
+const VALID_CONTRACT_ID = "C".padEnd(56, "A");
+
+function buildApp(stellarService: { getContractTradeState: jest.Mock }) {
+  const app = express();
+  app.use(express.json());
+  app.use("/contract", createContractStateRouter(stellarService as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /contract/:contractId/state", () => {
+  it("returns decoded contract trade state as JSON", async () => {
+    const state = {
+      tradeId: "42",
+      buyer: "GBUYER",
+      seller: "GSELLER",
+      amount: "10000000",
+      status: "Created",
+    };
+    const stellarService = {
+      getContractTradeState: jest.fn().mockResolvedValue(state),
+    };
+
+    const res = await request(buildApp(stellarService))
+      .get(`/contract/${VALID_CONTRACT_ID}/state`)
+      .query({ tradeId: "42" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      contractId: VALID_CONTRACT_ID,
+      tradeId: "42",
+      state,
+    });
+    expect(stellarService.getContractTradeState).toHaveBeenCalledWith(
+      VALID_CONTRACT_ID,
+      "42",
+    );
+  });
+
+  it("returns 404 for invalid contract IDs", async () => {
+    const stellarService = {
+      getContractTradeState: jest.fn().mockRejectedValue(
+        new StellarError({
+          code: "STELLAR_INVALID_CONTRACT_ID",
+          message: "Invalid Soroban contract ID",
+          httpStatus: 404,
+          retryable: false,
+        }),
+      ),
+    };
+
+    const res = await request(buildApp(stellarService))
+      .get("/contract/not-a-contract/state")
+      .query({ tradeId: "42" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("STELLAR_INVALID_CONTRACT_ID");
+  });
+
+  it("returns typed network errors from StellarService", async () => {
+    const stellarService = {
+      getContractTradeState: jest.fn().mockRejectedValue(
+        new StellarError({
+          code: "STELLAR_TIMEOUT",
+          message: "Stellar service timed out",
+          httpStatus: 504,
+          retryable: true,
+        }),
+      ),
+    };
+
+    const res = await request(buildApp(stellarService))
+      .get(`/contract/${VALID_CONTRACT_ID}/state`)
+      .query({ tradeId: "42" });
+
+    expect(res.status).toBe(504);
+    expect(res.body.code).toBe("STELLAR_TIMEOUT");
+    expect(res.body.details.retryable).toBe(true);
+  });
+});

--- a/backend/src/__tests__/service.errors.test.ts
+++ b/backend/src/__tests__/service.errors.test.ts
@@ -1,0 +1,63 @@
+import {
+  CacheError,
+  DatabaseError,
+  IpfsError,
+  StellarError,
+  classifyCacheServiceError,
+  classifyDatabaseServiceError,
+  classifyHorizonResultCode,
+  classifyIpfsServiceError,
+  classifyStellarServiceError,
+} from "../errors/service.errors";
+
+describe("service error classification", () => {
+  it("maps Horizon insufficient balance codes to StellarError", () => {
+    const error = classifyHorizonResultCode("op_underfunded");
+
+    expect(error).toBeInstanceOf(StellarError);
+    expect(error.code).toBe("STELLAR_INSUFFICIENT_BALANCE");
+    expect(error.statusCode).toBe(402);
+    expect(error.retryable).toBe(false);
+  });
+
+  it("maps Stellar not-found errors", () => {
+    const error = classifyStellarServiceError({ response: { status: 404 } });
+
+    expect(error.code).toBe("STELLAR_CONTRACT_NOT_FOUND");
+    expect(error.statusCode).toBe(404);
+    expect(error.retryable).toBe(false);
+  });
+
+  it("maps Prisma unique violations to DatabaseError", () => {
+    const error = classifyDatabaseServiceError({ code: "P2002" });
+
+    expect(error).toBeInstanceOf(DatabaseError);
+    expect(error.code).toBe("DATABASE_UNIQUE_CONSTRAINT");
+    expect(error.statusCode).toBe(409);
+  });
+
+  it("maps IPFS 404 errors to IpfsError", () => {
+    const error = classifyIpfsServiceError({ response: { status: 404 } });
+
+    expect(error).toBeInstanceOf(IpfsError);
+    expect(error.code).toBe("IPFS_NOT_FOUND");
+    expect(error.retryable).toBe(false);
+  });
+
+  it("maps Redis/cache timeouts to CacheError", () => {
+    const error = classifyCacheServiceError(new Error("redis timeout"));
+
+    expect(error).toBeInstanceOf(CacheError);
+    expect(error.code).toBe("CACHE_TIMEOUT");
+    expect(error.retryable).toBe(true);
+  });
+
+  it("falls back to typed unknown service errors", () => {
+    const error = classifyStellarServiceError(new Error("unmodeled provider failure"));
+
+    expect(error).toBeInstanceOf(StellarError);
+    expect(error.code).toBe("STELLAR_UNKNOWN_ERROR");
+    expect(error.statusCode).toBe(502);
+    expect(error.retryable).toBe(true);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -32,6 +32,7 @@ import { stellarTxStatusRoutes } from "./routes/stellar.tx.status";
 import { stellarAssetRoutes } from "./routes/stellar.asset";
 import { stellarAccountBalanceRoutes } from "./routes/stellar.account.balance";
 import { stellarAccountCreateRoutes } from "./routes/stellar.account.create";
+import { createContractStateRouter } from "./routes/contract.state.routes";
 import { webhooksRoutes } from "./routes/webhooks.routes";
 import { env } from "./config/env";
 
@@ -152,6 +153,7 @@ export function createApp(): express.Application {
   app.use("/stellar/assets", stellarAssetRoutes);
   app.use("/stellar/account", stellarAccountCreateRoutes);
   app.use("/stellar/account", stellarAccountBalanceRoutes);
+  app.use("/contract", createContractStateRouter());
 
   // Treasury management
   app.use("/treasury", createTreasuryRouter());

--- a/backend/src/errors/errorCodes.ts
+++ b/backend/src/errors/errorCodes.ts
@@ -34,7 +34,7 @@ export interface StructuredErrorPayload {
 
 export class AppError extends Error {
   constructor(
-    public code: ErrorCode,
+    public code: ErrorCode | string,
     public message: string,
     public statusCode: number = 400,
     public details: Record<string, unknown> = {}

--- a/backend/src/errors/service.errors.ts
+++ b/backend/src/errors/service.errors.ts
@@ -1,0 +1,204 @@
+import { AppError } from "./errorCodes";
+
+export interface ClassifiedServiceErrorOptions {
+  code: string;
+  message: string;
+  httpStatus: number;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export class ClassifiedServiceError extends AppError {
+  public readonly retryable: boolean;
+
+  constructor(
+    public readonly service: "stellar" | "database" | "ipfs" | "cache",
+    options: ClassifiedServiceErrorOptions,
+  ) {
+    super(options.code, options.message, options.httpStatus, {
+      service,
+      retryable: options.retryable,
+      ...(options.details ?? {}),
+    });
+    this.name = this.constructor.name;
+    this.retryable = options.retryable;
+  }
+}
+
+export class StellarError extends ClassifiedServiceError {
+  constructor(options: ClassifiedServiceErrorOptions) {
+    super("stellar", options);
+  }
+}
+
+export class DatabaseError extends ClassifiedServiceError {
+  constructor(options: ClassifiedServiceErrorOptions) {
+    super("database", options);
+  }
+}
+
+export class IpfsError extends ClassifiedServiceError {
+  constructor(options: ClassifiedServiceErrorOptions) {
+    super("ipfs", options);
+  }
+}
+
+export class CacheError extends ClassifiedServiceError {
+  constructor(options: ClassifiedServiceErrorOptions) {
+    super("cache", options);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null) {
+    const shaped = error as { message?: unknown; error?: unknown };
+    if (typeof shaped.message === "string") return shaped.message;
+    if (typeof shaped.error === "string") return shaped.error;
+  }
+  return "Unknown service error";
+}
+
+function responseStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const response = (error as { response?: { status?: unknown } }).response;
+  return typeof response?.status === "number" ? response.status : undefined;
+}
+
+function errorCode(error: unknown): string | number | undefined {
+  return typeof error === "object" && error !== null
+    ? (error as { code?: string | number }).code
+    : undefined;
+}
+
+export function classifyHorizonResultCode(code: string, error?: unknown): StellarError {
+  switch (code) {
+    case "op_underfunded":
+    case "tx_insufficient_balance":
+      return new StellarError({
+        code: "STELLAR_INSUFFICIENT_BALANCE",
+        message: "Stellar account has insufficient balance",
+        httpStatus: 402,
+        retryable: false,
+        details: { horizonCode: code },
+      });
+    case "tx_bad_seq":
+      return new StellarError({
+        code: "STELLAR_BAD_SEQUENCE",
+        message: "Stellar transaction sequence is stale",
+        httpStatus: 409,
+        retryable: true,
+        details: { horizonCode: code },
+      });
+    case "tx_too_late":
+    case "tx_too_early":
+      return new StellarError({
+        code: "STELLAR_TRANSACTION_TIMING",
+        message: "Stellar transaction is outside its valid time bounds",
+        httpStatus: 409,
+        retryable: true,
+        details: { horizonCode: code },
+      });
+    case "op_no_destination":
+    case "op_no_trust":
+      return new StellarError({
+        code: "STELLAR_ACCOUNT_NOT_FOUND",
+        message: "Stellar destination account or trustline was not found",
+        httpStatus: 404,
+        retryable: false,
+        details: { horizonCode: code },
+      });
+    default:
+      return new StellarError({
+        code: "STELLAR_UNKNOWN_ERROR",
+        message: errorMessage(error),
+        httpStatus: 502,
+        retryable: true,
+        details: { horizonCode: code },
+      });
+  }
+}
+
+export function classifyStellarServiceError(error: unknown): StellarError {
+  const status = responseStatus(error);
+  const code = errorCode(error);
+  const message = errorMessage(error);
+
+  if (typeof code === "string" && code.startsWith("tx_")) {
+    return classifyHorizonResultCode(code, error);
+  }
+
+  if (status === 404 || /not found/i.test(message)) {
+    return new StellarError({
+      code: "STELLAR_CONTRACT_NOT_FOUND",
+      message: "Soroban contract data was not found",
+      httpStatus: 404,
+      retryable: false,
+    });
+  }
+
+  if (status === 429 || /rate limit|try_again_later/i.test(message)) {
+    return new StellarError({
+      code: "STELLAR_RATE_LIMITED",
+      message: "Stellar service rate limit exceeded",
+      httpStatus: 429,
+      retryable: true,
+    });
+  }
+
+  if (/timeout|timed out|deadline/i.test(message)) {
+    return new StellarError({
+      code: "STELLAR_TIMEOUT",
+      message: "Stellar service timed out",
+      httpStatus: 504,
+      retryable: true,
+    });
+  }
+
+  return new StellarError({
+    code: "STELLAR_UNKNOWN_ERROR",
+    message,
+    httpStatus: 502,
+    retryable: true,
+  });
+}
+
+export function classifyDatabaseServiceError(error: unknown): DatabaseError {
+  const code = errorCode(error);
+  if (code === "P2002") {
+    return new DatabaseError({
+      code: "DATABASE_UNIQUE_CONSTRAINT",
+      message: "Database unique constraint violated",
+      httpStatus: 409,
+      retryable: false,
+    });
+  }
+
+  return new DatabaseError({
+    code: "DATABASE_UNKNOWN_ERROR",
+    message: errorMessage(error),
+    httpStatus: 500,
+    retryable: false,
+  });
+}
+
+export function classifyIpfsServiceError(error: unknown): IpfsError {
+  const status = responseStatus(error);
+  return new IpfsError({
+    code: status === 404 ? "IPFS_NOT_FOUND" : "IPFS_UNKNOWN_ERROR",
+    message: status === 404 ? "IPFS content was not found" : errorMessage(error),
+    httpStatus: status === 404 ? 404 : 502,
+    retryable: status !== 404,
+  });
+}
+
+export function classifyCacheServiceError(error: unknown): CacheError {
+  const message = errorMessage(error);
+  return new CacheError({
+    code: /timeout|timed out/i.test(message) ? "CACHE_TIMEOUT" : "CACHE_UNKNOWN_ERROR",
+    message,
+    httpStatus: 503,
+    retryable: true,
+  });
+}

--- a/backend/src/routes/contract.state.routes.ts
+++ b/backend/src/routes/contract.state.routes.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, Response, Router } from "express";
+import { AppError, ErrorCode } from "../errors/errorCodes";
+import { StellarService } from "../services/stellar.service";
+
+export function createContractStateRouter(
+  stellarService: Pick<StellarService, "getContractTradeState"> = new StellarService(),
+): Router {
+  const router = Router();
+
+  router.get(
+    "/:contractId/state",
+    async (req: Request, res: Response, next: NextFunction) => {
+      const contractId = String(req.params.contractId ?? "");
+      const tradeId = String(req.query.tradeId ?? "");
+
+      if (!tradeId) {
+        return next(
+          new AppError(
+            ErrorCode.VALIDATION_ERROR,
+            "tradeId query parameter is required",
+            400,
+          ),
+        );
+      }
+
+      try {
+        const state = await stellarService.getContractTradeState(contractId, tradeId);
+        res.json({ contractId, tradeId, state });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/backend/src/services/stellar.service.ts
+++ b/backend/src/services/stellar.service.ts
@@ -1,4 +1,4 @@
-import { Horizon, rpc, TransactionBuilder, BASE_FEE, StrKey, xdr } from '@stellar/stellar-sdk';
+import { Horizon, rpc, TransactionBuilder, BASE_FEE, StrKey, xdr, scValToNative } from '@stellar/stellar-sdk';
 import { 
   horizonServer, 
   sorobanRpcClient, 
@@ -13,6 +13,10 @@ import {
   classifySubmissionError,
   recordTransactionSubmission,
 } from "../lib/metrics";
+import {
+  classifyStellarServiceError,
+  StellarError,
+} from "../errors/service.errors";
 
 export type StellarErrorCategory =
   | "timeout"
@@ -28,6 +32,23 @@ export interface ClassifiedStellarError {
   category: StellarErrorCategory;
   message: string;
   isRetryable: boolean;
+}
+
+export interface ContractTradeState {
+  tradeId?: string;
+  buyer?: string;
+  seller?: string;
+  token?: string;
+  amount?: string;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  fundedAt?: string | null;
+  deliveredAt?: string | null;
+  buyerLossBps?: number;
+  sellerLossBps?: number;
+  expiresAt?: string | null;
+  [key: string]: unknown;
 }
 
 export function classifyStellarError(error: unknown): ClassifiedStellarError {
@@ -77,6 +98,97 @@ export function classifyStellarError(error: unknown): ClassifiedStellarError {
   return { category: "network_error", message: `Stellar network error: ${msg}`, isRetryable: true };
 }
 
+function isValidSorobanContractId(contractId: string): boolean {
+  return /^C[A-Z2-7]{55}$/.test(contractId);
+}
+
+function normalizeTradeState(value: unknown): ContractTradeState {
+  if (value instanceof Map) {
+    return normalizeTradeMap(value);
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return normalizeTradeObject(value as Record<string, unknown>);
+  }
+
+  return { value: normalizeScValue(value) };
+}
+
+function normalizeTradeMap(value: Map<unknown, unknown>): ContractTradeState {
+  const raw: Record<string, unknown> = {};
+  for (const [key, mapValue] of value.entries()) {
+    raw[String(key)] = mapValue;
+  }
+  return normalizeTradeObject(raw);
+}
+
+function normalizeTradeObject(value: Record<string, unknown>): ContractTradeState {
+  const aliases: Record<string, string> = {
+    amount: "amount",
+    buyer: "buyer",
+    buyer_loss_bps: "buyerLossBps",
+    created_at: "createdAt",
+    delivered_at: "deliveredAt",
+    expires_at: "expiresAt",
+    funded_at: "fundedAt",
+    seller: "seller",
+    seller_loss_bps: "sellerLossBps",
+    status: "status",
+    token: "token",
+    trade_id: "tradeId",
+    updated_at: "updatedAt",
+  };
+
+  return Object.entries(value).reduce<ContractTradeState>((state, [key, raw]) => {
+    state[aliases[key] ?? key] = normalizeScValue(raw);
+    return state;
+  }, {});
+}
+
+function normalizeScValue(value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Map) return normalizeTradeMap(value);
+  if (Array.isArray(value)) return value.map(normalizeScValue);
+  if (typeof value === "object" && value !== null) {
+    if ("toString" in value && value.constructor?.name === "Address") {
+      return String(value);
+    }
+
+    return Object.entries(value as Record<string, unknown>).reduce<Record<string, unknown>>(
+      (record, [key, raw]) => {
+        record[key] = normalizeScValue(raw);
+        return record;
+      },
+      {},
+    );
+  }
+  return value;
+}
+
+function extractContractDataScVal(entry: unknown): xdr.ScVal | undefined {
+  const maybeEntry = entry as {
+    val?: unknown;
+    xdr?: unknown;
+  };
+
+  if (typeof maybeEntry.val === "function") {
+    const ledgerEntryData = (maybeEntry.val as () => unknown)() as {
+      contractData?: () => { val: () => xdr.ScVal };
+    };
+    return ledgerEntryData.contractData?.().val();
+  }
+
+  if (maybeEntry.val instanceof xdr.ScVal) {
+    return maybeEntry.val;
+  }
+
+  if (typeof maybeEntry.xdr === "string") {
+    return xdr.LedgerEntryData.fromXDR(maybeEntry.xdr, "base64").contractData().val();
+  }
+
+  return undefined;
+}
+
 export class StellarService {
   private horizonServer: Horizon.Server;
   private sorobanRpc: rpc.Server;
@@ -104,6 +216,56 @@ export class StellarService {
 
   public getPaymentCircuitBreakerState(): string {
     return this.paymentCircuitBreaker.getState();
+  }
+
+  public async getContractTradeState(
+    contractId: string,
+    tradeId: string,
+  ): Promise<ContractTradeState> {
+    if (!isValidSorobanContractId(contractId)) {
+      throw new StellarError({
+        code: "STELLAR_INVALID_CONTRACT_ID",
+        message: "Invalid Soroban contract ID",
+        httpStatus: 404,
+        retryable: false,
+      });
+    }
+
+    if (!/^\d+$/.test(tradeId)) {
+      throw new StellarError({
+        code: "STELLAR_INVALID_TRADE_ID",
+        message: "Invalid trade ID",
+        httpStatus: 400,
+        retryable: false,
+      });
+    }
+
+    const tradeKey = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol("Trade"),
+      xdr.ScVal.scvU64(xdr.Uint64.fromString(tradeId)),
+    ]);
+
+    try {
+      const entry = await this.sorobanRpc.getContractData(
+        contractId,
+        tradeKey,
+        rpc.Durability.Persistent,
+      );
+      const scVal = extractContractDataScVal(entry);
+      if (!scVal) {
+        throw new StellarError({
+          code: "STELLAR_CONTRACT_DATA_NOT_FOUND",
+          message: "Soroban contract trade state was not found",
+          httpStatus: 404,
+          retryable: false,
+        });
+      }
+
+      return normalizeTradeState(scValToNative(scVal));
+    } catch (error) {
+      if (error instanceof StellarError) throw error;
+      throw classifyStellarServiceError(error);
+    }
   }
 
 public async getAccountBalance(publicKey: string, assetCode: string = TOKEN_CONFIG.symbol): Promise<string> {

--- a/contracts/amana_escrow/Cargo.toml
+++ b/contracts/amana_escrow/Cargo.toml
@@ -54,3 +54,11 @@ path = "tests/input_hardening_tests.rs"
 [[test]]
 name = "schema_version_tests"
 path = "tests/schema_version_tests.rs"
+
+[[test]]
+name = "buyer_cancel_tests"
+path = "tests/buyer_cancel_tests.rs"
+
+[[test]]
+name = "upgrade_tests"
+path = "tests/upgrade_tests.rs"

--- a/contracts/amana_escrow/src/lib.rs
+++ b/contracts/amana_escrow/src/lib.rs
@@ -3,8 +3,8 @@
 #[cfg(test)]
 mod tests;
 use soroban_sdk::{
-    Address, Bytes, Env, String, Symbol, Vec, contract, contractevent, contractimpl, contracttype,
-    symbol_short, token,
+    Address, Bytes, BytesN, Env, String, Symbol, Vec, contract, contractevent, contractimpl,
+    contracttype, symbol_short, token,
 };
 
 // ---------------------------------------------------------------------------
@@ -80,6 +80,20 @@ pub struct TradeCancelledEvent {
     pub trade_id: u64,
     pub refund_amount: i128,
     pub caller: Address,
+}
+
+#[contractevent(topics = ["TCNBYR"])]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TradeCancelledByBuyerEvent {
+    pub trade_id: u64,
+    pub buyer: Address,
+}
+
+#[contractevent(topics = ["UPGRAD"])]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContractUpgradedEvent {
+    pub admin: Address,
+    pub new_wasm_hash: BytesN<32>,
 }
 
 #[contractevent(topics = ["DELCNF"])]
@@ -497,6 +511,28 @@ impl EscrowContract {
             .unwrap_or(CURRENT_SCHEMA_VERSION)
     }
 
+    /// Upgrade this contract instance to a previously installed WASM hash.
+    ///
+    /// Only the admin may call this. Soroban preserves instance and persistent
+    /// storage across `update_current_contract_wasm`, so existing trade state
+    /// remains available to the upgraded code.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        ContractUpgradedEvent {
+            admin,
+            new_wasm_hash,
+        }
+        .publish(&env);
+        Self::bump_instance_ttl(&env);
+    }
+
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
@@ -880,6 +916,39 @@ impl EscrowContract {
         } else {
             panic!("Cannot cancel trade in current status");
         }
+    }
+
+    /// Allow the buyer to cancel a trade before funds are deposited.
+    ///
+    /// This is intentionally narrower than `cancel_trade`: only the buyer may
+    /// call it and only while the trade is still `Created`.
+    pub fn cancel_by_buyer(env: Env, trade_id: u64) {
+        let key = DataKey::Trade(trade_id);
+        let mut trade: Trade = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Trade not found");
+
+        trade.buyer.require_auth();
+        assert!(
+            matches!(trade.status, TradeStatus::Created),
+            "Trade must be in Created status"
+        );
+
+        trade.status = TradeStatus::Cancelled;
+        trade.updated_at = env.ledger().timestamp();
+        env.storage().persistent().set(&key, &trade);
+        Self::update_release_sequence(&env, &trade, |sequence, at| {
+            sequence.cancelled_at = Some(at);
+        });
+
+        TradeCancelledByBuyerEvent {
+            trade_id,
+            buyer: trade.buyer,
+        }
+        .publish(&env);
+        Self::bump_instance_ttl(&env);
     }
 
     /// Unilaterally refund a funded or delivered trade.

--- a/contracts/amana_escrow/tests/buyer_cancel_tests.rs
+++ b/contracts/amana_escrow/tests/buyer_cancel_tests.rs
@@ -1,0 +1,124 @@
+extern crate std;
+
+use amana_escrow::{EscrowContract, EscrowContractClient, TradeStatus};
+use soroban_sdk::{
+    Address, Env, IntoVal, Val, symbol_short,
+    testutils::{Address as _, Events as _},
+    token,
+    xdr::ContractEventBody,
+};
+
+struct Harness {
+    env: Env,
+    contract_id: Address,
+    usdc_id: Address,
+    buyer: Address,
+    seller: Address,
+    stranger: Address,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let usdc_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register(EscrowContract, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &usdc_id, &treasury, &100u32, &usdc_id);
+
+        Self {
+            env,
+            contract_id,
+            usdc_id,
+            buyer,
+            seller,
+            stranger,
+        }
+    }
+
+    fn client(&self) -> EscrowContractClient<'_> {
+        EscrowContractClient::new(&self.env, &self.contract_id)
+    }
+
+    fn create_trade(&self) -> u64 {
+        self.client().create_trade(
+            &self.buyer,
+            &self.seller,
+            &1_000i128,
+            &5000u32,
+            &5000u32,
+            &None,
+        )
+    }
+
+    fn mint(&self, to: &Address, amount: i128) {
+        token::StellarAssetClient::new(&self.env, &self.usdc_id).mint(to, &amount);
+    }
+}
+
+#[test]
+fn cancel_by_buyer_cancels_created_trade_and_emits_event() {
+    let h = Harness::new();
+    let trade_id = h.create_trade();
+
+    h.client().cancel_by_buyer(&trade_id);
+
+    let trade = h.client().get_trade(&trade_id);
+    assert!(matches!(trade.status, TradeStatus::Cancelled));
+
+    let events = h.env.events().all().events();
+    let event = events.last().expect("cancel event should be emitted");
+    match &event.body {
+        ContractEventBody::V0(v0) => {
+            assert_eq!(
+                v0.topics.get(0).unwrap(),
+                symbol_short!("TCNBYR").into_val(&h.env)
+            );
+            match &v0.data {
+                soroban_sdk::xdr::ScVal::Vec(Some(payload)) => assert_eq!(payload.len(), 2),
+                soroban_sdk::xdr::ScVal::Map(Some(payload)) => assert_eq!(payload.len(), 2),
+                other => panic!("expected vec or map event payload, got {other:?}"),
+            }
+        },
+    }
+}
+
+#[test]
+#[should_panic(expected = "Trade must be in Created status")]
+fn cancel_by_buyer_rejects_funded_trade() {
+    let h = Harness::new();
+    let trade_id = h.create_trade();
+    h.mint(&h.buyer, 1_000);
+    h.client().deposit(&trade_id);
+
+    h.client().cancel_by_buyer(&trade_id);
+}
+
+#[test]
+#[should_panic]
+fn cancel_by_buyer_rejects_non_buyer_auth() {
+    let h = Harness::new();
+    let trade_id = h.create_trade();
+
+    h.client()
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &h.stranger,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &h.contract_id,
+                fn_name: "cancel_by_buyer",
+                args: soroban_sdk::vec![
+                    &h.env,
+                    IntoVal::<Env, Val>::into_val(&trade_id, &h.env),
+                ],
+                sub_invokes: &[],
+            },
+        }])
+        .cancel_by_buyer(&trade_id);
+}

--- a/contracts/amana_escrow/tests/upgrade_tests.rs
+++ b/contracts/amana_escrow/tests/upgrade_tests.rs
@@ -1,0 +1,83 @@
+extern crate std;
+
+use amana_escrow::{EscrowContract, EscrowContractClient, TradeStatus};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Val, testutils::Address as _};
+
+struct Harness {
+    env: Env,
+    contract_id: Address,
+    buyer: Address,
+    seller: Address,
+    stranger: Address,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register(EscrowContract, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &token_id, &treasury, &100u32, &token_id);
+
+        Self {
+            env,
+            contract_id,
+            buyer,
+            seller,
+            stranger,
+        }
+    }
+
+    fn client(&self) -> EscrowContractClient<'_> {
+        EscrowContractClient::new(&self.env, &self.contract_id)
+    }
+}
+
+#[test]
+#[should_panic]
+fn upgrade_rejects_non_admin_auth() {
+    let h = Harness::new();
+    let new_wasm_hash = BytesN::from_array(&h.env, &[7; 32]);
+
+    h.client()
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &h.stranger,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &h.contract_id,
+                fn_name: "upgrade",
+                args: soroban_sdk::vec![
+                    &h.env,
+                    IntoVal::<Env, Val>::into_val(&new_wasm_hash, &h.env),
+                ],
+                sub_invokes: &[],
+            },
+        }])
+        .upgrade(&new_wasm_hash);
+}
+
+#[test]
+fn test_env_re_registration_preserves_trade_state_for_upgrade_compatibility() {
+    let h = Harness::new();
+    let trade_id = h.client().create_trade(
+        &h.buyer,
+        &h.seller,
+        &1_000i128,
+        &5000u32,
+        &5000u32,
+        &None,
+    );
+
+    h.env.register_at(&h.contract_id, EscrowContract, ());
+
+    let trade = h.client().get_trade(&trade_id);
+    assert_eq!(trade.trade_id, trade_id);
+    assert!(matches!(trade.status, TradeStatus::Created));
+}


### PR DESCRIPTION
## Summary
- Add admin-only Soroban contract upgrade support and upgrade-related events/tests
- Add buyer-only pre-funding trade cancellation with dedicated event/tests
- Add contract state query route backed by StellarService getContractData decoding
- Add centralized typed service error classes and mappings for Stellar, database, IPFS, and cache failures

## Tests
- npm test -- --runTestsByPath src/__tests__/contract.state.routes.test.ts src/__tests__/service.errors.test.ts --coverage=false
- npm run build *(blocked by existing src/services/health.service.ts processedLedger Prisma typing error)*
- cargo test --manifest-path contracts/amana_escrow/Cargo.toml buyer_cancel_tests -- --nocapture *(blocked: cargo is not installed in this environment)*

Closes #738
Closes #741
Closes #744
Closes #749