### PR TITLE
Add feature flag system in backend/src/services

### DIFF
--- a/backend/src/__tests__/admin.features.routes.test.ts
+++ b/backend/src/__tests__/admin.features.routes.test.ts
@@ -1,0 +1,154 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { createAdminFeaturesRouter } from "../routes/admin.features.routes";
+import { errorHandler } from "../middleware/errorHandler";
+
+jest.mock("../services/auth.service", () => {
+  const actual = jest.requireActual("../services/auth.service");
+  return {
+    ...actual,
+    AuthService: {
+      validateToken: jest.fn(async (token: string) => {
+        const jsonwebtoken = require("jsonwebtoken");
+        return jsonwebtoken.decode(token);
+      }),
+      isTokenRevoked: jest.fn().mockResolvedValue(false),
+    },
+  };
+});
+
+jest.mock("../services/feature-flags.service", () => ({
+  featureFlagService: {
+    listFlags: jest.fn(),
+    setFlag: jest.fn(),
+  },
+}));
+
+import { AuthService } from "../services/auth.service";
+import { featureFlagService } from "../services/feature-flags.service";
+
+const mockFeatureFlagService = featureFlagService as unknown as {
+  listFlags: jest.Mock;
+  setFlag: jest.Mock;
+};
+
+const app = express();
+app.use(express.json());
+app.use("/", createAdminFeaturesRouter());
+app.use(errorHandler);
+
+describe("Admin Features Routes", () => {
+  const adminAddress = StellarSdk.Keypair.random().publicKey();
+  const nonAdminAddress = StellarSdk.Keypair.random().publicKey();
+  let adminToken: string;
+  let nonAdminToken: string;
+
+  beforeAll(() => {
+    process.env.ADMIN_STELLAR_PUBKEYS = adminAddress;
+    const secret = process.env.JWT_SECRET || "test-secret-at-least-32-characters-long";
+    const now = Math.floor(Date.now() / 1000);
+    adminToken = jwt.sign(
+      {
+        walletAddress: adminAddress,
+        jti: "features-admin-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+    nonAdminToken = jwt.sign(
+      {
+        walletAddress: nonAdminAddress,
+        jti: "features-nonadmin-jti",
+        iss: process.env.JWT_ISSUER,
+        aud: process.env.JWT_AUDIENCE,
+        nbf: now - 1,
+      },
+      secret,
+      { algorithm: "HS256" },
+    );
+  });
+
+  beforeEach(() => {
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+    jest.clearAllMocks();
+  });
+
+  describe("GET /admin/features", () => {
+    it("returns the flag map for an admin", async () => {
+      mockFeatureFlagService.listFlags.mockResolvedValue({
+        "new-checkout": { enabled: true, updatedAt: "t" },
+      });
+
+      const res = await request(app)
+        .get("/admin/features")
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.flags).toEqual({
+        "new-checkout": { enabled: true, updatedAt: "t" },
+      });
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await request(app).get("/admin/features");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 for non-admin users", async () => {
+      const res = await request(app)
+        .get("/admin/features")
+        .set("Authorization", `Bearer ${nonAdminToken}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("PATCH /admin/features/:name", () => {
+    it("updates a flag as an admin", async () => {
+      mockFeatureFlagService.setFlag.mockResolvedValue({
+        enabled: true,
+        rolloutPercentage: 25,
+        updatedAt: "t",
+      });
+
+      const res = await request(app)
+        .patch("/admin/features/new-checkout")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({ enabled: true, rolloutPercentage: 25 });
+
+      expect(res.status).toBe(200);
+      expect(mockFeatureFlagService.setFlag).toHaveBeenCalledWith("new-checkout", {
+        enabled: true,
+        rolloutPercentage: 25,
+      });
+      expect(res.body).toEqual({
+        name: "new-checkout",
+        flag: { enabled: true, rolloutPercentage: 25, updatedAt: "t" },
+      });
+    });
+
+    it("rejects a rolloutPercentage outside 0-100", async () => {
+      const res = await request(app)
+        .patch("/admin/features/new-checkout")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({ enabled: true, rolloutPercentage: 150 });
+
+      expect(res.status).toBe(400);
+      expect(mockFeatureFlagService.setFlag).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 for non-admin users", async () => {
+      const res = await request(app)
+        .patch("/admin/features/new-checkout")
+        .set("Authorization", `Bearer ${nonAdminToken}`)
+        .send({ enabled: true });
+
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/backend/src/__tests__/requireFeature.middleware.test.ts
+++ b/backend/src/__tests__/requireFeature.middleware.test.ts
@@ -1,0 +1,77 @@
+import { Response } from "express";
+import { AuthRequest } from "../services/auth.service";
+
+jest.mock("../services/feature-flags.service", () => ({
+  featureFlagService: {
+    isEnabled: jest.fn(),
+  },
+}));
+
+import { featureFlagService } from "../services/feature-flags.service";
+import { requireFeature } from "../middleware/requireFeature";
+
+const mockFeatureFlagService = featureFlagService as unknown as { isEnabled: jest.Mock };
+
+function createRes() {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("requireFeature middleware", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls next() when the feature is enabled for the user", async () => {
+    mockFeatureFlagService.isEnabled.mockResolvedValue(true);
+    const req = { user: { sub: "user-1" } } as AuthRequest;
+    const res = createRes();
+    const next = jest.fn();
+
+    await requireFeature("new-checkout")(req, res, next);
+
+    expect(mockFeatureFlagService.isEnabled).toHaveBeenCalledWith("new-checkout", "user-1");
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("responds 503 when the feature is disabled", async () => {
+    mockFeatureFlagService.isEnabled.mockResolvedValue(false);
+    const req = { user: { sub: "user-1" } } as AuthRequest;
+    const res = createRes();
+    const next = jest.fn();
+
+    await requireFeature("new-checkout")(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      code: "FEATURE_DISABLED",
+      error: "Feature 'new-checkout' is currently disabled",
+    });
+  });
+
+  it("falls back to walletAddress when sub is absent", async () => {
+    mockFeatureFlagService.isEnabled.mockResolvedValue(true);
+    const req = { user: { walletAddress: "GABC" } } as AuthRequest;
+    const res = createRes();
+    const next = jest.fn();
+
+    await requireFeature("new-checkout")(req, res, next);
+
+    expect(mockFeatureFlagService.isEnabled).toHaveBeenCalledWith("new-checkout", "GABC");
+  });
+
+  it("passes undefined userId for unauthenticated requests", async () => {
+    mockFeatureFlagService.isEnabled.mockResolvedValue(false);
+    const req = {} as AuthRequest;
+    const res = createRes();
+    const next = jest.fn();
+
+    await requireFeature("new-checkout")(req, res, next);
+
+    expect(mockFeatureFlagService.isEnabled).toHaveBeenCalledWith("new-checkout", undefined);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -36,6 +36,7 @@ import { stellarAssetRoutes } from "./routes/stellar.asset";
 import { stellarAccountBalanceRoutes } from "./routes/stellar.account.balance";
 import { stellarAccountCreateRoutes } from "./routes/stellar.account.create";
 import { createContractStateRouter } from "./routes/contract.state.routes";
+import { createAdminFeaturesRouter } from "./routes/admin.features.routes";
 import { webhooksRoutes } from "./routes/webhooks.routes";
 import { env } from "./config/env";
 
@@ -165,6 +166,9 @@ export function createApp(): express.Application {
 
   // Treasury management
   app.use("/treasury", createTreasuryRouter());
+
+  // Feature flags (admin-managed)
+  app.use(createAdminFeaturesRouter());
 
   // Webhooks: CRUD /webhooks
   app.use("/webhooks", webhooksRoutes);

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -37,7 +37,7 @@ export function errorHandler(
     const payload: StructuredErrorPayload = {
       code: ErrorCode.VALIDATION_ERROR,
       message: 'Validation failed',
-      details: { errors: err.errors },
+      details: { errors: (err as { errors: unknown }).errors },
       timestamp: new Date().toISOString(),
       path,
       ...(correlationId && { correlationId }),

--- a/backend/src/middleware/requireFeature.ts
+++ b/backend/src/middleware/requireFeature.ts
@@ -1,0 +1,24 @@
+import { Response, NextFunction } from "express";
+import { AuthRequest } from "../services/auth.service";
+import { featureFlagService } from "../services/feature-flags.service";
+
+/**
+ * Gates a route behind a feature flag. Responds 503 when the flag resolves
+ * to disabled for the requesting user, otherwise calls `next()`.
+ */
+export function requireFeature(name: string) {
+  return async (req: AuthRequest, res: Response, next: NextFunction): Promise<void> => {
+    const userId = req.user?.sub ?? req.user?.walletAddress;
+    const enabled = await featureFlagService.isEnabled(name, userId);
+
+    if (!enabled) {
+      res.status(503).json({
+        code: "FEATURE_DISABLED",
+        error: `Feature '${name}' is currently disabled`,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/backend/src/routes/admin.features.routes.ts
+++ b/backend/src/routes/admin.features.routes.ts
@@ -1,0 +1,53 @@
+import { Response, Router } from "express";
+import { z } from "zod";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { adminMiddleware } from "../middleware/admin.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { AuthRequest } from "../services/auth.service";
+import { featureFlagService } from "../services/feature-flags.service";
+
+const updateFlagBodySchema = z.object({
+  enabled: z.boolean(),
+  rolloutPercentage: z.number().min(0).max(100).optional(),
+});
+
+export function createAdminFeaturesRouter() {
+  const router = Router();
+
+  router.get(
+    "/admin/features",
+    authMiddleware,
+    adminMiddleware,
+    async (_req: AuthRequest, res: Response, next) => {
+      try {
+        const flags = await featureFlagService.listFlags();
+        res.status(200).json({ flags });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.patch(
+    "/admin/features/:name",
+    authMiddleware,
+    adminMiddleware,
+    validateRequest({ body: updateFlagBodySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const name = String(req.params.name);
+        const { enabled, rolloutPercentage } = req.body as {
+          enabled: boolean;
+          rolloutPercentage?: number;
+        };
+
+        const flag = await featureFlagService.setFlag(name, { enabled, rolloutPercentage });
+        res.status(200).json({ name, flag });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/backend/src/services/__tests__/feature-flags.service.test.ts
+++ b/backend/src/services/__tests__/feature-flags.service.test.ts
@@ -1,0 +1,157 @@
+jest.mock("../../lib/redis", () => ({
+  redis: {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+  },
+}));
+
+import { redis } from "../../lib/redis";
+import { FeatureFlagService, FeatureFlagRecord } from "../feature-flags.service";
+
+const mockRedis = redis as unknown as {
+  get: jest.Mock;
+  set: jest.Mock;
+  del: jest.Mock;
+  keys: jest.Mock;
+};
+
+describe("FeatureFlagService", () => {
+  let service: FeatureFlagService;
+
+  beforeEach(() => {
+    service = new FeatureFlagService();
+    jest.clearAllMocks();
+  });
+
+  describe("setFlag / getFlag", () => {
+    it("stores a flag under feature:<name> and returns the record", async () => {
+      const record = await service.setFlag("new-checkout", { enabled: true });
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        "feature:new-checkout",
+        expect.stringContaining('"enabled":true'),
+      );
+      expect(record.enabled).toBe(true);
+      expect(record.updatedAt).toEqual(expect.any(String));
+    });
+
+    it("rejects an out-of-range rolloutPercentage", async () => {
+      await expect(
+        service.setFlag("new-checkout", { enabled: true, rolloutPercentage: 101 }),
+      ).rejects.toThrow(RangeError);
+      await expect(
+        service.setFlag("new-checkout", { enabled: true, rolloutPercentage: -1 }),
+      ).rejects.toThrow(RangeError);
+    });
+
+    it("returns null when the flag doesn't exist", async () => {
+      mockRedis.get.mockResolvedValue(null);
+      expect(await service.getFlag("missing")).toBeNull();
+    });
+
+    it("returns null instead of throwing on corrupt stored JSON", async () => {
+      mockRedis.get.mockResolvedValue("{not-json");
+      expect(await service.getFlag("corrupt")).toBeNull();
+    });
+  });
+
+  describe("listFlags", () => {
+    it("returns an empty object when no flags are set", async () => {
+      mockRedis.keys.mockResolvedValue([]);
+      expect(await service.listFlags()).toEqual({});
+    });
+
+    it("reads back every feature:* key, stripping the prefix", async () => {
+      const a: FeatureFlagRecord = { enabled: true, updatedAt: "t1" };
+      const b: FeatureFlagRecord = { enabled: false, updatedAt: "t2" };
+      mockRedis.keys.mockResolvedValue(["feature:a", "feature:b"]);
+      mockRedis.get.mockImplementation((key: string) => {
+        if (key === "feature:a") return Promise.resolve(JSON.stringify(a));
+        if (key === "feature:b") return Promise.resolve(JSON.stringify(b));
+        return Promise.resolve(null);
+      });
+
+      expect(await service.listFlags()).toEqual({ a, b });
+    });
+  });
+
+  describe("isEnabled", () => {
+    it("is false when the flag doesn't exist", async () => {
+      mockRedis.get.mockResolvedValue(null);
+      expect(await service.isEnabled("missing")).toBe(false);
+    });
+
+    it("is false when the flag is explicitly disabled", async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify({ enabled: false, updatedAt: "t" }));
+      expect(await service.isEnabled("off")).toBe(false);
+    });
+
+    it("is true for a plain enabled flag with no rollout", async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify({ enabled: true, updatedAt: "t" }));
+      expect(await service.isEnabled("on")).toBe(true);
+    });
+
+    it("is true when rolloutPercentage is 100", async () => {
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ enabled: true, rolloutPercentage: 100, updatedAt: "t" }),
+      );
+      expect(await service.isEnabled("on", "user-1")).toBe(true);
+    });
+
+    it("is false when rolloutPercentage is 0", async () => {
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ enabled: true, rolloutPercentage: 0, updatedAt: "t" }),
+      );
+      expect(await service.isEnabled("off", "user-1")).toBe(false);
+    });
+
+    it("is false for a partial rollout with no userId to gate on", async () => {
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ enabled: true, rolloutPercentage: 50, updatedAt: "t" }),
+      );
+      expect(await service.isEnabled("partial")).toBe(false);
+    });
+
+    it("is deterministic: the same user gets the same result across repeated checks", async () => {
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ enabled: true, rolloutPercentage: 50, updatedAt: "t" }),
+      );
+
+      const first = await service.isEnabled("partial", "user-42");
+      const second = await service.isEnabled("partial", "user-42");
+      const third = await service.isEnabled("partial", "user-42");
+
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it("distributes a rollout percentage roughly evenly across many users", async () => {
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ enabled: true, rolloutPercentage: 30, updatedAt: "t" }),
+      );
+
+      const sampleSize = 2000;
+      let enabledCount = 0;
+      for (let i = 0; i < sampleSize; i++) {
+        if (await service.isEnabled("partial", `user-${i}`)) {
+          enabledCount += 1;
+        }
+      }
+
+      const ratio = enabledCount / sampleSize;
+      // Allow generous slack (target 30% +/- 7pp) since this is a hash-based
+      // approximation, not a perfectly uniform distribution.
+      expect(ratio).toBeGreaterThan(0.23);
+      expect(ratio).toBeLessThan(0.37);
+    });
+  });
+
+  describe("deleteFlag", () => {
+    it("deletes the underlying redis key", async () => {
+      await service.deleteFlag("gone");
+      expect(mockRedis.del).toHaveBeenCalledWith("feature:gone");
+    });
+  });
+});

--- a/backend/src/services/feature-flags.service.ts
+++ b/backend/src/services/feature-flags.service.ts
@@ -1,0 +1,126 @@
+import { redis } from "../lib/redis";
+
+const FLAG_KEY_PREFIX = "feature:";
+
+export interface FeatureFlagRecord {
+  enabled: boolean;
+  /** 0-100. When set, gates the flag to a deterministic subset of users, keyed by user id. */
+  rolloutPercentage?: number;
+  updatedAt: string;
+}
+
+export interface FeatureFlagUpdate {
+  enabled: boolean;
+  rolloutPercentage?: number;
+}
+
+function flagKey(name: string): string {
+  return `${FLAG_KEY_PREFIX}${name}`;
+}
+
+/**
+ * Deterministic 0-99 bucket for a string, using FNV-1a. Same input always
+ * yields the same bucket, and buckets are spread evenly over many inputs -
+ * this is what makes percentage rollouts sticky per-user instead of a coin
+ * flip on every request.
+ */
+function hashToBucket(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return Math.abs(hash) % 100;
+}
+
+export class FeatureFlagService {
+  async getFlag(name: string): Promise<FeatureFlagRecord | null> {
+    const raw = await redis.get(flagKey(name));
+    if (!raw) {
+      return null;
+    }
+    try {
+      return JSON.parse(raw) as FeatureFlagRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  async listFlags(): Promise<Record<string, FeatureFlagRecord>> {
+    const keys = (await redis.keys(`${FLAG_KEY_PREFIX}*`)) as string[];
+    if (keys.length === 0) {
+      return {};
+    }
+
+    const values = await Promise.all(keys.map((key: string) => redis.get(key)));
+    const result: Record<string, FeatureFlagRecord> = {};
+
+    keys.forEach((key: string, index: number) => {
+      const raw = values[index];
+      if (!raw) {
+        return;
+      }
+      try {
+        result[key.slice(FLAG_KEY_PREFIX.length)] = JSON.parse(raw) as FeatureFlagRecord;
+      } catch {
+        // Skip a corrupt entry rather than failing the whole listing.
+      }
+    });
+
+    return result;
+  }
+
+  async setFlag(name: string, update: FeatureFlagUpdate): Promise<FeatureFlagRecord> {
+    if (
+      update.rolloutPercentage !== undefined &&
+      (update.rolloutPercentage < 0 || update.rolloutPercentage > 100)
+    ) {
+      throw new RangeError("rolloutPercentage must be between 0 and 100");
+    }
+
+    const record: FeatureFlagRecord = {
+      enabled: update.enabled,
+      rolloutPercentage: update.rolloutPercentage,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await redis.set(flagKey(name), JSON.stringify(record));
+    return record;
+  }
+
+  async deleteFlag(name: string): Promise<void> {
+    await redis.del(flagKey(name));
+  }
+
+  /**
+   * Resolves whether a feature is enabled for the given user.
+   *
+   * - Missing flag, or `enabled: false` -> disabled.
+   * - `enabled: true` with no `rolloutPercentage` (or `>= 100`) -> enabled for everyone.
+   * - `rolloutPercentage <= 0` -> disabled for everyone.
+   * - Otherwise, enabled for the deterministic subset of `userId`s that hash into
+   *   the rollout bucket. A request with no `userId` is treated as not in the
+   *   rollout, since there's no stable identity to gate on.
+   */
+  async isEnabled(name: string, userId?: string): Promise<boolean> {
+    const flag = await this.getFlag(name);
+    if (!flag || !flag.enabled) {
+      return false;
+    }
+
+    const rollout = flag.rolloutPercentage;
+    if (rollout === undefined || rollout >= 100) {
+      return true;
+    }
+    if (rollout <= 0) {
+      return false;
+    }
+    if (!userId) {
+      return false;
+    }
+
+    return hashToBucket(`${name}:${userId}`) < rollout;
+  }
+}
+
+export const featureFlagService = new FeatureFlagService();

--- a/backend/src/test-deps.d.ts
+++ b/backend/src/test-deps.d.ts
@@ -5,6 +5,7 @@ declare module 'ioredis' {
     set(...args: any[]): Promise<any>;
     del(...args: any[]): Promise<any>;
     exists(...args: any[]): Promise<any>;
+    keys(...args: any[]): Promise<any>;
   }
 }
 


### PR DESCRIPTION
## Summary
- `backend/src/services/feature-flags.service.ts` - flags stored in Redis under `feature:{name}` as `{enabled, rolloutPercentage, updatedAt}`. Supports a plain global boolean, a percentage rollout (deterministic per-user bucketing via an FNV-1a hash, so the same user always lands on the same side of the rollout line), and listing/deleting flags.
- `backend/src/middleware/requireFeature.ts` - `requireFeature('name')` gates a route and responds `503 { code: "FEATURE_DISABLED" }` when the flag resolves to disabled for the requesting user (identified by JWT `sub`, falling back to `walletAddress`).
- `backend/src/routes/admin.features.routes.ts` - `GET /admin/features` and `PATCH /admin/features/:name`, both behind the existing `authMiddleware` + `adminMiddleware`. Mounted in `app.ts`.

While wiring this up, two pre-existing compile errors surfaced that block every test suite importing `errorHandler.ts` (unrelated to feature flags, but needed to get anything running): the ambient `ioredis` type stub in `test-deps.d.ts` was missing `keys()`, and `errorHandler`'s `ZodError` branch narrowed on `z.ZodError`, which resolves to `any`/`unknown` through that same stub and left `err` typed `unknown` at the `.errors` access. Fixed both minimally.

Closes #795

## Test plan
- [x] `npx jest feature-flags.service.test.ts admin.features.routes.test.ts requireFeature.middleware.test.ts` - 25 tests pass (flag CRUD, `isEnabled` resolution for off/on/100%/0%/no-userId, rollout determinism + even distribution across 2000 simulated users, admin routes 200/401/403/400, middleware 503 vs `next()`)
- [x] `npx jest admin.trades.batch.routes.test.ts` (pre-existing suite that also imports `errorHandler.ts`) - now passes too, was previously broken by the same pre-existing bug