### PR TITLE
feat: add GET /health/detail route with per-service latency

### DIFF
--- a/backend/src/__tests__/health.detail.routes.test.ts
+++ b/backend/src/__tests__/health.detail.routes.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createHealthDetailRouter } from "../routes/health.detail.routes";
+import { HealthService } from "../services/health.service";
+
+vi.mock("../services/health.service");
+vi.mock("../middleware/logger", () => ({ appLogger: { info: vi.fn(), error: vi.fn() } }));
+
+const upCheck = (latency = 5) => ({ status: "up" as const, message: "ok", responseTime: latency });
+const downCheck = (msg = "timeout") => ({ status: "down" as const, message: msg, responseTime: 5000 });
+
+function makeHealthResult(overrides: Partial<{ status: "healthy" | "degraded" | "unhealthy"; checks: object }> = {}) {
+    return {
+        status: "healthy" as const,
+        timestamp: new Date().toISOString(),
+        uptime: 100,
+        checks: {
+            database: upCheck(),
+            indexer: upCheck(),
+            stellar: upCheck(),
+            ipfs: upCheck(),
+            redis: upCheck(),
+            config: upCheck(),
+        },
+        details: {},
+        ...overrides,
+    };
+}
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    app.use("/health", createHealthDetailRouter());
+    return app;
+}
+
+describe("GET /health/detail (#729)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns 200 with per-service status and latency when all healthy", async () => {
+        vi.mocked(HealthService.prototype.performHealthCheck).mockResolvedValue(makeHealthResult());
+
+        const res = await request(buildApp()).get("/health/detail");
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe("healthy");
+        expect(res.body.checks.database).toMatchObject({ status: "up", latency: expect.any(Number) });
+        expect(res.body.checks.redis).toMatchObject({ status: "up", latency: expect.any(Number) });
+    });
+
+    it("returns 200 with degraded status when one service is down", async () => {
+        vi.mocked(HealthService.prototype.performHealthCheck).mockResolvedValue(
+            makeHealthResult({
+                status: "degraded",
+                checks: {
+                    database: upCheck(),
+                    indexer: downCheck("connection refused"),
+                    stellar: upCheck(),
+                    ipfs: upCheck(),
+                    redis: upCheck(),
+                    config: upCheck(),
+                },
+            })
+        );
+
+        const res = await request(buildApp()).get("/health/detail");
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe("degraded");
+        expect(res.body.checks.indexer.status).toBe("down");
+        expect(res.body.checks.indexer.error).toBe("connection refused");
+    });
+
+    it("returns 503 when all services are down (unhealthy)", async () => {
+        vi.mocked(HealthService.prototype.performHealthCheck).mockResolvedValue(
+            makeHealthResult({
+                status: "unhealthy",
+                checks: {
+                    database: downCheck("DB unreachable"),
+                    indexer: downCheck(),
+                    stellar: downCheck(),
+                    ipfs: downCheck(),
+                    redis: downCheck(),
+                    config: downCheck(),
+                },
+            })
+        );
+
+        const res = await request(buildApp()).get("/health/detail");
+
+        expect(res.status).toBe(503);
+        expect(res.body.status).toBe("unhealthy");
+    });
+
+    it("does not include error field for healthy services", async () => {
+        vi.mocked(HealthService.prototype.performHealthCheck).mockResolvedValue(makeHealthResult());
+
+        const res = await request(buildApp()).get("/health/detail");
+
+        expect(res.body.checks.database.error).toBeUndefined();
+    });
+
+    it("returns 503 with error field when performHealthCheck throws", async () => {
+        vi.mocked(HealthService.prototype.performHealthCheck).mockRejectedValue(new Error("unexpected"));
+
+        const res = await request(buildApp()).get("/health/detail");
+
+        expect(res.status).toBe(503);
+        expect(res.body.status).toBe("down");
+        expect(res.body.error).toBeDefined();
+    });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,6 +21,7 @@ import { createEvidenceRouter } from "./routes/evidence.routes";
 import { createAuditTrailRouter } from "./routes/auditTrail.routes";
 import { createGoalsRouter } from "./routes/goals.routes";
 import { createHealthRouter } from "./routes/health.routes";
+import { createHealthDetailRouter } from "./routes/health.detail.routes";
 import { createNotificationPreferencesRouter } from "./routes/notifications.preferences.routes";
 import { createNotificationsRouter } from "./routes/notifications.inapp.routes";
 import { disputeRoutes } from "./routes/dispute.routes";
@@ -113,6 +114,7 @@ export function createApp(): express.Application {
 
   // Enhanced health check with deep introspection
   app.use("/health", createHealthRouter());
+  app.use("/health", createHealthDetailRouter());
 
   app.use("/auth", authRoutes);
   app.use("/wallet", walletRoutes);

--- a/backend/src/routes/health.detail.routes.ts
+++ b/backend/src/routes/health.detail.routes.ts
@@ -1,0 +1,55 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { HealthService } from "../services/health.service";
+import { appLogger } from "../middleware/logger";
+
+/**
+ * GET /health/detail
+ *
+ * Returns per-service health with latency for every external dependency.
+ * A single service failure degrades (not crashes) the endpoint.
+ * HTTP 200 → healthy/degraded, HTTP 503 → all-down or unhandled error.
+ */
+export function createHealthDetailRouter(): Router {
+    const router = Router();
+    const healthService = new HealthService();
+
+    router.get("/detail", async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const result = await healthService.performHealthCheck();
+
+            appLogger.info(
+                { status: result.status, checks: result.checks },
+                "Health detail check performed"
+            );
+
+            // Respond 503 only when fully down — degraded is still 200
+            const statusCode = result.status === "unhealthy" ? 503 : 200;
+
+            res.status(statusCode).json({
+                status: result.status,
+                timestamp: new Date().toISOString(),
+                checks: Object.fromEntries(
+                    Object.entries(result.checks).map(([service, check]) => [
+                        service,
+                        {
+                            status: check.status,
+                            latency: check.responseTime,
+                            ...(check.status === "down" && check.message
+                                ? { error: check.message }
+                                : {}),
+                        },
+                    ])
+                ),
+            });
+        } catch (error) {
+            appLogger.error({ error }, "Health detail check failed");
+            res.status(503).json({
+                status: "down",
+                timestamp: new Date().toISOString(),
+                error: "Health detail check failed",
+            });
+        }
+    });
+
+    return router;
+}


### PR DESCRIPTION
## Summary
- Adds `GET /health/detail` endpoint returning per-service status, latency, and error for unhealthy services
- Returns HTTP 200 for healthy/degraded, 503 for unhealthy
- 5 Vitest integration tests covering all states

Closes #729