### PR TITLE
feat: add body-hash 409 to idempotency middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5961,14 +5961,14 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5982,14 +5982,14 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -6001,7 +6001,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -9409,6 +9409,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12309,7 +12310,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/backend/src/__tests__/idempotency.middleware.test.ts
+++ b/backend/src/__tests__/idempotency.middleware.test.ts
@@ -288,6 +288,36 @@ describe("idempotencyMiddleware", () => {
     expect(headers2["X-Idempotency-Cache"]).toBe("HIT");
   });
 
+  it("returns 409 when same key is reused with a different request body", async () => {
+    const crypto = await import("crypto");
+    const originalBodyHash = crypto
+      .createHash("sha256")
+      .update(JSON.stringify({ amount: 100 }))
+      .digest("hex");
+
+    redisMock.get.mockResolvedValueOnce(
+      JSON.stringify({
+        status: 201,
+        body: { tradeId: "t-original" },
+        headers: {},
+        requestBodyHash: originalBodyHash,
+      }) as any,
+    );
+
+    // Request with a different body but the same idempotency key
+    const req = createReq({ body: { amount: 999 } } as any);
+    const { res } = createRes();
+    const next = jest.fn();
+
+    await idempotencyMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect((res as any).body).toMatchObject({
+      error: expect.stringContaining("different request body"),
+    });
+  });
+
   it("continues request flow when Redis storage fails", async () => {
     redisMock.get.mockRejectedValueOnce(new Error("redis down") as any);
 

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -1,7 +1,13 @@
+import { createHash } from "crypto";
 import { Request, Response, NextFunction } from "express";
 import { redis } from "../lib/redis";
 import { appLogger } from "./logger";
 import { alertService } from "../services/alert.service";
+
+function bodyHash(body: unknown): string {
+  const normalized = JSON.stringify(body ?? null);
+  return createHash("sha256").update(normalized).digest("hex");
+}
 
 const IDEMPOTENCY_TTL = 60 * 60 * 24; // 24 hours
 const IDEMPOTENCY_LOCK_TTL = 30; // 30 seconds
@@ -50,14 +56,21 @@ export const idempotencyMiddleware = async (
 
     if (cachedResponse) {
       appLogger.info({ key, path: req.path }, "Idempotency cache hit");
-      const { status, body, headers } = JSON.parse(cachedResponse);
-      
+      const { status, body, headers, requestBodyHash } = JSON.parse(cachedResponse);
+
+      // 409 if same key but different request body
+      if (requestBodyHash !== undefined && requestBodyHash !== bodyHash(req.body)) {
+        return res.status(409).json({
+          error: "Idempotency key already used with a different request body",
+        });
+      }
+
       // Set cached headers
       Object.entries(headers).forEach(([k, v]) => {
         res.setHeader(k, v as string);
       });
       res.setHeader("X-Idempotency-Cache", "HIT");
-      
+
       return res.status(status).json(body);
     }
 
@@ -107,6 +120,7 @@ export const idempotencyMiddleware = async (
           status: res.statusCode,
           body,
           headers: res.getHeaders(),
+          requestBodyHash: bodyHash(req.body),
         };
         redis.set(cacheKey, JSON.stringify(responseData), "EX", IDEMPOTENCY_TTL)
           .catch(err => appLogger.error({ err }, "Failed to cache idempotent response"));


### PR DESCRIPTION
## Summary
- Stores SHA-256 of request body alongside the cached idempotency response
- Returns HTTP 409 when the same `Idempotency-Key` is reused with a different request body
- Adds one new test for the conflicting-body case (total: 9 middleware tests pass)

## Test plan
- [ ] `npx jest idempotency.middleware --no-coverage` — 9 tests pass

Closes #733