### PR TITLE
Fix CI supply chain and vault audit gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        # Pinned from dorny/paths-filter@v3
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
         with:
           filters: |
             frontend:
@@ -82,6 +83,10 @@ jobs:
 
       - name: Install deps
         run: pnpm install --frozen-lockfile
+
+      - name: Security audit (npm)
+        if: needs.changes.outputs.frontend == 'true'
+        run: npm audit --audit-level=high
 
       - name: Lint
         if: needs.changes.outputs.frontend == 'true'
@@ -130,6 +135,10 @@ jobs:
 
       - name: Install deps
         run: pnpm install --frozen-lockfile
+
+      - name: Security audit (npm)
+        if: needs.changes.outputs.backend == 'true'
+        run: npm audit --audit-level=high
 
       - name: Build
         if: needs.changes.outputs.backend == 'true'
@@ -203,7 +212,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned from dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           targets: wasm32-unknown-unknown
 

--- a/frontend/src/__tests__/api-client.test.ts
+++ b/frontend/src/__tests__/api-client.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
-import { request, requestWithResult, ApiError, navigationHelpers } from "@/lib/api/client";
+import {
+  request,
+  requestWithResult,
+  ApiError,
+  navigationHelpers,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+} from "@/lib/api/client";
 import { z } from "zod";
 
 describe("API Client", () => {
@@ -19,6 +25,10 @@ describe("API Client", () => {
 
       const result = await request<{ data: string }>("/test");
       expect(result).toEqual({ data: "test" });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     });
 
     it("should auto-inject auth token from storage", async () => {
@@ -55,6 +65,37 @@ describe("API Client", () => {
       await expect(request<{ data: string }>("/test")).rejects.toThrow(
         "Network error",
       );
+    });
+
+    it("should abort requests after the configured timeout", async () => {
+      jest.useFakeTimers();
+      global.fetch = jest.fn((_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = (init as RequestInit).signal;
+          signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+      );
+
+      const pending = request<{ data: string }>("/test", { timeoutMs: 10 });
+      jest.advanceTimersByTime(10);
+
+      await expect(pending).rejects.toThrow("Request timed out after 10ms");
+      jest.useRealTimers();
+    });
+
+    it("uses the 30 second default timeout", async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: async () => ({ data: "test" }),
+        } as Response),
+      );
+
+      await request<{ data: string }>("/test");
+
+      expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(30000);
     });
   });
 

--- a/frontend/src/app/vault/manage/page.tsx
+++ b/frontend/src/app/vault/manage/page.tsx
@@ -395,12 +395,6 @@ export default function VaultManagePage() {
     .filter((t) => ["active", "locked"].includes(t.status.toLowerCase()))
     .reduce((sum, t) => sum + parseFloat(t.amountCngn), 0);
 
-  const auditEntries = trades.slice(0, 3).map((trade, i) => ({
-    type: (["biometric", "multi-sig", "ledger"] as const)[i % 3],
-    title: `Trade ${trade.status.toLowerCase().replace(/_/g, " ")}`,
-    metadata: `${fmt(trade.updatedAt)} · ${trade.tradeId.slice(0, 8)}`,
-  }));
-
   // Actions
   async function handleConfirm() {
     if (submittingRef.current || !modal || !token) return;
@@ -783,18 +777,9 @@ export default function VaultManagePage() {
 
                 {/* Audit log */}
                 <AuditLogCard
-                  entries={
-                    auditEntries.length > 0
-                      ? auditEntries
-                      : [
-                          {
-                            type: "ledger",
-                            title: "No recent activity",
-                            metadata: "Connect wallet to view",
-                          },
-                        ]
-                  }
-                  isLiveSync={isAuthenticated}
+                  entries={[]}
+                  isLiveSync={false}
+                  emptyMessage="Vault audit events are not available yet. No security entries are shown until a verified audit source is connected."
                 />
               </div>
             </div>

--- a/frontend/src/app/vault/page.tsx
+++ b/frontend/src/app/vault/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
 import { signTransaction } from "@stellar/freighter-api";
 import {
@@ -67,6 +67,9 @@ export default function VaultPage() {
 
   const [isManifestOpen, setIsManifestOpen] = useState(false);
   const [manifestData, setManifestData] = useState<DriverManifestData | null>(null);
+  const [manifestSubmitting, setManifestSubmitting] = useState(false);
+  const [manifestStatus, setManifestStatus] = useState<string | null>(null);
+  const manifestSubmittingRef = useRef(false);
 
   const fetchVaultData = useCallback(async () => {
     if (!token) return;
@@ -108,24 +111,6 @@ export default function VaultPage() {
   const vaultValue = stats?.totalVolume ?? 0;
   const escrowId = stats ? `${stats.totalTrades}-AX` : "0-AX";
   const sequenceId = stats ? `${stats.openTrades}-AF` : "0-AF";
-
-  const auditEntries =
-    recentTrades?.items.slice(0, 3).map((trade, index) => ({
-      type:
-        index === 0
-          ? ("biometric" as const)
-          : index === 1
-            ? ("multi-sig" as const)
-            : ("ledger" as const),
-      title: `Trade ${trade.status.toLowerCase().replace(/_/g, " ")}`,
-      metadata: `${new Date(trade.updatedAt).toLocaleString()} - ${trade.tradeId}`,
-    })) ?? [
-      {
-        type: "ledger" as const,
-        title: "No recent activity",
-        metadata: "Connect wallet to view",
-      },
-    ];
 
   const isEmpty =
     !loading && isAuthenticated && stats?.totalTrades === 0 && recentTrades?.items.length === 0;
@@ -305,11 +290,17 @@ export default function VaultPage() {
                 <p className="text-sm font-medium text-text-secondary">Driver/Vehicle Manifest</p>
                 <button
                   onClick={() => setIsManifestOpen(true)}
+                  disabled={manifestSubmitting}
                   className="rounded-lg bg-gold px-4 py-2 text-sm font-semibold text-text-inverse transition-colors hover:bg-gold-hover"
                 >
-                  Log Driver Details
+                  {manifestSubmitting ? "Submitting..." : "Log Driver Details"}
                 </button>
               </div>
+              {manifestStatus && (
+                <p className="mt-3 text-xs text-text-secondary" role="status">
+                  {manifestStatus}
+                </p>
+              )}
               {manifestData && (
                 <div className="mt-4 rounded-lg border border-border-default bg-bg-elevated p-3 text-sm text-text-primary">
                   <p><strong>Driver:</strong> {manifestData.driverName}</p>
@@ -396,7 +387,11 @@ export default function VaultPage() {
               </div>
 
               <div>
-                <AuditLogCard entries={auditEntries} isLiveSync={isAuthenticated} />
+                <AuditLogCard
+                  entries={[]}
+                  isLiveSync={false}
+                  emptyMessage="Vault audit events are not available yet. No security entries are shown until a verified audit source is connected."
+                />
               </div>
 
               <div className="md:col-span-2 lg:col-span-3 rounded-2xl border border-border-default bg-card p-5">

--- a/frontend/src/components/layout/AppTopNav.tsx
+++ b/frontend/src/components/layout/AppTopNav.tsx
@@ -35,7 +35,7 @@ export function AppTopNav({
         className="lg:hidden w-8 h-8 rounded-lg flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-elevated transition-all"
         aria-label={isSidebarOpen ? "Close menu" : "Open menu"}
       >
-        <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+        <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           {isSidebarOpen ? (
             <path
               fillRule="evenodd"
@@ -58,7 +58,7 @@ export function AppTopNav({
       </Link>
 
       {/* Nav links */}
-      <nav className="flex items-center gap-1">
+      <nav className="flex items-center gap-1" aria-label="Main navigation">
         {TOP_NAV.map((item) => {
           const isActive = pathname?.startsWith(item.href);
           return (
@@ -73,7 +73,7 @@ export function AppTopNav({
       <div className="ml-auto flex items-center gap-3">
         {/* Notification bell */}
         <button className="w-8 h-8 rounded-full flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-elevated transition-all">
-          <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+          <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
             <path d="M8 1a5 5 0 015 5v3l1.5 2.5H1.5L3 9V6a5 5 0 015-5z" />
             <path d="M6.5 13.5a1.5 1.5 0 003 0" />
           </svg>
@@ -81,7 +81,7 @@ export function AppTopNav({
 
         {/* Avatar */}
         <button className="w-8 h-8 rounded-full bg-elevated border border-border-default flex items-center justify-center text-text-secondary hover:text-text-primary transition-all">
-          <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+          <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
             <circle cx="8" cy="5" r="3" />
             <path d="M2 14c0-3.3 2.7-6 6-6s6 2.7 6 6" />
           </svg>

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -68,7 +68,12 @@ export function Badge({
       className={`inline-flex items-center gap-2 rounded-full font-semibold tracking-wide ${variantStyle.bg} ${variantStyle.text} ${sizeStyle} ${className}`}
       role="status"
     >
-      {dot && <span className={`w-1.5 h-1.5 rounded-full ${variantStyle.dot}`} />}
+      {dot && (
+        <span
+          className={`w-1.5 h-1.5 rounded-full ${variantStyle.dot}`}
+          aria-hidden="true"
+        />
+      )}
       {children}
     </span>
   );

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -126,6 +126,7 @@ export function StatusBadge({
         /* Dot when icon is hidden */
         <span
           className={`rounded-full shrink-0 ${sizeConfig.dot} ${config.dot}`}
+          aria-hidden="true"
         />
       )}
       {config.label}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -77,8 +77,12 @@ export function Toast({
         typeClasses[type]
       )}
       role="alert"
+      aria-live={type === "error" ? "assertive" : "polite"}
     >
-      <Icon className={clsx("h-6 w-6 shrink-0", iconColors[type])} />
+      <Icon
+        className={clsx("h-6 w-6 shrink-0", iconColors[type])}
+        aria-hidden="true"
+      />
       <div className="flex-1 pt-0.5">
         {title && <h3 className="text-sm font-semibold mb-1">{title}</h3>}
         <p className="text-sm text-text-secondary">{message}</p>
@@ -89,7 +93,7 @@ export function Toast({
         aria-label="Close"
       >
         <span className="sr-only">Close</span>
-        <X className="h-4 w-4" />
+        <X className="h-4 w-4" aria-hidden="true" />
       </button>
       
       {/* Optional: subtle progress bar for auto-dismiss */}
@@ -98,6 +102,7 @@ export function Toast({
           className={clsx(
             "absolute bottom-0 left-0 h-1 bg-current opacity-20",
           )}
+          aria-hidden="true"
           style={{
             width: "100%",
             animation: `shrink ${duration}ms linear forwards`,

--- a/frontend/src/components/vault/AuditLogCard.tsx
+++ b/frontend/src/components/vault/AuditLogCard.tsx
@@ -15,12 +15,13 @@ interface AuditLogEntry {
 interface AuditLogCardProps {
   entries: AuditLogEntry[];
   isLiveSync?: boolean;
+  emptyMessage?: string;
 }
 
 const logIcons: Record<LogType, ReactNode> = {
-  biometric: <Fingerprint className="w-4 h-4 text-emerald" />,
-  "multi-sig": <Image src={RequestIcon} alt="multisig icon" />,
-  ledger: <Database className="w-4 h-4 text-text-secondary" />,
+  biometric: <Fingerprint className="w-4 h-4 text-emerald" aria-hidden="true" />,
+  "multi-sig": <Image src={RequestIcon} alt="" aria-hidden="true" />,
+  ledger: <Database className="w-4 h-4 text-text-secondary" aria-hidden="true" />,
 };
 
 const logBgColors: Record<LogType, string> = {
@@ -29,7 +30,11 @@ const logBgColors: Record<LogType, string> = {
   ledger: "bg-bg-elevated",
 };
 
-export function AuditLogCard({ entries, isLiveSync = true }: AuditLogCardProps) {
+export function AuditLogCard({
+  entries,
+  isLiveSync = true,
+  emptyMessage = "Audit log source is coming soon.",
+}: AuditLogCardProps) {
   return (
     <BentoCard
       title="Audit Log"
@@ -40,28 +45,37 @@ export function AuditLogCard({ entries, isLiveSync = true }: AuditLogCardProps) 
       <div className="flex items-center justify-end -mt-8 mb-6">
         {isLiveSync && (
           <span className="flex items-center gap-1.5 text-xs font-semibold text-emerald bg-emerald-muted px-3 py-1 rounded-full">
-            <span className="w-2 h-2 rounded-full bg-emerald animate-pulse" />
+            <span className="w-2 h-2 rounded-full bg-emerald animate-pulse" aria-hidden="true" />
             Live Sync
           </span>
         )}
       </div>
 
       <div className="space-y-4">
-        {entries.map((entry, index) => (
-          <div key={index} className="flex items-start gap-3 bg-[#03110B4D] p-4 rounded-lg h-18">
-            <div
-              className={`w-10 h-10 rounded-full ${logBgColors[entry.type]} flex items-center justify-center shrink-0 mb-12`}
-            >
-              {logIcons[entry.type]}
+        {entries.length > 0 ? (
+          entries.map((entry, index) => (
+            <div key={index} className="flex items-start gap-3 bg-[#03110B4D] p-4 rounded-lg h-18">
+              <div
+                className={`w-10 h-10 rounded-full ${logBgColors[entry.type]} flex items-center justify-center shrink-0 mb-12`}
+              >
+                {logIcons[entry.type]}
+              </div>
+              <div>
+                <p className="text-sm font-medium text-text-primary">
+                  {entry.title}
+                </p>
+                <p className="text-xs text-text-secondary">{entry.metadata}</p>
+              </div>
             </div>
-            <div>
-              <p className="text-sm font-medium text-text-primary">
-                {entry.title}
-              </p>
-              <p className="text-xs text-text-secondary">{entry.metadata}</p>
-            </div>
+          ))
+        ) : (
+          <div className="rounded-lg border border-border-default bg-bg-elevated p-4">
+            <p className="text-sm font-medium text-text-primary">
+              Audit trail unavailable
+            </p>
+            <p className="mt-1 text-xs text-text-secondary">{emptyMessage}</p>
           </div>
-        ))}
+        )}
       </div>
     </BentoCard>
   );

--- a/frontend/src/components/vault/VaultDashboard.tsx
+++ b/frontend/src/components/vault/VaultDashboard.tsx
@@ -11,61 +11,44 @@ import {
   PaymentOverviewCard,
 } from "@/components/vault";
 
-// Mock data - in production, this would come from an API or database
 const VAULT_DATA = {
-  escrowId: "8492-AX",
-  custodyType: "Institutional Custody",
-  status: "Funds Locked",
-  isSecured: true,
-  sequenceId: "882-AF",
+  escrowId: "0-AX",
+  custodyType: "Pending Wallet Authorization",
+  status: "No Active Trades",
+  isSecured: false,
+  sequenceId: "0-AF",
   steps: [
-    { label: "Agreement", date: "Oct 12, 2023", status: "completed" as const },
+    { label: "Agreement", date: "-", status: "completed" as const },
     {
       label: "Audit Phase",
-      date: "Processing...",
+      date: "Coming soon",
       status: "in-progress" as const,
     },
-    { label: "Final Release", date: "Est. Nov 04", status: "pending" as const },
+    { label: "Final Release", date: "-", status: "pending" as const },
   ],
-  vaultValue: 2480000,
+  vaultValue: 0,
   currency: "USD",
-  isInsured: true,
+  isInsured: false,
   contract: {
-    id: "AMN-772-VLT-09",
-    agreementDate: "September 24, 2023",
-    settlementType: "Immediate / Fiat-Backed",
+    id: "No active trades",
+    agreementDate: "-",
+    settlementType: "Pending",
     originParty: {
       initials: "GB",
-      name: "Global Biotech Inc.",
+      name: "Buyer",
       color: "teal" as const,
     },
     recipientParty: {
       initials: "NS",
-      name: "Nova Solutions Ltd.",
+      name: "Seller",
       color: "emerald" as const,
     },
   },
-  auditLog: [
-    {
-      type: "biometric" as const,
-      title: "Biometric validation passed",
-      metadata: "2m ago • 192.168.1.44",
-    },
-    {
-      type: "multi-sig" as const,
-      title: "Multi-sig request broadcast",
-      metadata: "1h ago • ID: 494022",
-    },
-    {
-      type: "ledger" as const,
-      title: "Ledger synchronization",
-      metadata: "Yesterday • Block 182,990",
-    },
-  ],
+  auditLog: [],
   networkDescription:
     "Secured and powered by the Stellar network for instantaneous cross-border settlement and verifiable transparency.",
   paymentOverview: {
-    totalCngn: 2480000,
+    totalCngn: 0,
     ngnRate: 1580,
   },
   footer: {
@@ -138,7 +121,11 @@ export function VaultDashboard() {
             />
           </div>
           <div className="lg:col-span-5">
-            <AuditLogCard entries={VAULT_DATA.auditLog} isLiveSync />
+            <AuditLogCard
+              entries={VAULT_DATA.auditLog}
+              isLiveSync={false}
+              emptyMessage="Vault audit events are not available yet. No security entries are shown until a verified audit source is connected."
+            />
           </div>
 
           {/* Row 3: Payment Overview */}

--- a/frontend/src/components/vault/__tests__/AuditLogCard.test.tsx
+++ b/frontend/src/components/vault/__tests__/AuditLogCard.test.tsx
@@ -125,6 +125,8 @@ describe('AuditLogCard Component', () => {
     it('handles empty entries array', () => {
         render(<AuditLogCard {...defaultProps} entries={[]} />);
         expect(screen.getByText('Audit Log')).toBeInTheDocument();
+        expect(screen.getByText('Audit trail unavailable')).toBeInTheDocument();
+        expect(screen.getByText('Audit log source is coming soon.')).toBeInTheDocument();
     });
 
     it('handles single entry', () => {

--- a/frontend/src/components/vault/__tests__/VaultDashboard.test.tsx
+++ b/frontend/src/components/vault/__tests__/VaultDashboard.test.tsx
@@ -76,10 +76,10 @@ describe('VaultDashboard Component', () => {
 
     it('passes correct props to VaultHero', () => {
         render(<VaultDashboard />);
-        expect(screen.getByText('8492-AX')).toBeInTheDocument();
-        expect(screen.getByText('Institutional Custody')).toBeInTheDocument();
-        expect(screen.getByText('Funds Locked')).toBeInTheDocument();
-        expect(screen.getByText('Secured')).toBeInTheDocument();
+        expect(screen.getByText('0-AX')).toBeInTheDocument();
+        expect(screen.getByText('Pending Wallet Authorization')).toBeInTheDocument();
+        expect(screen.getByText('No Active Trades')).toBeInTheDocument();
+        expect(screen.getByText('Not Secured')).toBeInTheDocument();
     });
 
     it('renders the ReleaseSequenceCard component', () => {
@@ -89,7 +89,7 @@ describe('VaultDashboard Component', () => {
 
     it('passes correct props to ReleaseSequenceCard', () => {
         render(<VaultDashboard />);
-        expect(screen.getByText('882-AF')).toBeInTheDocument();
+        expect(screen.getByText('0-AF')).toBeInTheDocument();
         expect(screen.getByText('3 steps')).toBeInTheDocument();
     });
 
@@ -101,9 +101,9 @@ describe('VaultDashboard Component', () => {
     it('passes correct props to VaultValueCard', () => {
         render(<VaultDashboard />);
         const card = screen.getByTestId('vault-value-card');
-        expect(within(card).getByText('2480000')).toBeInTheDocument();
+        expect(within(card).getByText('0')).toBeInTheDocument();
         expect(within(card).getByText('USD')).toBeInTheDocument();
-        expect(within(card).getByText('Insured')).toBeInTheDocument();
+        expect(within(card).getByText('Not Insured')).toBeInTheDocument();
     });
 
     it('renders the ContractManifestCard component', () => {
@@ -113,11 +113,11 @@ describe('VaultDashboard Component', () => {
 
     it('passes correct props to ContractManifestCard', () => {
         render(<VaultDashboard />);
-        expect(screen.getByText('AMN-772-VLT-09')).toBeInTheDocument();
-        expect(screen.getByText('September 24, 2023')).toBeInTheDocument();
-        expect(screen.getByText('Immediate / Fiat-Backed')).toBeInTheDocument();
-        expect(screen.getByText('Global Biotech Inc.')).toBeInTheDocument();
-        expect(screen.getByText('Nova Solutions Ltd.')).toBeInTheDocument();
+        expect(screen.getByText('No active trades')).toBeInTheDocument();
+        expect(screen.getByText('-')).toBeInTheDocument();
+        expect(screen.getByText('Pending')).toBeInTheDocument();
+        expect(screen.getByText('Buyer')).toBeInTheDocument();
+        expect(screen.getByText('Seller')).toBeInTheDocument();
     });
 
     it('renders the AuditLogCard component', () => {
@@ -127,8 +127,8 @@ describe('VaultDashboard Component', () => {
 
     it('passes correct props to AuditLogCard', () => {
         render(<VaultDashboard />);
-        expect(screen.getByText('3 entries')).toBeInTheDocument();
-        expect(screen.getByText('Live Sync')).toBeInTheDocument();
+        expect(screen.getByText('0 entries')).toBeInTheDocument();
+        expect(screen.getByText('Not Live')).toBeInTheDocument();
     });
 
     it('renders the PaymentOverviewCard component', () => {
@@ -139,7 +139,7 @@ describe('VaultDashboard Component', () => {
     it('passes correct props to PaymentOverviewCard', () => {
         render(<VaultDashboard />);
         const card = screen.getByTestId('payment-overview-card');
-        expect(within(card).getByText('2480000')).toBeInTheDocument();
+        expect(within(card).getByText('0')).toBeInTheDocument();
         expect(within(card).getByText('1580')).toBeInTheDocument();
     });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import { authApi } from "./api/auth";
 import { ApiError } from "./api/client";
 import { disputesApi } from "./api/disputes";
 import { getApiBaseUrl, getStellarNetworkPassphrase, getStellarRpcUrl } from "./api/env";
+import { reputationApi } from "./api/reputation";
 import { searchApi } from "./api/search";
 import { tradesApi } from "./api/trades";
 import { walletApi } from "./api/wallet";
@@ -16,6 +17,7 @@ export type {
   EvidenceRecord,
   EvidenceResponse,
   PathPaymentQuote,
+  ReputationResponse,
   SearchResponse,
   SearchResultItem,
   TradeHistoryEvent,
@@ -28,6 +30,8 @@ export type {
 
 export const api = {
   auth: authApi,
+  disputes: disputesApi,
+  reputation: reputationApi,
   search: searchApi,
   trades: tradesApi,
   wallet: walletApi,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 export type FetchOptions = RequestInit & {
   token?: string | null;
   skipAuth?: boolean;
+  timeoutMs?: number;
 };
 
 export type ApiResult<T> =
@@ -27,6 +28,7 @@ export class ApiError extends Error {
 }
 
 const TOKEN_STORAGE_KEY = "amana_jwt";
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 function getStoredToken(): string | null {
   if (typeof window === "undefined") return null;
@@ -88,14 +90,38 @@ export async function request<T>(
   endpoint: string,
   options: FetchOptions = {},
 ): Promise<T> {
-  const { token, skipAuth, headers, ...fetchOptions } = options;
+  const {
+    token,
+    skipAuth,
+    headers,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    signal,
+    ...fetchOptions
+  } = options;
 
   const authToken = token ?? (!skipAuth ? getStoredToken() : null);
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout =
+    timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, timeoutMs)
+      : undefined;
+  const abortRequest = () => controller.abort();
+
+  if (signal?.aborted) {
+    controller.abort();
+  } else {
+    signal?.addEventListener("abort", abortRequest, { once: true });
+  }
 
   try {
     const response = await fetch(`${getApiBaseUrl()}${endpoint}`, {
       ...fetchOptions,
       headers: createHeaders(headers, authToken),
+      signal: controller.signal,
     });
 
     const data = await response.json().catch(() => null);
@@ -116,14 +142,22 @@ export async function request<T>(
     if (error instanceof ApiError) {
       throw error;
     }
+    const message =
+      timedOut && error instanceof DOMException && error.name === "AbortError"
+        ? `Request timed out after ${timeoutMs}ms`
+        : error instanceof Error
+          ? error.message
+          : "Network error";
     trackApiFailure(endpoint, 0, {
       method: fetchOptions.method ?? "GET",
-      error: error instanceof Error ? error.message : "Unknown error",
+      error: message,
     });
-    throw new ApiError(
-      0,
-      error instanceof Error ? error.message : "Network error",
-    );
+    throw new ApiError(0, message);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    signal?.removeEventListener("abort", abortRequest);
   }
 }
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -109,3 +109,53 @@ export interface SearchResponse {
   users: SearchResultItem[];
   contracts: SearchResultItem[];
 }
+
+export interface DisputeResponse {
+  id: number;
+  tradeId: string;
+  initiator: string;
+  reason: string;
+  status: "OPEN" | "UNDER_REVIEW" | "RESOLVED" | "CLOSED";
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt?: string | null;
+  trade: {
+    buyerAddress: string;
+    sellerAddress: string;
+    amountUsdc: string;
+  };
+}
+
+export interface DisputeListResponse {
+  items: DisputeResponse[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface ReputationEvent {
+  id: string;
+  event: string;
+  impact: number;
+  impactLabel: string;
+  timestamp: string;
+  type:
+    | "trade_completed"
+    | "trade_initiated"
+    | "dispute_initiated"
+    | "dispute_resolved"
+    | "dispute_involved"
+    | "account_created";
+}
+
+export interface ReputationResponse {
+  trustScore: number;
+  totalTrades: number;
+  completedTrades: number;
+  disputedTrades: number;
+  successRate: number;
+  history: ReputationEvent[];
+}

--- a/frontend/src/lib/validation/schemas.ts
+++ b/frontend/src/lib/validation/schemas.ts
@@ -40,7 +40,7 @@ export const DisputeSchema = z.object({
     .min(10, "Reason must be at least 10 characters")
     .max(500, "Reason cannot exceed 500 characters"),
   category: z.enum(["quality", "delivery", "payment", "fraud", "other"], {
-    error: "Invalid dispute category",
+    message: "Invalid dispute category",
   }),
   evidenceCids: z.array(z.string().min(1)).optional(),
 });


### PR DESCRIPTION
## Summary
- pin reported third-party CI actions to immutable SHAs and add high-severity npm audit gates for frontend/backend
- add a default 30s AbortController timeout to the frontend API client
- improve accessibility on nav, toast, badges, and decorative indicators
- remove fabricated vault audit/security entries and show truthful unavailable states until a verified audit source exists
- restore missing API barrel exports/types and fix a Zod 3 schema option uncovered by the build

## Verification
- corepack pnpm test -- --runTestsByPath src/__tests__/api-client.test.ts src/__tests__/Toast.test.tsx src/components/vault/__tests__/AuditLogCard.test.tsx src/components/vault/__tests__/VaultDashboard.test.tsx src/__tests__/validation.test.ts
- corepack pnpm lint
- corepack pnpm build

## Notes
- npm audit --audit-level=high now correctly fails on existing vulnerabilities: frontend reports 4 high findings; backend reports 58 vulnerabilities including 14 high. This is the intended gate behavior for the CI issue, but dependency remediation will be needed for CI to pass.

close #867 
close #865 
close #866 
close #857 