### PR TITLE
Write deployment runbook

### DIFF
--- a/docs/runbooks/database-migration.md
+++ b/docs/runbooks/database-migration.md
@@ -1,0 +1,100 @@
+# Database Migration Runbook
+
+This is the short, operational version for the moment you're about to run
+(or roll back) a migration. For the full policy - backward-compatibility
+rules, backup schedule, CI enforcement, and the escalation matrix - see
+[migration-rollback-playbook.md](../migration-rollback-playbook.md), which
+this page defers to rather than duplicates.
+
+## How to run a migration
+
+Always go through `scripts/migrate-safe.sh`, never `prisma migrate deploy`
+directly:
+
+```bash
+# See what would happen, without applying anything
+./scripts/migrate-safe.sh --env=staging --dry-run
+
+# Staging
+./scripts/migrate-safe.sh --env=staging
+
+# Production (adds a backup step + interactive confirmation for destructive DDL)
+./scripts/migrate-safe.sh --env=production
+```
+
+`migrate-safe.sh` runs, in order: a connectivity check, a list of pending
+migrations, a scan of the pending SQL for destructive DDL (`DROP`,
+`TRUNCATE`, `NOT NULL` without a `DEFAULT`), a backup (production only,
+warns on non-production), the actual `prisma migrate deploy`, and a
+post-migration status check. See
+[migration-rollback-playbook.md §1](../migration-rollback-playbook.md#1-everyday-migration-workflow)
+for the full breakdown of each step.
+
+Before writing a migration that changes an existing column, check
+[migration-rollback-playbook.md §2](../migration-rollback-playbook.md#2-backward-compatibility-rules)
+for which operations are safe, which need care (add a default before
+`NOT NULL`, two-phase a rename), and which are destructive enough to need a
+maintenance window.
+
+## How to verify a migration
+
+1. `migrate-safe.sh`'s own post-migration status check (step 6) confirms
+   Prisma's migration table is consistent.
+2. Hit `GET /health/ready` and `GET /health/detail` on the environment you
+   migrated - a broken migration usually shows up as a DB health-check
+   failure immediately (see [incident-response.md](./incident-response.md)
+   if it doesn't come back healthy).
+3. For a schema change that a route depends on, exercise that route once
+   in the migrated environment before considering the deploy done (see
+   [deployment.md §post-deploy-verification](./deployment.md#post-deploy-verification)).
+
+## How to roll back a migration
+
+Read [migration-rollback-playbook.md §4 Rollback Procedures](../migration-rollback-playbook.md#4-rollback-procedures)
+for the full detail on each scenario below before acting - which one applies
+depends on how far the migration got and whether it's already in
+production:
+
+1. **Scenario A - migration failed mid-run.** Prisma rolls back the failed
+   transaction automatically, leaving it "failed" in `_prisma_migrations`.
+   Inspect with `npx prisma migrate status`, fix the SQL and re-run
+   `migrate-safe.sh`, or mark it rolled back without reapplying via
+   `./scripts/migrate-rollback.sh --env=<env> --mark-rolled-back=<migration_name>`.
+2. **Scenario B - migration succeeded but broke the application.** Apply
+   the migration's companion `rollback.sql` (if one exists) via
+   `./scripts/migrate-rollback.sh --env=<env> --from-sql=backend/prisma/migrations/<name>/rollback.sql`.
+   For production, coordinate with on-call first - this modifies the live
+   schema.
+3. **Scenario C - catastrophic failure, restore from backup.**
+   `./scripts/migrate-rollback.sh --env=production --from-backup=<backup file>`.
+   This drops and recreates the database - all rows written after the
+   backup point are lost. Last resort only, and requires the escalation in
+   [migration-rollback-playbook.md §8](../migration-rollback-playbook.md#8-contacts-and-escalation)
+   - page on-call, do not run further migrations until resolved.
+
+After any of the above: confirm the application is healthy (see
+[deployment.md §post-deploy-verification](./deployment.md#post-deploy-verification)),
+mark the migration rolled back if you haven't already, and file a
+postmortem per [incident-response.md](./incident-response.md) if this was
+production.
+
+## Backups
+
+| Environment | When | How | Retention |
+|---|---|---|---|
+| Staging | Before every migration | `pg_dump` via `migrate-safe.sh` | 7 days |
+| Production | Before every migration + daily | Managed cloud backup + `pg_dump` | 30 days |
+
+See [migration-rollback-playbook.md §6 Backup Strategy](../migration-rollback-playbook.md#6-backup-strategy)
+for where backups are stored and how to restore one.
+
+## CI enforcement
+
+[migration-rollback-playbook.md §7 CI Migration Check](../migration-rollback-playbook.md#7-ci-migration-check)
+documents a dedicated `migration-check.yml` workflow that scans PR
+migration diffs for destructive DDL and gates merges to `main` behind a
+`migration:destructive-approved` label. As of this writing that workflow
+isn't present in `.github/workflows/` (only `ci.yml` and `staging.yml`
+exist) - treat the label/approval process as the manual policy until the
+automated gate is actually wired up, and don't assume CI will catch a
+destructive migration for you today.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -1,0 +1,149 @@
+# Deployment Runbook
+
+Step-by-step deploy process for the three deployable pieces of Amana:
+backend, frontend, and the Soroban escrow contract. Companion docs:
+[docker-profiles.md](../docker-profiles.md) (environment topology),
+[migration-rollback-playbook.md](../migration-rollback-playbook.md)
+(migrations in depth - see also [database-migration.md](./database-migration.md)),
+and [contract-deployment-local-network.md](../contract-deployment-local-network.md).
+
+## Environments
+
+| Environment | Infra | How it's deployed |
+|---|---|---|
+| `dev` | Local Docker (`docker-compose.yml` `dev` profile) | `./scripts/dev-up.sh` |
+| `staging` | Docker Compose `staging` profile, seeded synthetic data | `./scripts/staging-up.sh`, also runs automatically via `.github/workflows/staging.yml` on push to `develop` |
+| `production` | Externally managed cloud infra (managed Postgres, managed Redis) - see [docker-profiles.md](../docker-profiles.md#production-notes) | Manual, following this runbook (no CD pipeline exists yet) |
+
+There is currently no automated production deploy workflow - production
+release is a manual, checklist-driven process. If you're setting one up,
+this runbook is the source of truth for what it needs to do.
+
+## Pre-deploy checklist
+
+Before deploying to staging or production:
+
+1. CI is green on the commit you're deploying (`.github/workflows/ci.yml`).
+2. Risky changes are behind a feature flag defaulted to off (see
+   [admin.md](../api/admin.md#feature-flags)) rather than deployed live.
+3. Confirm whether this deploy includes a Prisma migration. If so, read
+   [database-migration.md](./database-migration.md) fully before continuing
+   - migrations are the highest-risk part of any deploy.
+4. Take a fresh backup if deploying to production (see
+   [database-migration.md](./database-migration.md#backups)).
+
+## Backend deployment
+
+The backend is an Express app under `backend/`, backed by Postgres (via
+Prisma) and Redis.
+
+### Staging
+
+```bash
+cp .env.staging.example .env.staging   # first time only; fill in secrets
+./scripts/staging-up.sh
+```
+
+`staging-up.sh` starts the `staging` Docker Compose profile, waits for
+Postgres/Redis health checks, applies pending migrations via
+`migrate-safe.sh --env=staging`, seeds synthetic data, and (unless
+`--skip-validate` is passed) runs `staging-validate.sh` to smoke-test the
+deployment. This is the same sequence `.github/workflows/staging.yml` runs
+on every push to `develop`.
+
+Tear down with:
+
+```bash
+docker compose --profile staging down -v --remove-orphans
+```
+
+### Production
+
+1. Build the backend:
+   ```bash
+   cd backend
+   npm ci
+   npx prisma generate
+   npm run build   # emits dist/
+   ```
+2. Apply migrations first, separately from the app deploy:
+   ```bash
+   ./scripts/migrate-safe.sh --env=production
+   ```
+   See [database-migration.md](./database-migration.md) - this step alone
+   has its own pre-flight checks, backup, and confirmation gate for
+   destructive DDL.
+3. Roll out `dist/` to the production environment (behind whatever process
+   manager/orchestrator the target infra uses) with the production `.env`
+   populated per `backend/src/config/env.ts` (JWT secrets, `DATABASE_URL`,
+   `REDIS_URL`, `ADMIN_STELLAR_PUBKEYS`, `STELLAR_NETWORK=mainnet`, etc.).
+4. Confirm the new instance is healthy before routing traffic to it:
+   ```bash
+   curl https://<host>/health/ready
+   curl https://<host>/health/startup
+   ```
+   Both should return `200`. `health.detail.routes.ts` also exposes deeper
+   dependency checks (DB, Redis) under `/health` - see
+   [trades.md](../api/trades.md) and [overview.md](../api/overview.md) for
+   general API conventions if you're scripting this check.
+5. Only after the new instance passes health checks, shift traffic to it
+   and stop the old instance (keep it stoppable-but-not-deleted for a
+   rollback window - see [rollback.md](./rollback.md)).
+
+## Frontend deployment
+
+The frontend is a Next.js app under `frontend/`.
+
+```bash
+cd frontend
+npm ci
+npm run build   # next build
+npm run start   # next start, or hand dist output to your Next.js host
+```
+
+There's no Vercel/Netlify config checked into the repo today - deploy
+`frontend/` to whatever Node host or static/edge platform your environment
+uses, pointing its API base URL env var at the backend for that
+environment (staging backend for a staging frontend deploy, etc.).
+
+## Contract deployment
+
+The Soroban escrow contract lives in `contracts/amana_escrow`.
+
+- **Local network**: fully scripted and documented -
+  `./scripts/deploy-contract-local.sh --network standalone --admin <pubkey> --token-contract <id> --treasury <pubkey>`.
+  See [contract-deployment-local-network.md](../contract-deployment-local-network.md)
+  for the full flow, including `--upgrade` for redeploying to an existing
+  contract ID. `scripts/check-contract-deployment-safety.sh` runs as a
+  separate CI check (`.github/workflows/ci.yml`) against the contract
+  source, not from inside the deploy script itself - it's worth running
+  manually before a deploy too, since a CI failure after you've already
+  deployed is too late.
+- **Testnet/mainnet**: not yet scripted. Use the same parameters and
+  `soroban-cli`/`stellar-cli` flow as the local script, pointed at the
+  target network's RPC and passphrase (`STELLAR_NETWORK_PASSPHRASE` in
+  `backend/src/config/env.ts` shows the values the backend expects to
+  match). Run `check-contract-deployment-safety.sh` against the contract
+  source before deploying to a real network, the same check CI runs on
+  every PR.
+- After deploying/upgrading a contract, update the backend's contract ID
+  configuration (`treasury.routes.ts` / `stellar.service.ts` consumers read
+  it from environment) and verify with:
+  ```bash
+  curl "https://<backend-host>/contract/<contractId>/state?tradeId=<known-trade-id>"
+  ```
+  (see [stellar.md](../api/stellar.md#contract-state)).
+
+## Post-deploy verification
+
+1. `GET /health/ready` and `GET /health/startup` return `200`.
+2. Run (or confirm CI already ran) `staging-validate.sh`-equivalent smoke
+   checks for the environment you deployed to.
+3. Spot-check one read endpoint (`GET /trades/stats` with a known test
+   token) and, for a backend deploy, one write endpoint in a non-production
+   environment before trusting the same code path in production.
+4. Watch error rates/logs for the deployed service for at least one full
+   request-rate cycle before declaring the deploy complete.
+
+If any of the above fails, go to [rollback.md](./rollback.md) rather than
+attempting a forward fix under pressure.

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,89 @@
+# Incident Response Runbook
+
+Severity levels, response steps, and escalation for production incidents.
+Uses the same P0-P3 severity convention as
+[threat-model.md](../threat-model.md).
+
+## Severity levels
+
+| Severity | Definition | Examples | Response time |
+|---|---|---|---|
+| **P0 - Critical** | Funds at risk, or the service is down for all users | Treasury/escrow contract draining unexpectedly; backend fully down; database unreachable in production; admin key compromise (see [threat-model.md](../threat-model.md) TH-P-02) | Immediate - page on-call now |
+| **P1 - High** | Core functionality broken for a significant subset of users, no direct fund loss yet | Trade creation/deposit/release failing; auth broken for a subset of wallets; a migration failed mid-way in production | Immediate - page on-call |
+| **P2 - Medium** | Degraded but workable; a non-core path is broken | Evidence upload failing; audit history export broken; elevated but not failing error rates; a feature-flagged feature misbehaving (can be disabled via [admin.md](../api/admin.md#feature-flags) as immediate mitigation) | Same business day |
+| **P3 - Low** | Cosmetic or edge-case issue, no user-facing outage | Docs endpoint drift; a rarely-hit validation message is wrong | Next working session |
+
+When in doubt, classify one level higher and downgrade after triage - it's
+cheaper to stand down a P0 than to escalate a mishandled P1.
+
+## Immediate response steps
+
+1. **Acknowledge.** Whoever notices first (alert, user report, or manual
+   observation) claims the incident and starts a timeline (timestamped
+   notes - what you observed, what you tried, what happened).
+2. **Classify severity** using the table above.
+3. **Mitigate before diagnosing**, if a fast mitigation exists:
+   - Disable the specific feature flag if the incident traces to a
+     flagged feature ([admin.md](../api/admin.md#feature-flags)) - this
+     takes effect immediately with no redeploy.
+   - Roll back the last deploy if the incident started right after one
+     (see [rollback.md](./rollback.md)).
+   - For a suspected fund-draining or key-compromise incident (P0), the
+     priority is stopping further loss, not preserving evidence -
+     revoke/rotate the admin key(s) in `ADMIN_STELLAR_PUBKEYS` and pause
+     the affected flow if possible before anything else.
+4. **Check health/status signals**:
+   ```bash
+   curl https://<host>/health/ready
+   curl https://<host>/health/detail   # deeper dependency checks
+   ```
+   (see [trades.md](../api/trades.md) / [overview.md](../api/overview.md)
+   for general API conventions, and [errors.md](../api/errors.md) for
+   reading error codes out of application logs).
+5. **Communicate.** Post an initial status update as soon as severity is
+   classified, even before root cause is known - "investigating a P1
+   affecting trade releases" beats silence. Update at a cadence
+   proportional to severity (continuous for P0, every 30-60 min for P1).
+6. **Escalate** per the table below if you can't mitigate or diagnose
+   within the response-time target for the severity.
+
+## Escalation matrix
+
+| Situation | Escalate to | Notes |
+|---|---|---|
+| P0/P1, on-call hasn't acknowledged within 10 min | Secondary on-call / eng lead | Don't wait past the response-time target to escalate |
+| Suspected fund loss or admin-key compromise | Eng lead + whoever holds treasury/admin key rotation authority | Follow the mitigation-before-diagnosis order above |
+| Failed production migration | On-call, immediately - see the escalation table in [migration-rollback-playbook.md](../migration-rollback-playbook.md#8-contacts-and-escalation) | Do not attempt further migrations until resolved |
+| Data loss suspected | On-call immediately; stop all writes | Same as the migration playbook's guidance - do not run further migrations or write operations until the extent of loss is understood |
+| Contract bug already executed on-chain (funds moved incorrectly) | Eng lead + treasury/admin key holder | This is not a rollback - see [rollback.md](./rollback.md#contract-rollback) |
+
+## During the incident
+
+- Keep the timeline updated - every mitigation attempt and its result, not
+  just the final fix. This becomes the postmortem's evidence.
+- Prefer the smallest change that stops user impact over a complete fix
+  under pressure. Land the full fix as a follow-up once the incident is
+  stood down.
+- If a rollback is the mitigation, follow [rollback.md](./rollback.md)
+  rather than improvising - rolling back application code while a
+  migration is half-applied, or rolling back a contract upgrade with
+  in-flight trades, has specific failure modes documented there.
+
+## Stand-down criteria
+
+An incident is resolved (not just mitigated) when:
+
+- The user-facing symptom is gone and has stayed gone through at least one
+  full traffic cycle.
+- Root cause is identified (not just "the rollback fixed it").
+- Any data inconsistency introduced during the incident has been
+  accounted for (reconciled, or confirmed none exists).
+
+## Postmortem
+
+For P0/P1 incidents, write a blameless postmortem within 2 business days
+covering: timeline, root cause, what mitigated it, what will prevent
+recurrence (with owners and rough timing - not necessarily a hard deadline).
+Link the postmortem from the incident's tracking issue. P2/P3 incidents get
+a postmortem at the reporter's discretion - always write one if the same
+class of issue has recurred.

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,113 @@
+# Rollback Procedures
+
+How to roll back each deployable piece of Amana after a bad deploy. If the
+bad deploy included a database migration, read
+[database-migration.md](./database-migration.md) and
+[migration-rollback-playbook.md](../migration-rollback-playbook.md) first -
+rolling back application code while a migration is half-applied can make
+things worse, not better.
+
+## General principle: roll back code before data
+
+Application rollbacks are fast and cheap; data rollbacks are slow and risky.
+Always prefer:
+
+1. Roll back the application (backend/frontend/contract) to the last known
+   good version.
+2. Only touch the database if the bad deploy already wrote bad data, or the
+   migration itself is the problem.
+
+## Backend rollback
+
+Because there's no automated CD pipeline for production (see
+[deployment.md](./deployment.md)), rollback is redeploying the previous
+known-good build:
+
+1. Identify the last good commit/build (the one deployed before the
+   incident).
+2. Rebuild and redeploy it following the same steps as
+   [deployment.md](./deployment.md#backend-deployment), pointed at the
+   *existing* database - do **not** re-run migrations as part of a
+   rollback unless the migration itself is what you're rolling back (see
+   below).
+3. Verify with `GET /health/ready` and `GET /health/startup` before
+   shifting traffic back.
+4. If the bad deploy is still serving traffic and can't be replaced
+   immediately, disable the specific broken feature via the feature-flag
+   admin API instead of a full rollback where possible - see
+   [admin.md](../api/admin.md#feature-flags). Setting `enabled: false` on
+   the offending flag takes effect immediately, with no redeploy, and is
+   almost always faster than a full rollback.
+
+### Staging
+
+```bash
+docker compose --profile staging down -v --remove-orphans
+git checkout <previous-good-commit>
+./scripts/staging-up.sh --reset
+```
+
+`--reset` wipes the staging database/seed data so you get a clean re-seed
+against the previous version - use this when the bad deploy corrupted
+staging state, skip it if you just need the previous binary running against
+existing data.
+
+## Frontend rollback
+
+Redeploy the previous build to your Next.js host (`frontend/`, `npm run
+build && npm run start`, or the equivalent for your hosting platform).
+Frontend rollback is independent of backend rollback - the two aren't
+required to move in lockstep unless the incident is caused by an API
+contract change between them (check [errors.md](../api/errors.md) and the
+relevant endpoint doc under `docs/api/` for what changed).
+
+## Contract rollback
+
+Soroban contracts are **not trivially reversible** - once a contract holds
+funds and state, there is no "undo" at the network level.
+
+- If the bad deploy is a fresh contract with no funds/trades yet: redeploy
+  the previous contract version at a new contract ID and update the
+  backend's contract ID config. Nothing to migrate.
+- If the bad deploy is an **upgrade** to an existing contract
+  (`deploy-contract-local.sh --upgrade`, or the equivalent for a real
+  network) and the new version has a bug: upgrade again with the previous
+  known-good WASM. This works because Soroban upgrades replace the
+  contract's executable while preserving its storage/state - it is not a
+  fresh deploy, so in-flight trades are unaffected by the upgrade itself.
+- If the bug already caused an incorrect on-chain state change (e.g. wrong
+  fee applied, funds moved incorrectly): this is **not a rollback
+  situation**, it's an incident - see [incident-response.md](./incident-response.md).
+  Recovering funds/state requires a deliberate corrective transaction, not
+  an automated rollback, and likely involves the admin/treasury flows in
+  [admin.md](../api/admin.md).
+- Run `scripts/check-contract-deployment-safety.sh` against the rollback
+  target before deploying it, same as CI would for a forward deploy.
+
+## Database rollback
+
+See [database-migration.md](./database-migration.md) for the full decision
+tree (revert-migration vs. restore-from-backup vs. rollback SQL file). In
+short:
+
+- Migration failed mid-run: Prisma auto-rolls-back the failed transaction;
+  fix the SQL and retry, or mark it rolled back without reapplying
+  (Scenario A in the playbook).
+- Migration succeeded but broke the application: apply its companion
+  `rollback.sql` via `migrate-rollback.sh` (Scenario B) - coordinate with
+  on-call first in production, since this modifies the live schema.
+- Catastrophic failure: restore from the pre-migration backup (Scenario C)
+  - last resort, drops and recreates the database, and always requires the
+  escalation defined in
+  [migration-rollback-playbook.md §8](../migration-rollback-playbook.md#8-contacts-and-escalation).
+
+## Post-rollback
+
+1. Confirm the rolled-back version is healthy (same checks as
+   [deployment.md](./deployment.md#post-deploy-verification)).
+2. Leave the broken build/artifact available (don't delete it) so it can be
+   inspected for the postmortem.
+3. Open (or update) the incident record per
+   [incident-response.md](./incident-response.md) - a rollback is a
+   mitigation, not a resolution; root cause still needs to be found and
+   fixed before re-attempting the deploy.


### PR DESCRIPTION
## Summary
Adds `docs/runbooks/`:
- `deployment.md` - step-by-step deploy for backend, frontend, and the Soroban contract, across dev/staging/production. Documents what's actually automated today (staging via `staging-up.sh` + `.github/workflows/staging.yml`) vs. what's manual (production has no CD pipeline yet - this runbook is the checklist for that manual process).
- `rollback.md` - rollback per service, including why contract rollbacks are fundamentally different (Soroban upgrades replace code but preserve state; a bad on-chain state change is an incident, not a rollback).
- `incident-response.md` - P0-P3 severity levels (consistent with the existing convention in `docs/threat-model.md`), immediate response steps, and an escalation matrix.
- `database-migration.md` - deliberately short: it's an operational quick-reference that points into the existing `docs/migration-rollback-playbook.md` (Scenarios A/B/C for rollback, the backup schedule, CI enforcement) rather than duplicating it.

While writing the CI-enforcement section I found that `docs/migration-rollback-playbook.md` references a `.github/workflows/migration-check.yml` that doesn't actually exist in the repo (only `ci.yml` and `staging.yml` do) - flagged that explicitly in `database-migration.md` rather than repeating the stale claim, since asserting a CI gate exists when it doesn't could lead someone to skip manual review of a destructive migration.

Closes #793