### PR TITLE
Add architecture decision records (ADRs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ See [DISTRIBUTED_TRACING_GUIDE.md](./DISTRIBUTED_TRACING_GUIDE.md) for detailed 
 
 ---
 
+## 📐 Architecture Decision Records
+
+Key architectural decisions are documented as ADRs in [`docs/adr/`](./docs/adr):
+
+- [ADR-001: Stellar Path Payment Architecture](./docs/adr/ADR-001-stellar-path-payment-architecture.md)
+- [ADR-002: Escrow Loss-Sharing Model](./docs/adr/ADR-002-escrow-loss-sharing-model.md)
+- [ADR-003: Off-chain vs. On-chain Data Partitioning](./docs/adr/ADR-003-offchain-vs-onchain-data-partitioning.md)
+- [ADR-004: Idempotency and Retry Strategy](./docs/adr/ADR-004-idempotency-and-retry-strategy.md)
+- [ADR-005: Frontend State Management](./docs/adr/ADR-005-frontend-state-management.md)
+
 ## 🤝 Contributing
 
 Amana is an open-source project aimed at improving food security and trade efficiency. We welcome developers, designers, and agricultural experts!

--- a/docs/adr/ADR-001-stellar-path-payment-architecture.md
+++ b/docs/adr/ADR-001-stellar-path-payment-architecture.md
@@ -1,0 +1,80 @@
+# ADR-001: Stellar Path Payment Architecture
+
+## Status
+
+Accepted (implemented in `backend/src/services/pathPayment.service.ts`,
+exposed via `GET /wallet/path-payment-quote` - see
+[docs/api/stellar.md](../api/stellar.md#path-payment-quotes)).
+
+## Context
+
+Amana settles trades in USDC on Stellar, but buyers frequently hold other
+assets (most notably NGN-pegged tokens, or XLM). Requiring a buyer to
+manually acquire USDC before funding a trade is friction that pushes people
+off the platform. Stellar's DEX supports **path payments**, which let a
+sender pay in one asset while the receiver gets another, atomically, via an
+on-network conversion path - but discovering a *viable* path (one with
+enough liquidity for the amount involved) requires querying Horizon's
+`strictSendPaths` endpoint, and that endpoint is an external network
+dependency that can be slow, rate-limited, or briefly unavailable.
+
+We needed a way to expose "what will I get if I pay with X" to the frontend
+without making every quote request a single point of failure for the rest
+of the API.
+
+## Decision
+
+1. **Always quote against USDC as the destination asset.** The backend
+   resolves the correct USDC issuer for the configured network
+   (`USDC_ISSUER_MAINNET`/`USDC_ISSUER_TESTNET`) rather than accepting an
+   arbitrary destination asset - trade settlement is always USDC, so the
+   quote endpoint's job is narrowly "convert this into what a trade needs,"
+   not a general-purpose DEX quoting service.
+2. **Source asset defaults to a fixed test/reference issuer when the caller
+   doesn't supply one**, so the endpoint has a sane behavior in
+   non-production environments without every caller needing to know a real
+   issuer address.
+3. **Wrap the Horizon call in both a retry and a circuit breaker**
+   (`retryAsync` from `lib/retry.ts`, `CircuitBreaker` from
+   `lib/circuitBreaker.ts`, named `horizon-path-payment`):
+   - `retryAsync` absorbs transient failures (network blips, Horizon 5xx)
+     with backoff, so a single flaky request doesn't surface as an error to
+     the client.
+   - The circuit breaker (5 consecutive failures to open, 2 successes in
+     half-open to close, 30s cooldown) protects the rest of the backend
+     from a sustained Horizon outage - once open, quote requests fail fast
+     with a clear "temporarily unavailable" error instead of piling up
+     retries against a dead dependency.
+4. **The quote endpoint is read-only and side-effect-free.** It never
+   builds or submits a transaction; it only returns candidate routes
+   (`source_amount`, `destination_amount`, `path`, etc.) for the client to
+   choose from before initiating an actual payment/deposit flow elsewhere.
+5. **No caching of path payment quotes.** Unlike `stellar.asset.ts` (which
+   caches asset lookups for 5 minutes - see
+   [docs/api/stellar.md](../api/stellar.md#assets)), path quotes are
+   time-sensitive to DEX liquidity and are deliberately fetched live every
+   time rather than risking a stale quote a user acts on.
+
+## Consequences
+
+- **Positive:** A Horizon outage degrades gracefully (fast, clear failure
+  via the circuit breaker) instead of cascading into slow timeouts across
+  the API.
+- **Positive:** Buyers can fund trades from whatever asset they hold,
+  which is the entire point of exposing this endpoint.
+- **Negative:** Quotes are advisory only - the actual conversion happens
+  when the buyer's wallet builds and submits the real path payment
+  transaction client-side, and DEX liquidity can move between quote and
+  execution. The backend does not (and cannot, without holding funds)
+  guarantee the quoted rate.
+- **Negative:** The circuit breaker is process-local (an in-memory
+  `Map`-backed registry in `lib/circuitBreaker.ts`), so in a multi-instance
+  deployment each instance trips independently - a coordinated view of
+  Horizon health across instances would need a shared store, which we
+  don't have today.
+- **Follow-up:** If additional Horizon-backed endpoints need the same
+  resilience pattern, extract the retry+circuit-breaker wrapping into a
+  shared helper rather than re-implementing it per service - `stellar.fees.ts`
+  and `stellar.tx.status.ts` currently handle Horizon failures with a bare
+  `try/catch` -> `502`, not this pattern, and might benefit from it as they
+  see more traffic.

--- a/docs/adr/ADR-002-escrow-loss-sharing-model.md
+++ b/docs/adr/ADR-002-escrow-loss-sharing-model.md
@@ -1,0 +1,110 @@
+# ADR-002: Escrow Loss-Sharing Model
+
+## Status
+
+Accepted (implemented in `contracts/amana_escrow/src/lib.rs`,
+`resolve_dispute`; surfaced to API consumers as `buyerLossBps`/
+`sellerLossBps` on trade creation - see
+[docs/api/trades.md](../api/trades.md#create-a-trade)).
+
+## Context
+
+Amana escrows funds during a trade and, on a dispute, a mediator has to
+decide how much of the total goes to the seller vs. is refunded to the
+buyer. A binary "seller gets everything" or "buyer gets everything"
+outcome doesn't reflect the reality of most delivery disputes (e.g. goods
+arrived late but usable, or partially damaged) - most disputes resolve
+somewhere in between.
+
+We needed a payout model that:
+- Lets a mediator issue a partial ruling (e.g. "seller gets 70%") without
+  the contract needing dispute-specific logic per case.
+  Lets the two parties pre-agree, at trade creation, how *they personally*
+  want any eventual loss split between them - some trade pairs may agree
+  the buyer should absorb more risk (e.g. buyer is testing an unproven
+  seller), others the opposite.
+- Is exact integer arithmetic on-chain (no floats in Soroban), auditable,
+  and cannot be gamed by rounding in either party's favor.
+
+## Decision
+
+Basis points (bps, 1/100th of a percent, `BPS_DIVISOR = 10_000`) are used
+throughout instead of percentages or decimals, matching how Stellar/Soroban
+fee configuration already works elsewhere in the contract (`fee_bps`).
+
+At trade creation, the buyer supplies `buyer_loss_bps` and
+`seller_loss_bps`, which **must sum to exactly 10_000** (100%) - this is
+enforced by the contract (`assert!(buyer_loss_bps + seller_loss_bps ==
+10_000)`), not left to convention. These describe how a loss, if one
+occurs, is split between the two parties; they say nothing about the size
+of the loss itself.
+
+At dispute resolution, the mediator supplies a single number,
+`seller_gets_bps` (0-10_000): what fraction of the total the seller
+deserves, in the mediator's judgment. The contract derives everything else:
+
+```
+loss_bps          = 10_000 - seller_gets_bps
+buyer_loss_amount  = total * loss_bps * buyer_loss_bps  / (10_000 * 10_000)
+seller_loss_amount = total * loss_bps * seller_loss_bps / (10_000 * 10_000)
+seller_raw        = total - seller_loss_amount
+buyer_refund      = total - seller_raw
+fee               = seller_raw * fee_bps / 10_000   # platform fee, seller's portion only
+seller_net        = seller_raw - fee
+```
+
+Worked example (`total=10_000, seller_gets_bps=7_000 (mediator: seller
+deserves 70%), buyer_loss_bps=6_000, seller_loss_bps=4_000, fee_bps=100`):
+
+| Quantity | Value |
+|---|---|
+| `loss_bps` (30% loss) | `3_000` |
+| `buyer_loss_amount` | `1_800` |
+| `seller_loss_amount` | `1_200` |
+| `seller_raw` | `8_800` |
+| `buyer_refund` | `1_200` |
+| platform `fee` | `88` |
+| `seller_net` -> seller | `8_712` |
+| `buyer_refund` -> buyer | `1_200` |
+| `fee` -> treasury | `88` |
+
+`8_712 + 1_200 + 88 = 10_000` - the three payouts always sum to the
+original total; there is no remainder to account for separately.
+
+Key design choices worth calling out explicitly:
+
+- **The mediator never sees or sets `buyer_loss_bps`/`seller_loss_bps`.**
+  Those were fixed by the two parties at trade creation and are immutable
+  for that trade. The mediator's only input is "how much did the seller
+  earn," which keeps the mediator's job simple and prevents a mediator
+  from unilaterally changing the parties' pre-agreed risk split.
+- **The platform fee is deducted only from the seller's portion**, never
+  from the buyer's refund - a buyer who ends up refunded (in part or
+  fully) because the seller under-delivered isn't also charged a platform
+  fee on money they're getting back.
+- **All arithmetic is `i128`/`u32` integer math with `checked_mul`,
+  panicking (reverting the transaction) on overflow** rather than wrapping
+  or silently truncating - an overflowed payout calculation must fail the
+  transaction, not produce a wrong number.
+
+## Consequences
+
+- **Positive:** A single mediator input (`seller_gets_bps`) is sufficient
+  for any dispute outcome from "buyer fully refunded" to "seller fully
+  paid," with the parties' own risk-sharing agreement automatically
+  applied - the mediator doesn't need to reason about basis-point math per
+  case.
+- **Positive:** The three-way payout (seller/buyer/treasury) always sums
+  exactly to the escrowed total by construction, which makes the
+  calculation straightforward to unit-test and fuzz-test exhaustively (see
+  `contracts/amana_escrow/src/tests/bps_fuzz_tests.rs`).
+- **Negative:** `buyer_loss_bps`/`seller_loss_bps` are fixed at trade
+  creation and cannot be renegotiated later, even if circumstances change
+  before a dispute arises - amending them requires cancelling and
+  recreating the trade.
+- **Negative:** The double basis-point multiplication
+  (`loss_bps * buyer_loss_bps`, divided by `10_000 * 10_000`) means very
+  small trade amounts can round loss shares down to zero for one party
+  even when a nonzero split was intended - this is expected integer-math
+  behavior, not a bug, but is worth knowing before assuming precision holds
+  at very low `total` values.

--- a/docs/adr/ADR-003-offchain-vs-onchain-data-partitioning.md
+++ b/docs/adr/ADR-003-offchain-vs-onchain-data-partitioning.md
@@ -1,0 +1,107 @@
+# ADR-003: Off-chain vs. On-chain Data Partitioning
+
+## Status
+
+Accepted (implemented across `contracts/amana_escrow`, `backend/prisma/schema.prisma`,
+and the event-sync pipeline documented in [docs/event-flow.md](../event-flow.md)
+and [docs/data-model-relationships.md](../data-model-relationships.md), which
+remain the detailed references for the mechanics this ADR only summarizes the
+reasoning for).
+
+## Context
+
+Amana needs both the trustlessness of on-chain escrow (funds move only
+according to contract rules, verifiable by anyone) and the practicality of
+a queryable, indexable backend (list a user's trades, filter by status,
+paginate, join to disputes/evidence/manifests). Putting everything on-chain
+would make the contract expensive to run and impossible to query
+efficiently; putting everything off-chain would make the "escrow" part of
+the product just a database record someone could edit.
+
+We needed a clear line for what belongs where, and a reliable way to keep
+the off-chain copy consistent with on-chain reality without trusting
+clients to report their own trade status.
+
+## Decision
+
+**On-chain (Soroban contract, `contracts/amana_escrow`) holds only what
+must be trust-minimized:**
+
+- The escrowed funds themselves (held by the contract, not any party or
+  the backend).
+- The authoritative trade status enum and the numbers that determine fund
+  movement: `amount`, `buyer_loss_bps`/`seller_loss_bps`, `fee_bps` at
+  resolution time, and the mediator's `seller_gets_bps` ruling.
+- Nothing that's expensive to store or has no bearing on fund movement:
+  no manifest text, no evidence files, no user profile data, no dispute
+  reason/category text.
+
+**Off-chain (Postgres via Prisma) holds everything queryable and
+human-facing:**
+
+- A `Trade` row **mirroring** the on-chain status/amount/participants for
+  fast reads (list, filter, paginate - see
+  [docs/api/trades.md](../api/trades.md#list-your-trades)), plus fields
+  that have no on-chain equivalent at all: `version` (optimistic
+  concurrency for the backend's own writes),
+  `fundedAt`/`deliveredAt`/`completedAt` timestamps, and relations to
+  `Dispute`, `DeliveryManifest`, `TradeEvidence`, `TradeNote`.
+- Delivery manifests and dispute evidence - PII (driver identity,
+  documents, photos/video) that has no reason to ever be on a public
+  ledger, and where role-based masking (see
+  [docs/api/trades.md](../api/trades.md#manifest)) only makes sense
+  server-side.
+- User profiles, notifications, webhooks - product features with no
+  trust-minimization requirement at all.
+
+**The off-chain `Trade` row is never the source of truth for fund
+movement - it's a read-optimized mirror, kept in sync via an event-sourced
+pipeline, not by trusting API callers to report their own status.** A
+dedicated `EventListener` service polls Soroban RPC for contract events,
+deduplicates them (in-memory `Set` for the hot path, a durable
+`ProcessedEvent` table so a service restart doesn't reprocess history), and
+a `ChainEventOutbox` table persists each event with retry/backoff and
+dead-lettering if handling fails - see
+[docs/event-flow.md](../event-flow.md) for the full pipeline. Event
+handlers apply mirrored updates inside an atomic Prisma `$transaction`
+guarded by `Trade.version` (optimistic concurrency), so a concurrent
+handler run or an admin batch update
+([docs/api/admin.md](../api/admin.md#batch-trade-status-updates)) can't
+silently clobber another update.
+
+**Contract state remains independently queryable and is not just "trust
+the mirror."** `GET /contract/:contractId/state?tradeId=<id>` (see
+[docs/api/stellar.md](../api/stellar.md#contract-state)) reads the Soroban
+contract directly, bypassing Postgres entirely - this exists specifically
+so the off-chain mirror's claim about a trade's status can be checked
+against the chain when it matters (support escalations, audits, disputes
+about disputes).
+
+## Consequences
+
+- **Positive:** Reads that matter for UX (list my trades, filter by
+  status, join to dispute/evidence data) are fast Postgres queries, not
+  Soroban RPC calls - the contract is never on the hot path for anything
+  except the transactions that actually move funds.
+- **Positive:** Sensitive data (manifest PII, evidence files, dispute
+  narratives) never touches a public ledger, and role-based
+  masking/hashing of that data (buyer sees masked driver identity, mediator
+  sees hashed) is only possible because it's server-mediated, not
+  on-chain.
+- **Positive:** Because the mirror is derived from chain events rather
+  than trusted client input, a compromised or buggy API client can't lie
+  about a trade's status - it can only be as wrong as the event pipeline,
+  which is independently auditable against
+  `GET /contract/:contractId/state`.
+- **Negative:** There is an inherent lag between an on-chain state change
+  and its reflection in the Postgres mirror (bounded by the event
+  listener's poll interval plus handler processing time) - a client that
+  reads `GET /trades/:id` immediately after submitting a transaction may
+  briefly see stale status. Clients needing a stronger guarantee should
+  cross-check `GET /contract/:contractId/state` directly.
+- **Negative:** Two representations of "trade status" (on-chain enum,
+  off-chain `TradeStatus`) must be kept conceptually aligned by hand when
+  either one changes - see
+  [docs/data-model-relationships.md](../data-model-relationships.md) for
+  the current mapping. A status added to one side without the other is a
+  real failure mode the event pipeline can't protect against by itself.

--- a/docs/adr/ADR-004-idempotency-and-retry-strategy.md
+++ b/docs/adr/ADR-004-idempotency-and-retry-strategy.md
@@ -1,0 +1,110 @@
+# ADR-004: Idempotency and Retry Strategy
+
+## Status
+
+Accepted (implemented in `backend/src/middleware/idempotency.ts`,
+`backend/src/lib/retry.ts`, and `backend/src/lib/circuitBreaker.ts`; see
+[docs/api/overview.md](../api/overview.md#idempotency) for the
+consumer-facing contract).
+
+## Context
+
+Amana's mutating endpoints build Stellar/Soroban transactions - operations
+where a client retry after a network timeout is dangerous if the original
+request actually succeeded server-side (e.g. a trade got created, but the
+client never saw the response and retries "create trade" again). Separately,
+several backend services depend on external, occasionally-flaky
+infrastructure (Horizon, IPFS, the Soroban RPC event stream) where
+transient failures are normal and shouldn't surface as user-facing errors,
+but a *sustained* outage shouldn't be retried forever either.
+
+These are two different problems that need two different mechanisms:
+**idempotency** (client retries of the same logical request must be safe)
+and **retry/circuit-breaking** (server-to-dependency calls must tolerate
+transient failure without hammering a dead dependency).
+
+## Decision
+
+### Idempotency: client-supplied key, Redis-backed, lock + cache
+
+Mutating endpoints (trade creation, deposit, release, dispute - see
+[docs/api/trades.md](../api/trades.md)) accept an optional
+`Idempotency-Key` header, handled by `idempotencyMiddleware`:
+
+1. **Cache hit** (`idempotency:<method>:<path>:<key>` exists in Redis):
+   replay the original cached response verbatim, *unless* the request body
+   hash differs from the original - a key reused with a different body is
+   a client bug, not a safe retry, and gets `409` rather than silently
+   serving the wrong cached response.
+2. **No cache, but a lock exists** (`idempotency:lock:...`, set via Redis
+   `SET NX EX` so acquiring it is atomic): another request with the same
+   key is already in flight. Rather than racing it, this request **polls
+   for the first request's result** for up to `IDEMPOTENCY_LOCK_TTL`
+   (30s), and only returns `409 "already in progress"` if that window
+   elapses without a result - a client that retries quickly because it
+   hasn't heard back yet gets the real answer, not a spurious conflict.
+3. **No cache, no lock**: this request acquires the lock, proceeds
+   normally, and on any 2xx response caches it (24h TTL) before releasing
+   the lock (via `res.once("finish"/"close")`, so the lock releases even
+   if the handler throws).
+4. Non-2xx responses are **not cached** - a failed attempt should be
+   retryable with the same key, not permanently frozen as "the answer."
+
+Idempotency only applies to `POST`/`PUT`/`PATCH`/`DELETE` (mutations); a
+request without the header is unaffected, and idempotency is opt-in per
+request, not enforced globally, since not every mutation needs it (see
+[docs/api/overview.md](../api/overview.md#idempotency) for which endpoints
+support it).
+
+### Retry and circuit-breaking: for server-to-dependency calls, not client requests
+
+Separately, outbound calls to Horizon/Stellar RPC and IPFS (in
+`pathPayment.service.ts`, `stellar.service.ts`, `eventListener.service.ts`,
+`ipfs.service.ts`, `contract.service.ts`) go through:
+
+- **`retryAsync`** (`lib/retry.ts`): retries only errors classified
+  retryable by `isRetryableNetworkError` (HTTP `429`, or any `5xx`) -
+  a `4xx` (bad request) is never retried, since retrying an invalid
+  request just repeats the failure. Default backoff is fixed-step
+  (`[1000, 2000, 4000, 8000]`ms) rather than exponential-with-jitter,
+  capped at `DEFAULT_MAX_RETRIES` (3) attempts.
+- **`CircuitBreaker`** (`lib/circuitBreaker.ts`): wraps a named dependency
+  (e.g. `"horizon-path-payment"`) with `CLOSED`/`OPEN`/`HALF_OPEN` states -
+  after `failureThreshold` consecutive failures it opens and fails fast
+  (`CircuitBreakerOpenError`) for `cooldownMs` before allowing a trial
+  request through (`HALF_OPEN`); `successThreshold` consecutive successes
+  there closes it again. This protects the rest of the backend from
+  piling up slow, doomed retries against a dependency that's actually
+  down, and gives callers a fast, clear failure instead of a slow one.
+- The two compose: `circuitBreaker.call(() => retryAsync(() => ...))` -
+  retry absorbs brief blips, the circuit breaker catches sustained
+  outages that retries alone wouldn't (and shouldn't) paper over.
+
+## Consequences
+
+- **Positive:** A client that retries a trade-creation/deposit/release/
+  dispute request after a timeout - the most likely failure mode for a
+  wallet-signing flow, where the user may take a while to sign - gets the
+  original result instead of a duplicate side effect or a confusing error.
+- **Positive:** Horizon/IPFS/RPC flakiness is absorbed close to the call
+  site, and a sustained outage in one dependency fails fast instead of
+  degrading the whole API's latency.
+- **Negative:** Idempotency correctness depends entirely on Redis being
+  available and not evicting keys early - a Redis outage during the
+  `IDEMPOTENCY_LOCK_TTL` window degrades this to "no idempotency
+  protection" rather than blocking requests (the middleware doesn't fail
+  closed on Redis errors); this is a deliberate availability-over-strictness
+  tradeoff worth knowing about, not a bug.
+- **Negative/follow-up:** There are currently **two parallel circuit
+  breaker implementations** - `lib/circuitBreaker.ts` (used by
+  `pathPayment.service.ts`, `health.service.ts`, `ipfs.service.ts`,
+  `eventListener.service.ts`) and a separate `lib/circuit-breaker.ts` (used
+  only by `stellar.service.ts`), with different option shapes
+  (`cooldownMs` vs `resetTimeoutMs`). This wasn't a deliberate decision so
+  much as duplication that crept in - consolidating onto one
+  implementation would remove a real source of confusion for anyone
+  adding a new Horizon-backed call and guessing which one to import.
+- **Negative:** The retry backoff is a fixed schedule, not exponential
+  with jitter - under a thundering-herd scenario (many requests retrying
+  the same dependency at once) this doesn't spread retries out as well as
+  jittered backoff would.

--- a/docs/adr/ADR-005-frontend-state-management.md
+++ b/docs/adr/ADR-005-frontend-state-management.md
@@ -1,0 +1,90 @@
+# ADR-005: Frontend State Management
+
+## Status
+
+Accepted (implemented in `frontend/src/stores/`, `frontend/src/hooks/useAuth.tsx`,
+`frontend/src/lib/api/`).
+
+## Context
+
+The frontend (Next.js 16 App Router, React 19) needs to manage three
+distinct kinds of state that don't naturally belong to the same mechanism:
+
+1. **Server-mirrored data** - trades fetched from the backend, which can
+   go stale, need pagination/filtering, and benefit from optimistic UI
+   updates on mutation (see [docs/api/trades.md](../api/trades.md)).
+2. **Client-only UI preferences** - sidebar collapsed state, preferred
+   currency display - things with no server representation at all, that
+   should survive a page reload.
+3. **Auth/session state** - the wallet connection and JWT, which is
+   security-sensitive and used by nearly every component, but isn't
+   "application data" in the same sense as trades.
+
+We deliberately did not add a server-cache library (React Query, SWR) -
+`frontend/package.json` has no such dependency today.
+
+## Decision
+
+**Zustand (`create`) for both server-mirrored and client-only state**,
+but used differently for each:
+
+- **`useTradeStore`**: holds the fetched `trades` array, `page`,
+  `filters`, `isLoading`/`error`, and actions (`fetchTrades`, `setPage`,
+  `setFilter`) that call `tradesApi` directly and write the result into
+  the store. There is no separate cache layer, no automatic
+  revalidation-on-focus, and no query-key-based invalidation - the store
+  *is* the cache, and it's invalidated by explicitly calling `fetchTrades`
+  again (e.g. after `setPage`/`setFilter`).
+- **Optimistic mutations with manual rollback**: `updateTrade`/
+  `removeTrade` apply the change to local state immediately, then run an
+  optional `serverFn` callback; if `serverFn` rejects, the store restores
+  the pre-mutation snapshot it captured before optimistically updating.
+  This is done by hand (capture `prev`, mutate, revert on catch) rather
+  than via a library's built-in optimistic-update/rollback primitive.
+- **`useUIStore`**: client-only preferences (`sidebarCollapsed`,
+  `currencyDisplay`, `theme`), wrapped in zustand's `persist` middleware so
+  they survive a reload. This store has no server interaction at all and
+  no reason to ever need one.
+
+**Auth is a React Context (`useAuth`/`AuthContextType`), not a zustand
+store.** It wraps Freighter wallet integration (`@stellar/freighter-api`:
+`getAddress`, `isConnected`, `signMessage`, etc.) and the challenge/verify
+flow (`docs/api/overview.md#authentication`), and holds `address`, `token`,
+and connection/loading state. The JWT is persisted directly to
+`localStorage` under a fixed key rather than through the `zustand/persist`
+middleware used for `uiStore` - auth predates (or was deliberately kept
+separate from) the zustand-based stores, and mixing security-sensitive
+session state into the same store family as UI preferences wasn't judged
+worth the consistency gain.
+
+**Data-fetching hooks (`useTradeDetail`, `useTradeDetails`, etc.) wrap
+individual API calls in plain React state**, independent of the zustand
+stores, for data that's fetched once per view rather than needing the
+shared, mutable, list-level state a store provides.
+
+## Consequences
+
+- **Positive:** No extra dependency, and no cache-key/staleness model to
+  learn beyond "call the fetch action again when you need fresh data" -
+  for a codebase of this size, the manual model in `useTradeStore` is
+  simple to reason about end to end.
+- **Positive:** Optimistic updates are explicit and visible in the store
+  code (`updateTrade`/`removeTrade`), rather than hidden behind a library's
+  mutation lifecycle - easy to see exactly what happens on failure.
+- **Negative:** Every consumer of trade data re-fetches through the same
+  store rather than getting automatic dedup/sharing across independent
+  `useQuery`-style calls a library would provide - two components needing
+  the same data both go through `useTradeStore`, which is fine as long as
+  there's exactly one canonical store per resource, but doesn't generalize
+  automatically to a new resource without writing a new store by hand.
+- **Negative:** No automatic revalidation (on refetch-on-focus,
+  refetch-on-reconnect, background polling) - staleness is only resolved
+  when something explicitly calls a fetch action again. `useOffline`
+  exists as a separate hook to at least detect connectivity changes, but
+  reconnection doesn't automatically trigger a re-fetch today.
+- **Negative:** Splitting auth (Context) from app data (zustand) means two
+  different state-access patterns exist side by side
+  (`useAuth()` vs. `useTradeStore()`) - a new contributor has to learn
+  both rather than one consistent pattern, and there's no written rule
+  captured elsewhere for which one a new piece of state should use before
+  this ADR.


### PR DESCRIPTION
## Summary
Adds `docs/adr/ADR-001` through `ADR-005`, each documenting a decision already made in the codebase rather than proposing something new, so the ADR is checkable against the actual implementation:

- **ADR-001** Stellar path payment architecture - why quotes always target USDC, retry + circuit-breaker wrapping around Horizon's `strictSendPaths`, and why quotes aren't cached (unlike asset lookups).
- **ADR-002** Escrow loss-sharing model - the basis-point math in `resolve_dispute` (buyer/seller pre-agreed loss split + mediator's single `seller_gets_bps` ruling), with the worked example straight from the contract's own doc comments.
- **ADR-003** Off-chain vs. on-chain data partitioning - what belongs in the Soroban contract vs. Postgres, and why the Postgres `Trade` row is a read-optimized mirror driven by the event-sourcing pipeline (not a trusted client report) - links out to the existing `docs/event-flow.md` and `docs/data-model-relationships.md` rather than duplicating them.
- **ADR-004** Idempotency and retry strategy - the `Idempotency-Key` lock+cache flow in `idempotency.ts`, and the separate retry/circuit-breaker pattern for outbound Horizon/IPFS calls. Flags a real inconsistency found while researching this: two parallel circuit-breaker implementations (`circuitBreaker.ts` vs `circuit-breaker.ts`) with different option shapes.
- **ADR-005** Frontend state management - why zustand handles both server-mirrored trade state and persisted UI prefs, but auth is a separate React Context, plus the manual optimistic-update/rollback pattern in `tradeStore.ts`.

Linked from `README.md` per the issue's acceptance criteria.

Closes #792