### PR TITLE
Write API consumer documentation

### DIFF
--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -1,0 +1,140 @@
+# Admin Endpoints
+
+Every endpoint on this page requires a bearer token whose wallet address
+appears in the `ADMIN_STELLAR_PUBKEYS` environment variable (a
+comma-separated allowlist of Stellar public keys). This is enforced by
+`adminMiddleware`, stacked after the usual `authMiddleware`:
+
+1. No/invalid token -> `401 Unauthorized`
+2. Valid token, wallet not on the allowlist -> `403 { "error": "Forbidden: admin access required" }`
+3. Valid token, wallet on the allowlist -> request proceeds
+
+There is no separate "admin login" - the same challenge/verify flow in
+[overview.md](./overview.md#authentication) applies; admin status is purely
+a function of which wallet signed in.
+
+## Treasury
+
+The treasury holds funds swept from resolved/expired escrow contracts.
+
+`GET /treasury/balance` - current balance of the escrow contract treasury.
+
+```json
+{ "balance": "50000.0000000", "asset": "USDC", "contractId": "CA..." }
+```
+
+`GET /treasury/config` - the treasury's contract id, network, and settlement
+asset.
+
+```json
+{ "contractId": "CA...", "network": "testnet", "asset": "USDC" }
+```
+
+`POST /treasury/withdraw` - builds an unsigned withdrawal transaction moving
+funds out of the treasury.
+
+```json
+{ "destination": "GBBB...C4", "amount": "1000.0000000" }
+```
+
+Response: `{ "unsignedXdr": "..." }`. As with trade transactions, the caller
+still signs and submits this themselves - the backend never holds a signing
+key for the treasury.
+
+## Batch trade status updates
+
+`POST /admin/trades/batch/status`
+
+Force-transitions up to 100 trades in one call, e.g. for support/ops
+workflows where a trade is stuck. Bypasses the normal buyer/seller-only
+transition endpoints in [trades.md](./trades.md), but still enforces the
+same status-transition graph (you can't jump straight from `CREATED` to
+`COMPLETED`).
+
+**Request body**
+
+```json
+{
+  "updates": [
+    { "tradeId": "4294967297", "status": "CANCELLED" },
+    { "tradeId": "4294967298", "status": "CANCELLED" }
+  ]
+}
+```
+
+**Response `200`** - always `200` even for partial failure; check
+`succeeded`/`failed` per item rather than the HTTP status:
+
+```json
+{
+  "succeeded": ["4294967297"],
+  "failed": [
+    { "tradeId": "4294967298", "reason": "Invalid transition from COMPLETED to CANCELLED" }
+  ]
+}
+```
+
+Failure reasons include `"Trade not found"`, an invalid-transition message,
+and `"Concurrency conflict: trade was modified"` (another request updated
+the same trade between this request's read and write - retry the batch for
+just that trade).
+
+## Feature flags
+
+`GET /admin/features` - list every configured flag.
+
+```json
+{
+  "flags": {
+    "new-checkout": { "enabled": true, "updatedAt": "2026-07-05T12:00:00.000Z" },
+    "beta-dashboard": { "enabled": true, "rolloutPercentage": 25, "updatedAt": "2026-07-01T09:00:00.000Z" }
+  }
+}
+```
+
+A flag not present in this map is treated as disabled everywhere.
+
+`PATCH /admin/features/:name` - create or update a flag.
+
+**Request body**
+
+```json
+{ "enabled": true, "rolloutPercentage": 25 }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `enabled` | yes | Master on/off switch |
+| `rolloutPercentage` | no | `0`-`100`. Omit (or `100`) for "on for everyone"; `0` for "off for everyone but flag stays configured"; anything in between gates a deterministic subset of users |
+
+`400 VALIDATION_ERROR` if `rolloutPercentage` is outside `0`-`100`.
+
+**Response `200`**
+
+```json
+{
+  "name": "new-checkout",
+  "flag": { "enabled": true, "rolloutPercentage": 25, "updatedAt": "2026-07-05T12:00:00.000Z" }
+}
+```
+
+### How rollout percentage gating works
+
+When a route is wrapped in `requireFeature('name')` middleware, the flag is
+resolved per authenticated user (by JWT `sub`, falling back to
+`walletAddress`), not per request:
+
+- The same user always lands on the same side of the rollout line - a user
+  in a 10% rollout stays in it on every request, they aren't re-rolled each
+  time.
+- A request with no authenticated user can't be placed in a partial
+  rollout and is treated as disabled.
+- A disabled route responds `503`:
+
+```json
+{ "code": "FEATURE_DISABLED", "error": "Feature 'new-checkout' is currently disabled" }
+```
+
+Flags are stored in Redis under `feature:<name>`, so flipping a flag via
+`PATCH` takes effect immediately for all backend instances - no
+redeploy required.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,91 @@
+# Error Reference
+
+## Envelope shapes
+
+Most routes return a **structured error**:
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Validation failed",
+  "details": [{ "path": "body.amountUsdc", "message": "Invalid amount format" }],
+  "timestamp": "2026-07-05T12:00:00.000Z",
+  "path": "/trades",
+  "requestId": "...",
+  "correlationId": "..."
+}
+```
+
+A handful of older/simpler routes (mostly the Stellar proxy endpoints in
+[stellar.md](./stellar.md) and a few `403` checks) instead return a
+**legacy envelope**:
+
+```json
+{ "error": "Forbidden" }
+```
+
+Check for `code` first; if absent, fall back to `error`. Both shapes are
+called out per-endpoint in [trades.md](./trades.md), [stellar.md](./stellar.md),
+and [admin.md](./admin.md) where they differ from the structured default.
+
+`requestId` and `correlationId` (when present) identify the request in
+server logs/tracing - include them when reporting an issue.
+
+## Error codes
+
+| Code | Typical HTTP status | Meaning | What to do |
+|---|---|---|---|
+| `VALIDATION_ERROR` | 400 | Request body/query failed schema validation | Fix the field(s) listed in `details` and retry - don't retry unchanged |
+| `AUTH_ERROR` | 401 | Missing, expired, revoked, or otherwise invalid bearer token | Re-run the [challenge/verify flow](./overview.md#authentication) to get a fresh token |
+| `DOMAIN_ERROR` | 400/403 | A business rule was violated (rather than a schema failure) | Message/`details` explain the rule; not retryable without changing the request |
+| `INFRA_ERROR` | 500/503 | A dependency (JWT config, database, etc.) failed | Transient - safe to retry with backoff; if it persists, treat it as a service incident |
+| `NOT_FOUND` | 404 | The resource doesn't exist, or you don't have access to see that it does | Check the identifier; some endpoints intentionally 404 instead of 403 to avoid leaking existence |
+| `INTERNAL_ERROR` | 500 | Unhandled server error | Retry once with backoff; if it repeats, report `requestId` |
+| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests for the bucket the endpoint belongs to | Wait `details.retryAfterSeconds` before retrying - see [overview.md](./overview.md#rate-limits) |
+
+### Trade-specific codes
+
+| Code | HTTP status | Meaning | What to do |
+|---|---|---|---|
+| `TRADE_NOT_FOUND` | 404 | No trade with that id (or id malformed) | Confirm the `tradeId` |
+| `TRADE_ACCESS_DENIED` | 403 | Caller is not the buyer/seller/admin required for this action | Check which role the action requires - see [trades.md](./trades.md) |
+| `TRADE_INVALID_STATUS` | 400 | The trade isn't in the status this action requires (e.g. confirming delivery on a trade that isn't `FUNDED`) | Fetch the trade's current `status` and only call the action valid for it |
+| `TRADE_BUILD_FAILED` | 500 | Building the Stellar/Soroban transaction failed server-side | Retryable; if it persists the underlying contract/network call is likely failing |
+
+### Dispute-specific codes
+
+| Code | HTTP status | Meaning | What to do |
+|---|---|---|---|
+| `DISPUTE_INVALID_CATEGORY` | 400 | `category`/`categoryId` doesn't match an active dispute category | Fetch `GET /dispute-categories` for valid values |
+| `DISPUTE_STATUS_TRANSITION_INVALID` | 400 | Requested dispute status change isn't a legal transition | Check the dispute's current status before transitioning |
+| `DISPUTE_STATUS_CONFLICT` | 409 | Dispute was modified concurrently (optimistic-lock conflict) | Re-fetch the dispute and retry |
+| `DISPUTE_NOT_FOUND` | 404 | No dispute with that id | Confirm the identifier |
+
+### Payment provider codes
+
+These surface from the path-payment/quote flow when the upstream payment
+provider misbehaves.
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `PAYMENT_PROVIDER_ERROR` | The payment provider returned an error | Not generally retryable without changing input; check `details` |
+| `PAYMENT_PROVIDER_TIMEOUT` | The payment provider didn't respond in time | Safe to retry with backoff |
+| `PAYMENT_INSUFFICIENT_FUNDS` | The quoted route can't be filled at the requested amount | Retry with a smaller `sourceAmount` or a different `sourceAsset` |
+
+## Resolution checklist
+
+1. **Read `code` before `message`** - `message` is for humans/logs and can
+   change wording over time; `code` is the stable contract to branch on.
+2. **`401` is always worth one retry** after re-authenticating - tokens
+   expire (`JWT_EXPIRES_IN`, default 24h) and can be revoked by logout on
+   another session.
+3. **`429` and `INFRA_ERROR`/`5xx`** are the only cases worth an automatic
+   retry with backoff. Everything else (`400`, `403`, `404`, `409`) means
+   the request itself needs to change first.
+4. **`403` vs `404`**: some endpoints (e.g. fetching another user's trade)
+   intentionally return `404` instead of `403` to avoid confirming that a
+   resource exists for an unauthorized caller. Don't assume a `404` means
+   "never existed."
+5. When reporting a bug, include the endpoint, `code`, and `requestId`
+   (or `correlationId`) from the response - that's what maps back to a
+   specific server-side log entry.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,0 +1,151 @@
+# API Overview
+
+This is the consumer-facing entry point for the Amana backend API. It covers
+authentication, base URLs, rate limits, and pagination conventions that apply
+across every endpoint. For endpoint-by-endpoint detail see:
+
+- [trades.md](./trades.md) - trade lifecycle endpoints
+- [stellar.md](./stellar.md) - Stellar network proxy endpoints
+- [admin.md](./admin.md) - admin-only endpoints
+- [errors.md](./errors.md) - error code reference
+
+The machine-readable spec lives at
+[`backend/src/docs/openapi.json`](../../backend/src/docs/openapi.json) /
+`openapi.yaml`; this page is the narrative companion to it.
+
+## Base URL
+
+The backend listens on `PORT` (default `4000`), with all routes mounted at
+the root:
+
+```
+http://localhost:4000
+```
+
+There is no versioned URL prefix (e.g. no `/v1`) today - all paths in this
+guide are relative to the base URL above.
+
+## Authentication
+
+Amana authenticates wallets with a challenge/response flow instead of
+passwords, since the only identity a client has is a Stellar keypair:
+
+1. `POST /auth/challenge` with your wallet's public key. The server returns a
+   short-lived, single-use challenge string.
+2. Sign the challenge with your Stellar secret key (client-side - the secret
+   key never leaves the wallet).
+3. `POST /auth/verify` with the public key and the signature. The server
+   verifies it against the challenge and returns a JWT bearer token.
+4. Send `Authorization: Bearer <token>` on every subsequent protected
+   request.
+5. `POST /auth/logout` revokes the current token immediately by adding its
+   `jti` to a denylist, instead of waiting for natural expiry.
+
+```bash
+curl -X POST http://localhost:4000/auth/challenge \
+  -H 'Content-Type: application/json' \
+  -d '{"walletAddress":"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}'
+# => {"challenge":"amana:login:1742794421:7ced1c65a9a44a7d"}
+
+curl -X POST http://localhost:4000/auth/verify \
+  -H 'Content-Type: application/json' \
+  -d '{"walletAddress":"GAAA...WHF","signedChallenge":"<base64url signature>"}'
+# => {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...."}
+
+curl http://localhost:4000/users/me -H 'Authorization: Bearer <token>'
+```
+
+### JWT semantics enforced by the server
+
+The auth middleware rejects a token if any of these fail:
+
+| Claim | Requirement |
+|---|---|
+| `iss` | Must match `JWT_ISSUER` (default `amana`) |
+| `aud` | Must match `JWT_AUDIENCE` (default `amana-api`) |
+| `jti` | Required, and must not be on the revocation denylist (see logout above) |
+| `nbf` | Required, and must not be in the future |
+| `exp` | Token lifetime is `JWT_EXPIRES_IN` seconds from issuance (default `86400`, i.e. 24h) |
+
+A request with a missing, expired, revoked, or otherwise invalid token gets
+`401 Unauthorized` (see [errors.md](./errors.md#auth_error)).
+
+### Public vs. protected endpoints
+
+Most endpoints require a bearer token. A few are intentionally public, e.g.
+`GET /users/:address` (public profile lookup) and the `/health*` endpoints.
+Each endpoint's own doc page notes whether auth is required.
+
+### Admin endpoints
+
+A subset of endpoints (treasury management, admin trade transitions, feature
+flags) additionally require the caller's wallet address to appear in the
+`ADMIN_STELLAR_PUBKEYS` allowlist (a comma-separated list of Stellar public
+keys). See [admin.md](./admin.md) for the full list and behavior.
+
+## Rate limits
+
+Selected endpoints are rate limited per client. The limiter keys on wallet
+address when the request is authenticated, and falls back to client IP
+otherwise. Defaults (all configurable via environment variables):
+
+| Bucket | Applies to | Window | Max requests |
+|---|---|---|---|
+| `auth` | `POST /auth/challenge`, `POST /auth/verify` | 15 minutes | 10 |
+| `authRefresh` | Token refresh flows | 15 minutes | 30 |
+| `user` | User profile endpoints | 1 minute | 30 |
+| `dispute` | `POST /trades/:id/dispute` | 1 hour | 5 |
+
+A request over the limit gets `429 Too Many Requests`:
+
+```json
+{
+  "code": "RATE_LIMIT_EXCEEDED",
+  "message": "Too many challenges/verify attempts, try again later.",
+  "details": { "retryAfterSeconds": 900, "limit": 10, "windowMs": 900000 },
+  "timestamp": "2026-07-05T12:00:00.000Z",
+  "path": "/auth/challenge"
+}
+```
+
+Respect `retryAfterSeconds` (and the standard `RateLimit-*` response
+headers) before retrying.
+
+## Pagination
+
+List endpoints that support pagination (e.g. `GET /trades`) use `page` +
+`limit` query parameters rather than cursors:
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `page` | `1` | 1-indexed |
+| `limit` | `20` | Max `100` |
+| `sort` | server default | Format `field:direction`, e.g. `createdAt:desc` |
+
+```bash
+curl 'http://localhost:4000/trades?status=FUNDED&page=2&limit=50&sort=createdAt:desc' \
+  -H 'Authorization: Bearer <token>'
+```
+
+Responses return the page of items under `items`; there is no total count or
+next-page cursor in the payload today, so clients should keep requesting
+increasing `page` values until a page comes back shorter than `limit`.
+
+## Idempotency
+
+Endpoints that create or mutate on-chain state (trade creation, deposit,
+release, dispute, etc.) accept an optional `Idempotency-Key` request header.
+Replaying the same request with the same key within 24 hours returns the
+original cached response instead of re-executing the operation - use this
+for safe client-side retries over flaky networks. A concurrent duplicate
+request with the same key while the first is still in flight waits (up to
+30s) for that first response rather than racing it.
+
+## Content type and payload limits
+
+- Send `Content-Type: application/json` on all request bodies.
+- JSON bodies are capped at 100kb; url-encoded bodies at 5mb (for evidence
+  upload metadata).
+- Responses are JSON unless otherwise noted (the audit history export at
+  `GET /trades/:id/history?format=csv` is the one `text/csv` exception - see
+  [trades.md](./trades.md#audit-history)).

--- a/docs/api/stellar.md
+++ b/docs/api/stellar.md
@@ -1,0 +1,166 @@
+# Stellar Proxy Endpoints
+
+These endpoints proxy the Stellar network (via Horizon) so clients don't
+need to talk to Horizon directly or manage network selection themselves. The
+backend targets whichever network `STELLAR_NETWORK` is configured for
+(`testnet` or `pubnet`/mainnet).
+
+None of these require a bearer token unless noted.
+
+## Fee stats
+
+`GET /stellar/fees`
+
+Current network fee statistics, straight from Horizon's fee stats endpoint.
+
+**Response `200`**
+
+```json
+{
+  "feeCharged": { "min": "100", "max": "10000", "p50": "100" },
+  "maxFee": { "min": "100", "max": "10000", "p50": "100" },
+  "ledger": 51234567,
+  "lastLedgerBaseFee": 100
+}
+```
+
+`502` if Horizon is unreachable or errors.
+
+## Transaction status
+
+`GET /stellar/tx/:hash/status`
+
+Looks up a submitted transaction by its 64-character hex hash and decodes
+its result XDR into human-readable operation result codes.
+
+**Response `200`**
+
+```json
+{
+  "status": "success",
+  "resultCodes": { "transaction": "txSUCCESS", "operations": ["opINNER"] },
+  "ledger": 51234567,
+  "hash": "a1b2c3...",
+  "createdAt": "2026-07-05T12:00:00Z"
+}
+```
+
+| Status | Meaning |
+|---|---|
+| `400` | `hash` missing or not 64 characters |
+| `404` | Not found on the network yet - `{ "status": "pending", ... }`. A transaction that was just submitted may briefly 404 before Horizon ingests it; poll rather than treating this as a failure. |
+| `502` | Horizon lookup failed for another reason |
+
+## Assets
+
+`GET /stellar/assets?issuer=<address>` - lists assets, optionally filtered by
+issuer.
+
+`GET /stellar/assets/:code?issuer=<address>` - lists assets matching a code,
+optionally scoped to one issuer. `404` if nothing matches.
+
+Both endpoints cache Horizon responses for 5 minutes; a cache hit is
+indicated by `"cached": true` in the response so clients can tell freshness
+apart from a live lookup.
+
+**Response `200`**
+
+```json
+{
+  "assets": [
+    {
+      "code": "USDC",
+      "issuer": "GBBB...C4",
+      "supply": "1000000.0000000",
+      "authRequired": false,
+      "authRevocable": false,
+      "authClawbackEnabled": false,
+      "numAccounts": 42
+    }
+  ],
+  "cached": false
+}
+```
+
+## Account balance
+
+`GET /stellar/account/:address/balance`
+
+**Response `200`**
+
+```json
+{
+  "address": "GAAA...WHF",
+  "balances": [
+    { "assetType": "native", "assetCode": "XLM", "issuer": null, "balance": "100.0000000", "limit": null },
+    { "assetType": "credit_alphanum4", "assetCode": "USDC", "issuer": "GBBB...C4", "balance": "250.0000000", "limit": "1000000" }
+  ]
+}
+```
+
+An address that's valid but not yet funded on-network returns `200` with an
+empty `balances` array rather than a `404` - "not funded" and "no balances"
+are treated as the same client-visible state. `400` for a malformed address
+(must be 56 characters starting with `G`).
+
+## Account creation
+
+`POST /stellar/account/create`
+
+Generates a new Stellar keypair server-side. **The response includes the
+secret key, symmetrically encrypted** (`encryptedSecretKey`) - decrypting it
+is the caller's responsibility using whatever key-management flow the
+client app implements; the backend does not persist the plaintext secret.
+
+**Request body** (all optional)
+
+```json
+{ "fund": true }
+```
+
+`fund: true` on testnet triggers a Friendbot airdrop so the account is
+immediately usable; on mainnet `fund` is accepted but ignored (no automatic
+funding exists there), and Friendbot failures don't fail account creation -
+the account is still returned with `"funded": false`.
+
+**Response `201`**
+
+```json
+{
+  "publicKey": "GAAA...WHF",
+  "encryptedSecretKey": "...",
+  "funded": true
+}
+```
+
+## Contract state
+
+`GET /contract/:contractId/state?tradeId=<id>`
+
+Reads a trade's on-chain escrow contract state directly from the Soroban
+contract (not the backend's own database) - useful for verifying that the
+backend's view of a trade matches the chain.
+
+**Response `200`**
+
+```json
+{ "contractId": "CA...", "tradeId": "4294967297", "state": { "...": "..." } }
+```
+
+`tradeId` query parameter is required (`400 VALIDATION_ERROR` otherwise).
+
+## Path payment quotes
+
+`GET /wallet/path-payment-quote?sourceAmount=1000&sourceAsset=NGN&sourceAssetIssuer=<issuer>`
+
+**Requires a bearer token.** Returns candidate Stellar path-payment routes
+for converting `sourceAsset` into the trade settlement asset (USDC).
+
+| Query param | Required | Notes |
+|---|---|---|
+| `sourceAmount` | yes | Decimal string |
+| `sourceAsset` | yes | Asset code, or `native` for XLM |
+| `sourceAssetIssuer` | only for non-native assets | Issuer's Stellar public key |
+
+`400` with `{ "error": "Missing sourceAmount or sourceAsset" }` if either
+required parameter is absent.

--- a/docs/api/trades.md
+++ b/docs/api/trades.md
@@ -1,0 +1,209 @@
+# Trade Endpoints
+
+All trade endpoints require `Authorization: Bearer <token>` (see
+[overview.md](./overview.md#authentication)) unless stated otherwise.
+Responses generally follow the [error envelope](./errors.md) on failure.
+
+## Trade lifecycle
+
+A trade moves through these statuses:
+
+```
+CREATED -> FUNDED -> DELIVERED -> COMPLETED
+                  \-> DISPUTED -/
+   \------------------------------> CANCELLED
+```
+
+Each transition below is built server-side as an **unsigned Stellar
+transaction (XDR)** that the caller must sign client-side and submit to the
+network - the backend never holds a user's signing key. `PENDING_SIGNATURE`
+is the transient state between building and submitting a transaction.
+
+## Create a trade
+
+`POST /trades`
+
+Builds the create-trade contract call. The buyer is derived from the bearer
+token, not the request body - you cannot create a trade on someone else's
+behalf.
+
+Supports `Idempotency-Key` (see [overview.md](./overview.md#idempotency)).
+
+**Request body**
+
+```json
+{
+  "sellerAddress": "GBBB...C4",
+  "amountUsdc": "125.1234567",
+  "buyerLossBps": 5000,
+  "sellerLossBps": 5000
+}
+```
+
+`buyerLossBps` / `sellerLossBps` are basis points (0-10000) describing how a
+dispute loss would be split between the two parties.
+
+**Response `201`**
+
+```json
+{ "tradeId": "4294967297", "unsignedXdr": "AAAAAgAAAAC..." }
+```
+
+| Status | Meaning |
+|---|---|
+| `400` | Validation failed, see `VALIDATION_ERROR` in [errors.md](./errors.md) |
+| `401` | Missing/invalid token |
+| `500` | Unexpected server error |
+
+## List your trades
+
+`GET /trades`
+
+Paginated list of trades where the caller is buyer or seller. See
+[overview.md](./overview.md#pagination) for `page`/`limit`/`sort`.
+
+**Query parameters**
+
+| Param | Type | Notes |
+|---|---|---|
+| `status` | enum | `CREATED`, `FUNDED`, `DELIVERED`, `RELEASED`, `DISPUTED`, `RESOLVED` |
+| `page` | integer | default `1` |
+| `limit` | integer | default `20`, max `100` |
+| `sort` | string | e.g. `createdAt:desc` |
+
+**Response `200`**
+
+```json
+{
+  "items": [
+    {
+      "tradeId": "4294967297",
+      "buyerAddress": "GAAA...WHF",
+      "sellerAddress": "GBBB...C4",
+      "amountUsdc": "125.1234567",
+      "status": "FUNDED"
+    }
+  ]
+}
+```
+
+## Trade stats
+
+`GET /trades/stats` - aggregate counts/totals for the caller's trades.
+Response shape is intentionally open-ended (`additionalProperties: true` in
+the OpenAPI spec) since new aggregates get added over time; treat unknown
+fields as forward-compatible additions.
+
+## Fetch a trade
+
+`GET /trades/:id` - returns the [`TradeSummary`](#trade-object-fields) for a
+single trade. `403` if the caller is neither buyer, seller, nor an admin;
+`404` if the trade doesn't exist.
+
+## Deposit
+
+`POST /trades/:id/deposit`
+
+Builds the deposit transaction. **Buyer only**, and the trade must be
+`CREATED`. Supports `Idempotency-Key`.
+
+**Response `200`**: `{ "unsignedXdr": "..." }`
+
+## Confirm delivery
+
+`POST /trades/:id/confirm`
+
+Builds the confirm-delivery transaction. **Buyer only**, and the trade must
+be `FUNDED`.
+
+`403` example bodies:
+
+```json
+{ "error": "Only the buyer may confirm delivery" }
+```
+
+## Release funds
+
+`POST /trades/:id/release`
+
+Builds the release-funds transaction, moving escrowed funds to the seller.
+**Buyer or an admin wallet** (see [admin.md](./admin.md)), and the trade
+must be `DELIVERED`. Supports `Idempotency-Key`.
+
+`403` example: `{ "error": "Only the buyer or an admin may release funds" }`
+
+## Open a dispute
+
+`POST /trades/:id/dispute`
+
+Builds the dispute transaction. Supports `Idempotency-Key`.
+
+**Request body**
+
+```json
+{
+  "reason": "Goods arrived damaged at delivery point.",
+  "category": "DAMAGE"
+}
+```
+
+- `reason` is required, minimum 10 characters.
+- Provide either `category` (name) or `categoryId` (numeric id) - it must
+  match an active entry from `GET /dispute-categories`.
+
+## Manifest
+
+`GET /trades/:id/manifest` / `POST /trades/:id/manifest`
+
+The delivery manifest (driver, vehicle, route, ETA). The response shape
+depends on the caller's role, since manifest data includes courier PII:
+
+| Caller | View |
+|---|---|
+| Seller | Full manifest, all fields |
+| Buyer | Driver identity fields masked |
+| Mediator/admin | Driver identity fields hashed |
+
+`POST` requires `driverName`, `driverIdNumber`, `vehicleRegistration`,
+`routeDescription`, `expectedDeliveryAt` (ISO 8601). Returns `409` if a
+manifest already exists for the trade - manifests aren't overwritable via
+this endpoint.
+
+## Evidence
+
+`GET /trades/:id/evidence` - list evidence records attached to a trade (photos, documents, etc. referenced by IPFS CID). Streaming/upload of the underlying files is handled by `GET /evidence/:cid/stream` and `POST /evidence/video`.
+
+## Audit history
+
+`GET /trades/:id/history`
+
+Returns the full event history for a trade.
+
+| Query param | Effect |
+|---|---|
+| `format=json` (default) | JSON array of events under `events` |
+| `format=csv` | Returns `text/csv` instead of JSON |
+| `signed=true` | Adds `canonicalPayload` and `integrity` (hash + algorithm + key id) so the export can be verified later |
+
+`GET /trades/:id/history/verify?signature=<base64>` re-verifies a
+previously-issued signed export and returns:
+
+```json
+{ "valid": true, "payloadHash": "...", "algorithm": "ed25519", "keyId": null }
+```
+
+## Trade object fields
+
+`TradeSummary` (the shape returned by list/fetch endpoints) is intentionally
+open (`additionalProperties: true`) since fields get added as the domain
+model grows. The fields guaranteed to be present today:
+
+| Field | Type | Notes |
+|---|---|---|
+| `tradeId` | string | Stable identifier, always present |
+| `buyerAddress` | string | Stellar public key |
+| `sellerAddress` | string | Stellar public key |
+| `amountUsdc` | string | Decimal string, not a float - do not parse with `parseFloat` for anything money-related |
+| `status` | string | One of the lifecycle statuses above |
+
+Treat any other field on a trade object as informational and optional.


### PR DESCRIPTION
## Summary
Adds `docs/api/`:
- `overview.md` - base URL, the challenge/verify/JWT auth flow, JWT claim requirements, rate limit buckets, pagination (`page`/`limit`/`sort`), idempotency keys, payload limits.
- `trades.md` - the full trade lifecycle (create/list/stats/fetch/deposit/confirm/release/dispute/manifest/evidence/audit history), with real request/response examples.
- `stellar.md` - the Horizon-proxying endpoints (fees, tx status, assets, account balance/create, contract state, path payment quotes).
- `admin.md` - treasury, batch trade status updates, and the new feature-flag endpoints from #795, all gated by `ADMIN_STELLAR_PUBKEYS`.
- `errors.md` - both error envelope shapes in use, the full `ErrorCode` enum with actual HTTP statuses (cross-checked against where each is thrown in `trade.controller.ts`/`auth.service.ts`/etc.), and a retry-vs-don't-retry checklist.

Written directly from the route handlers and the existing OpenAPI spec (`backend/src/docs/openapi.json`) rather than from scratch, so the examples reflect actual behavior instead of guessed shapes.

Closes #794