### PR TITLE
Feature/issue 737 748

### DIFF
--- a/backend/src/__tests__/request.logger.middleware.test.ts
+++ b/backend/src/__tests__/request.logger.middleware.test.ts
@@ -1,0 +1,198 @@
+import request from "supertest";
+import express, { Request, Response } from "express";
+import { correlationIdMiddleware, TracedRequest } from "../middleware/correlationId.middleware";
+import { requestLoggerMiddleware } from "../middleware/request.logger.middleware";
+import { appLogger } from "../middleware/logger";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeApp(statusCode = 200) {
+  const app = express();
+  app.use(correlationIdMiddleware);
+  app.use(requestLoggerMiddleware);
+  app.get("/test", (_req: Request, res: Response) => res.status(statusCode).json({ ok: true }));
+  app.get("/user-test", (req: Request, res: Response) => {
+    (req as any).user = { id: "user-123" };
+    res.status(statusCode).json({ ok: true });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Log shape
+// ---------------------------------------------------------------------------
+
+describe("requestLoggerMiddleware – log shape", () => {
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(appLogger, "info").mockImplementation(() => appLogger);
+    warnSpy = jest.spyOn(appLogger, "warn").mockImplementation(() => appLogger);
+    errorSpy = jest.spyOn(appLogger, "error").mockImplementation(() => appLogger);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("logs method, path, status, durationMs for a 200 response", async () => {
+    const app = makeApp(200);
+    await request(app).get("/test");
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [fields] = infoSpy.mock.calls[0];
+    expect(fields).toMatchObject({
+      method: "GET",
+      path: "/test",
+      status: 200,
+    });
+    expect(typeof fields.durationMs).toBe("number");
+  });
+
+  it("includes correlationId in the log entry", async () => {
+    const app = makeApp(200);
+    const correlationId = "test-correlation-id";
+    await request(app).get("/test").set("x-correlation-id", correlationId);
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [fields] = infoSpy.mock.calls[0];
+    expect(fields.correlationId).toBe(correlationId);
+  });
+
+  it("includes userAgent in the log entry", async () => {
+    const app = makeApp(200);
+    await request(app).get("/test").set("user-agent", "test-agent/1.0");
+
+    const [fields] = infoSpy.mock.calls[0];
+    expect(fields.userAgent).toBe("test-agent/1.0");
+  });
+
+  it("includes ip in the log entry", async () => {
+    const app = makeApp(200);
+    await request(app).get("/test");
+
+    const [fields] = infoSpy.mock.calls[0];
+    expect("ip" in fields).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Log level selection
+// ---------------------------------------------------------------------------
+
+describe("requestLoggerMiddleware – log level", () => {
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(appLogger, "info").mockImplementation(() => appLogger);
+    warnSpy = jest.spyOn(appLogger, "warn").mockImplementation(() => appLogger);
+    errorSpy = jest.spyOn(appLogger, "error").mockImplementation(() => appLogger);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses info level for 2xx", async () => {
+    const app = makeApp(200);
+    await request(app).get("/test");
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses info level for 3xx", async () => {
+    const app = express();
+    app.use(correlationIdMiddleware);
+    app.use(requestLoggerMiddleware);
+    app.get("/redir", (_req, res) => res.redirect("/test"));
+    await request(app).get("/redir");
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses warn level for 4xx", async () => {
+    const app = makeApp(404);
+    await request(app).get("/test");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses error level for 5xx", async () => {
+    const app = makeApp(500);
+    await request(app).get("/test");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// X-Request-Id response header
+// ---------------------------------------------------------------------------
+
+describe("requestLoggerMiddleware – X-Request-Id header", () => {
+  it("attaches X-Request-Id to the response", async () => {
+    const app = makeApp(200);
+    const res = await request(app).get("/test");
+    expect(res.headers["x-request-id"]).toBeDefined();
+  });
+
+  it("X-Request-Id is a valid UUID", async () => {
+    const app = makeApp(200);
+    const res = await request(app).get("/test");
+    expect(res.headers["x-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("matches the x-request-id response header set by correlationIdMiddleware", async () => {
+    const app = makeApp(200);
+    const res = await request(app).get("/test");
+    // Both correlationId middleware and requestLogger set x-request-id; they must agree.
+    expect(res.headers["x-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Correlation ID propagation
+// ---------------------------------------------------------------------------
+
+describe("requestLoggerMiddleware – correlation ID propagation", () => {
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(appLogger, "info").mockImplementation(() => appLogger);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("propagates caller-supplied correlation ID into log fields", async () => {
+    const app = makeApp(200);
+    const id = "caller-abc-123";
+    await request(app).get("/test").set("x-correlation-id", id);
+
+    const [fields] = infoSpy.mock.calls[0];
+    expect(fields.correlationId).toBe(id);
+  });
+
+  it("generates a correlation ID when caller does not supply one", async () => {
+    const app = makeApp(200);
+    await request(app).get("/test");
+
+    const [fields] = infoSpy.mock.calls[0];
+    expect(fields.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import { correlationIdMiddleware } from './middleware/correlationId.middleware';
 import { tracingMiddleware } from './middleware/tracing.middleware';
 import loggerMiddleware, { appLogger } from './middleware/logger';
 import { requestIdMiddleware } from "./middleware/requestId";
+import { requestLoggerMiddleware } from "./middleware/request.logger.middleware";
 import { authRoutes } from "./routes/auth.routes";
 import { walletRoutes } from "./routes/wallet.routes";
 import { createTradeRouter } from "./routes/trade.routes";
@@ -112,6 +113,8 @@ export function createApp(): express.Application {
   // OpenTelemetry tracing middleware - integrates with correlation IDs
   app.use(tracingMiddleware);
   app.use(loggerMiddleware);
+  // Structured per-request logger: method, path, status, durationMs, correlationId, userId, userAgent, ip
+  app.use(requestLoggerMiddleware);
 
   // Enhanced health check with deep introspection
   app.use("/health", createHealthRouter());

--- a/backend/src/middleware/request.logger.middleware.ts
+++ b/backend/src/middleware/request.logger.middleware.ts
@@ -1,0 +1,56 @@
+import { NextFunction, Request, Response } from "express";
+import { appLogger } from "./logger";
+import { TracedRequest } from "./correlationId.middleware";
+
+/**
+ * Structured request logging middleware.
+ *
+ * Logs every request with consistent fields:
+ *   method, path, status, durationMs, correlationId, userId, userAgent, ip
+ *
+ * Log level:
+ *   info  → 2xx / 3xx
+ *   warn  → 4xx
+ *   error → 5xx
+ *
+ * Also attaches X-Request-Id to the response for client-side tracing.
+ */
+export function requestLoggerMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const start = Date.now();
+  const traced = req as TracedRequest;
+
+  // Propagate the server-generated request ID to the client.
+  if (traced.requestId) {
+    res.setHeader("X-Request-Id", traced.requestId);
+  }
+
+  res.on("finish", () => {
+    const durationMs = Date.now() - start;
+    const status = res.statusCode;
+
+    const logFields = {
+      method: req.method,
+      path: req.path,
+      status,
+      durationMs,
+      correlationId: traced.correlationId,
+      userId: (req as any).user?.id ?? (req as any).userId ?? undefined,
+      userAgent: req.get("user-agent"),
+      ip: req.ip,
+    };
+
+    if (status >= 500) {
+      appLogger.error(logFields, "request completed");
+    } else if (status >= 400) {
+      appLogger.warn(logFields, "request completed");
+    } else {
+      appLogger.info(logFields, "request completed");
+    }
+  });
+
+  next();
+}

--- a/contracts/amana_escrow/src/lib.rs
+++ b/contracts/amana_escrow/src/lib.rs
@@ -61,6 +61,7 @@ fn checked_loss_amount(total: i128, loss_bps: i128, seller_loss_bps: u32) -> i12
 pub struct InitializedEvent {
     pub admin: Address,
     pub fee_bps: u32,
+    pub timestamp: u64,
 }
 
 #[contractevent(topics = ["TRDCRT"])]
@@ -85,6 +86,7 @@ pub struct TradeCancelledEvent {
     pub trade_id: u64,
     pub refund_amount: i128,
     pub caller: Address,
+    pub timestamp: u64,
 }
 
 #[contractevent(topics = ["TCNBYR"])]
@@ -159,6 +161,7 @@ pub struct VideoProofSubmittedEvent {
     pub trade_id: u64,
     pub submitter: Address,
     pub ipfs_cid: String,
+    pub timestamp: u64,
 }
 
 /// Emitted when a trade's expiry deadline is reached and a refund is claimed.
@@ -178,6 +181,7 @@ pub struct ManifestSubmittedEvent {
     pub seller: Address,
     pub driver_name_hash: String,
     pub driver_id_hash: String,
+    pub timestamp: u64,
 }
 
 /// Emitted when a mediator address is added to the registry by the admin.
@@ -455,7 +459,7 @@ impl EscrowContract {
             .instance()
             .set(&DataKey::SchemaVersion, &CURRENT_SCHEMA_VERSION);
         Self::bump_instance_ttl(&env);
-        InitializedEvent { admin, fee_bps }.publish(&env);
+        InitializedEvent { admin, fee_bps, timestamp: env.ledger().timestamp() }.publish(&env);
     }
 
     /// Register a single legacy mediator address. Only the admin may call this.
@@ -1113,6 +1117,7 @@ impl EscrowContract {
             trade_id: trade.trade_id,
             refund_amount,
             caller,
+            timestamp: env.ledger().timestamp(),
         }
         .publish(env);
     }
@@ -1577,6 +1582,7 @@ impl EscrowContract {
             trade_id,
             submitter,
             ipfs_cid,
+            timestamp: now,
         }
         .publish(&env);
     }
@@ -1639,6 +1645,7 @@ impl EscrowContract {
             seller,
             driver_name_hash,
             driver_id_hash,
+            timestamp: env.ledger().timestamp(),
         }
         .publish(&env);
     }
@@ -3223,7 +3230,7 @@ mod test {
         let token_mint = token::StellarAssetClient::new(env, &usdc_id);
         token_mint.mint(&buyer, &amount);
         let trade_id =
-            client.create_trade(&buyer, &seller, &amount, &buyer_loss_bps, &seller_loss_bps);
+            client.create_trade(&buyer, &seller, &amount, &buyer_loss_bps, &seller_loss_bps, &None);
         client.deposit(&trade_id);
         let reason = soroban_sdk::String::from_str(env, "QmInvariantTest");
         client.initiate_dispute(&trade_id, &buyer, &reason);
@@ -3830,7 +3837,7 @@ mod test {
         let usdc_id = env
             .register_stellar_asset_contract_v2(admin.clone())
             .address();
-        client.initialize(&admin, &usdc_id, &treasury, &100);
+        client.initialize(&admin, &usdc_id, &treasury, &100, &usdc_id);
         let amount = 10_000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);
@@ -6025,7 +6032,7 @@ mod property_tests {
             let seller_loss_bps = 10_000 - buyer_loss_bps;
 
             let trade_id =
-                client.create_trade(&buyer, &seller, &amount, &buyer_loss_bps, &seller_loss_bps);
+                client.create_trade(&buyer, &seller, &amount, &buyer_loss_bps, &seller_loss_bps, &None);
             client.deposit(&trade_id);
             client.initiate_dispute(&trade_id, &buyer, &String::from_str(&env, "reason"));
 
@@ -6300,6 +6307,7 @@ mod property_tests {
             &case.amount,
             &case.buyer_loss_bps,
             &case.seller_loss_bps,
+            &None,
         );
 
         match case.route % 4 {
@@ -6385,6 +6393,7 @@ mod property_tests {
             &case.amount,
             &case.buyer_loss_bps,
             &case.seller_loss_bps,
+            &None,
         );
 
         let rejected = match case.route % 4 {
@@ -7190,7 +7199,7 @@ mod fee_and_evidence_tests {
             .register_stellar_asset_contract_v2(admin.clone())
             .address();
         // fee_bps = 0 so fee is also zero
-        client.initialize(&admin, &usdc_id, &treasury, &0);
+        client.initialize(&admin, &usdc_id, &treasury, &0, &usdc_id);
         let amount = 10_000_i128;
         let token_client = token::StellarAssetClient::new(&env, &usdc_id);
         token_client.mint(&buyer, &amount);

--- a/contracts/amana_escrow/src/tests/trade_data_tests.rs
+++ b/contracts/amana_escrow/src/tests/trade_data_tests.rs
@@ -27,7 +27,7 @@ mod trade_data_tests {
         let (contract_id, _token_id, buyer, seller, _treasury) = setup(&env, 10_000);
         let client = EscrowContractClient::new(&env, &contract_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &10_000i128, &5000u32, &5000u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000i128, &5000u32, &5000u32, &None);
         let trade = client.get_trade(&trade_id);
 
         assert_eq!(trade.trade_id, trade_id);
@@ -44,7 +44,7 @@ mod trade_data_tests {
         let (contract_id, _token_id, buyer, seller, _treasury) = setup(&env, 10_000);
         let client = EscrowContractClient::new(&env, &contract_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &10_000i128, &5000u32, &5000u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000i128, &5000u32, &5000u32, &None);
 
         env.as_contract(&contract_id, || {
             let raw: TradeData = env
@@ -70,7 +70,7 @@ mod trade_data_tests {
         let (contract_id, token_id, buyer, seller, _treasury) = setup(&env, 10_000);
         let client = EscrowContractClient::new(&env, &contract_id);
 
-        let trade_id = client.create_trade(&buyer, &seller, &10_000i128, &5000u32, &5000u32);
+        let trade_id = client.create_trade(&buyer, &seller, &10_000i128, &5000u32, &5000u32, &None);
 
         // Re-write as explicit V0 (simulates what the contract already does).
         env.as_contract(&contract_id, || {

--- a/contracts/amana_escrow/tests/event_emission_tests.rs
+++ b/contracts/amana_escrow/tests/event_emission_tests.rs
@@ -13,7 +13,7 @@ use soroban_sdk::{
     token,
     xdr::ContractEventBody,
     xdr::ScVal,
-    Address, Bytes, Env, IntoVal, String, Val,
+    Address, Env, IntoVal, String, Val,
 };
 use std::vec::Vec;
 
@@ -382,7 +382,37 @@ fn test_event_video_proof_submitted_payload() {
     assert_last_topic(&env, symbol_short!("VIDPRF").into_val(&env));
 
     let data = last_event_data(&env);
-    assert_eq!(data.len(), 3, "VideoProofSubmittedEvent must have 3 payload fields");
+    assert_eq!(data.len(), 4, "VideoProofSubmittedEvent must have 4 payload fields (trade_id, submitter, ipfs_cid, timestamp)");
+}
+
+// ---------------------------------------------------------------------------
+// VideoProofSubmittedEvent – timestamp field is present and non-zero
+// ---------------------------------------------------------------------------
+#[test]
+fn test_event_video_proof_submitted_has_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, buyer, seller, _, _) = setup(&env, 10_000, 100);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(buyer.clone())
+        .address();
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
+    client.deposit(&trade_id);
+    client.submit_video_proof(&trade_id, &buyer, &String::from_str(&env, "QmVideoCID"));
+
+    let data = last_event_data(&env);
+    // timestamp is the last field (index 3)
+    assert!(
+        matches!(&data[3], ScVal::U64(_)),
+        "VideoProofSubmittedEvent timestamp must be a U64, got {:?}", data[3]
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -416,7 +446,42 @@ fn test_event_manifest_submitted_payload() {
     assert_last_topic(&env, symbol_short!("MNFST").into_val(&env));
 
     let data = last_event_data(&env);
-    assert_eq!(data.len(), 4, "ManifestSubmittedEvent must have 4 payload fields");
+    assert_eq!(data.len(), 5, "ManifestSubmittedEvent must have 5 payload fields (trade_id, seller, driver_name_hash, driver_id_hash, timestamp)");
+}
+
+// ---------------------------------------------------------------------------
+// ManifestSubmittedEvent – timestamp field is present and non-zero
+// ---------------------------------------------------------------------------
+#[test]
+fn test_event_manifest_submitted_has_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, buyer, seller, _, _) = setup(&env, 10_000, 100);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(buyer.clone())
+        .address();
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
+    client.deposit(&trade_id);
+    client.submit_manifest(
+        &trade_id,
+        &seller,
+        &String::from_str(&env, "QmDriverName"),
+        &String::from_str(&env, "QmDriverId"),
+    );
+
+    let data = last_event_data(&env);
+    // timestamp is the last field (index 4)
+    assert!(
+        matches!(&data[4], ScVal::U64(_)),
+        "ManifestSubmittedEvent timestamp must be a U64, got {:?}", data[4]
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -443,7 +508,149 @@ fn test_event_trade_cancelled_payload() {
     assert_last_topic(&env, symbol_short!("TRDCAN").into_val(&env));
 
     let data = last_event_data(&env);
-    assert_eq!(data.len(), 3, "TradeCancelledEvent must have 3 payload fields");
+    assert_eq!(data.len(), 4, "TradeCancelledEvent must have 4 payload fields (trade_id, refund_amount, caller, timestamp)");
+}
+
+// ---------------------------------------------------------------------------
+// TradeCancelledEvent – timestamp field is present
+// ---------------------------------------------------------------------------
+#[test]
+fn test_event_trade_cancelled_has_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, buyer, seller, _, _) = setup(&env, 10_000, 100);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(buyer.clone())
+        .address();
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
+    client.cancel_trade(&trade_id, &buyer);
+
+    let data = last_event_data(&env);
+    // timestamp is the last field (index 3)
+    assert!(
+        matches!(&data[3], ScVal::U64(_)),
+        "TradeCancelledEvent timestamp must be a U64, got {:?}", data[3]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// InitializedEvent – payload field count and timestamp presence
+// ---------------------------------------------------------------------------
+#[test]
+fn test_event_initialized_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    // The InitializedEvent uses multi-topic ["amana", "initialized"], so we check
+    // that the last event was our initialize call and has the right field count.
+    let all = env.events().all();
+    let events = all.events();
+    assert!(!events.is_empty(), "no events emitted");
+    // initialize is the only call so it must be the last event
+    let data = last_event_data(&env);
+    assert_eq!(data.len(), 3, "InitializedEvent must have 3 payload fields (admin, fee_bps, timestamp)");
+}
+
+#[test]
+fn test_event_initialized_has_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    let data = last_event_data(&env);
+    // timestamp is the last field (index 2)
+    assert!(
+        matches!(&data[2], ScVal::U64(_)),
+        "InitializedEvent timestamp must be a U64, got {:?}", data[2]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// confirm_delivery – DeliveryConfirmedEvent has delivered_at (timestamp)
+// ---------------------------------------------------------------------------
+#[test]
+fn test_event_confirm_delivery_has_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, buyer, seller, _, _) = setup(&env, 10_000, 100);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(buyer.clone())
+        .address();
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
+    client.deposit(&trade_id);
+    client.confirm_delivery(&trade_id);
+
+    assert_last_topic(&env, symbol_short!("DELCNF").into_val(&env));
+
+    let data = last_event_data(&env);
+    assert_eq!(data.len(), 2, "DeliveryConfirmedEvent must have 2 payload fields (trade_id, delivered_at)");
+    // delivered_at is at index 0 (fields sorted by name: delivered_at < trade_id)
+    assert!(
+        data.iter().any(|v| matches!(v, ScVal::U64(_))),
+        "DeliveryConfirmedEvent must contain a U64 timestamp (delivered_at)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// execute_cancellation via refund – TradeCancelledEvent has timestamp
+// ---------------------------------------------------------------------------
+#[test]
+fn test_event_execute_cancellation_via_refund_has_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, buyer, seller, _, _) = setup(&env, 10_000, 100);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(buyer.clone())
+        .address();
+    token::StellarAssetClient::new(&env, &usdc_id).mint(&buyer, &10_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &usdc_id, &treasury, &100_u32, &usdc_id);
+
+    let trade_id = client.create_trade(&buyer, &seller, &10_000_i128, &5000_u32, &5000_u32, &None);
+    client.deposit(&trade_id);
+    // seller refund triggers execute_cancellation
+    client.refund(&trade_id);
+
+    assert_last_topic(&env, symbol_short!("TRDCAN").into_val(&env));
+
+    let data = last_event_data(&env);
+    assert_eq!(data.len(), 4, "TradeCancelledEvent (via refund) must have 4 fields including timestamp");
+    assert!(
+        matches!(&data[3], ScVal::U64(_)),
+        "TradeCancelledEvent timestamp must be a U64, got {:?}", data[3]
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add event emission to all remaining contract state changes
Summary
Audit every state-mutating function in the escrow contract and add event emissions where missing.

Requirements

Audit functions in contracts/amana_escrow/src/lib.rs: initialize, submit_video_proof, submit_manifest, confirm_delivery, cancel_trade, execute_cancellation
Add SorobanEvent emissions with consistent schema for each
Events include: caller address, trade ID, block timestamp, and function-specific data
Tests cover event presence and event data shape for every function
Scope

Event additions in contracts/amana_escrow/src/lib.rs
Tests in contracts/amana_escrow/tests/
Acceptance Criteria

Every state-mutating function emits at least one event
Event data includes caller, trade ID, and timestamp
All tests pass

closes #748
closes #737