### PR TITLE
Add useDispute hook for dispute lifecycle management

### DIFF
--- a/frontend/src/hooks/__tests__/useDispute.test.ts
+++ b/frontend/src/hooks/__tests__/useDispute.test.ts
@@ -1,0 +1,241 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useDispute } from "../useDispute";
+import { useAuth } from "../useAuth";
+import { api, ApiError } from "@/lib/api";
+
+jest.mock("../useAuth");
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    disputes: {
+      get: jest.fn(),
+      resolve: jest.fn(),
+    },
+    trades: {
+      getEvidence: jest.fn(),
+      uploadEvidence: jest.fn(),
+    },
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    data: unknown;
+    constructor(status: number, message: string, data?: unknown) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+      this.data = data;
+    }
+  },
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockGetDispute = api.disputes.get as jest.MockedFunction<typeof api.disputes.get>;
+const mockResolveDispute = api.disputes.resolve as jest.MockedFunction<typeof api.disputes.resolve>;
+const mockGetEvidence = api.trades.getEvidence as jest.MockedFunction<typeof api.trades.getEvidence>;
+const mockUploadEvidence = api.trades.uploadEvidence as jest.MockedFunction<typeof api.trades.uploadEvidence>;
+
+const TRADE_ID = "trade-123";
+
+const MOCK_DISPUTE = {
+  id: 1,
+  tradeId: TRADE_ID,
+  initiator: "GBUYER123456789012345678901234567890123456789012345678",
+  reason: "Item not delivered",
+  status: "OPEN",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+  resolvedAt: null,
+  trade: {
+    buyerAddress: "GBUYER123456789012345678901234567890123456789012345678",
+    sellerAddress: "GSELLER12345678901234567890123456789012345678901234567",
+    amountUsdc: "5000",
+  },
+};
+
+const MOCK_EVIDENCE_RECORD = {
+  id: "ev-001",
+  cid: "QmTestHash123",
+  mimeType: "video/mp4",
+  uploadedBy: "seller-address",
+  createdAt: "2026-05-01T10:00:00.000Z",
+};
+
+function authed() {
+  mockUseAuth.mockReturnValue({
+    token: "token-123",
+    isAuthenticated: true,
+  } as unknown as ReturnType<typeof useAuth>);
+}
+
+describe("useDispute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("starts in a loading state before the fetch resolves", () => {
+    authed();
+    mockGetDispute.mockImplementation(() => new Promise(() => {}));
+    mockGetEvidence.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.dispute).toBeNull();
+    expect(result.current.evidence).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("loads dispute and evidence data on success", async () => {
+    authed();
+    mockGetDispute.mockResolvedValue(MOCK_DISPUTE);
+    mockGetEvidence.mockResolvedValue({ evidence: [MOCK_EVIDENCE_RECORD] });
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.dispute).toEqual(MOCK_DISPUTE);
+    expect(result.current.evidence).toEqual([MOCK_EVIDENCE_RECORD]);
+    expect(result.current.error).toBeNull();
+    expect(mockGetDispute).toHaveBeenCalledWith("token-123", TRADE_ID);
+    expect(mockGetEvidence).toHaveBeenCalledWith("token-123", TRADE_ID);
+  });
+
+  it("skips fetching and clears loading when not authenticated", async () => {
+    mockUseAuth.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.dispute).toBeNull();
+    expect(mockGetDispute).not.toHaveBeenCalled();
+    expect(mockGetEvidence).not.toHaveBeenCalled();
+  });
+
+  it("sets an error message when loading the dispute fails", async () => {
+    authed();
+    mockGetDispute.mockRejectedValue(new ApiError(404, "Dispute not found"));
+    mockGetEvidence.mockResolvedValue({ evidence: [] });
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.dispute).toBeNull();
+    expect(result.current.error).toBe("Dispute not found");
+  });
+
+  it("uploads evidence and refreshes the evidence list", async () => {
+    authed();
+    mockGetDispute.mockResolvedValue(MOCK_DISPUTE);
+    mockGetEvidence.mockResolvedValue({ evidence: [] });
+    mockUploadEvidence.mockResolvedValue({
+      evidenceId: "ev-002",
+      cid: "QmNewHash",
+      ipfsUrl: "https://gateway.pinata.cloud/ipfs/QmNewHash",
+    });
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockGetEvidence.mockResolvedValue({ evidence: [MOCK_EVIDENCE_RECORD] });
+
+    const file = new File(["video content"], "evidence.mp4", { type: "video/mp4" });
+
+    await act(async () => {
+      await result.current.submitEvidence(file);
+    });
+
+    expect(mockUploadEvidence).toHaveBeenCalledWith("token-123", TRADE_ID, file);
+    expect(result.current.evidence).toEqual([MOCK_EVIDENCE_RECORD]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets an error and rethrows when evidence upload fails", async () => {
+    authed();
+    mockGetDispute.mockResolvedValue(MOCK_DISPUTE);
+    mockGetEvidence.mockResolvedValue({ evidence: [] });
+    mockUploadEvidence.mockRejectedValue(new ApiError(415, "Unsupported media type"));
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const file = new File(["not a video"], "evidence.txt", { type: "text/plain" });
+
+    await act(async () => {
+      await expect(result.current.submitEvidence(file)).rejects.toThrow(
+        "Unsupported media type",
+      );
+    });
+
+    expect(result.current.error).toBe("Unsupported media type");
+  });
+
+  it("resolves the dispute and returns the unsigned XDR", async () => {
+    authed();
+    mockGetDispute.mockResolvedValue(MOCK_DISPUTE);
+    mockGetEvidence.mockResolvedValue({ evidence: [] });
+    mockResolveDispute.mockResolvedValue({ unsignedXdr: "AAAA-resolve-xdr" });
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let xdr: string | undefined;
+    await act(async () => {
+      xdr = await result.current.resolveDispute(7000);
+    });
+
+    expect(xdr).toBe("AAAA-resolve-xdr");
+    expect(mockResolveDispute).toHaveBeenCalledWith("token-123", TRADE_ID, {
+      sellerGetsBps: 7000,
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets an error and rethrows when dispute resolution fails", async () => {
+    authed();
+    mockGetDispute.mockResolvedValue(MOCK_DISPUTE);
+    mockGetEvidence.mockResolvedValue({ evidence: [] });
+    mockResolveDispute.mockRejectedValue(new ApiError(403, "Not authorized to resolve"));
+
+    const { result } = renderHook(() => useDispute(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await expect(result.current.resolveDispute(7000)).rejects.toThrow(
+        "Not authorized to resolve",
+      );
+    });
+
+    expect(result.current.error).toBe("Not authorized to resolve");
+  });
+
+  it("re-fetches when the trade id changes", async () => {
+    authed();
+    mockGetDispute.mockResolvedValue(MOCK_DISPUTE);
+    mockGetEvidence.mockResolvedValue({ evidence: [] });
+
+    const { result, rerender } = renderHook(
+      ({ tradeId }: { tradeId: string }) => useDispute(tradeId),
+      { initialProps: { tradeId: TRADE_ID } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetDispute).toHaveBeenCalledWith("token-123", TRADE_ID);
+
+    const otherTradeId = "trade-456";
+    const otherDispute = { ...MOCK_DISPUTE, tradeId: otherTradeId };
+    mockGetDispute.mockResolvedValue(otherDispute);
+
+    rerender({ tradeId: otherTradeId });
+
+    await waitFor(() => {
+      expect(result.current.dispute?.tradeId).toBe(otherTradeId);
+    });
+    expect(mockGetDispute).toHaveBeenCalledWith("token-123", otherTradeId);
+  });
+});

--- a/frontend/src/hooks/useDispute.ts
+++ b/frontend/src/hooks/useDispute.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { api, ApiError, type DisputeResponse, type EvidenceRecord } from "@/lib/api";
+import { useAuth } from "./useAuth";
+
+interface UseDisputeResult {
+  dispute: DisputeResponse | null;
+  evidence: EvidenceRecord[];
+  isLoading: boolean;
+  error: string | null;
+  submitEvidence: (file: File) => Promise<void>;
+  resolveDispute: (sellerGetsBps: number) => Promise<string>;
+}
+
+function toErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return fallback;
+}
+
+export function useDispute(tradeId: string): UseDisputeResult {
+  const { token, isAuthenticated } = useAuth();
+  const [dispute, setDispute] = useState<DisputeResponse | null>(null);
+  const [evidence, setEvidence] = useState<EvidenceRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDispute = useCallback(async () => {
+    if (!isAuthenticated || !token) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [disputeData, evidenceData] = await Promise.all([
+        api.disputes.get(token, tradeId),
+        api.trades.getEvidence(token, tradeId),
+      ]);
+      setDispute(disputeData);
+      setEvidence(evidenceData.evidence);
+    } catch (err) {
+      setError(toErrorMessage(err, "Failed to load dispute"));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, isAuthenticated, tradeId]);
+
+  useEffect(() => {
+    void fetchDispute();
+  }, [fetchDispute]);
+
+  const submitEvidence = useCallback(
+    async (file: File) => {
+      if (!token) {
+        throw new Error("Not authenticated");
+      }
+
+      setError(null);
+
+      try {
+        await api.trades.uploadEvidence(token, tradeId, file);
+        const evidenceData = await api.trades.getEvidence(token, tradeId);
+        setEvidence(evidenceData.evidence);
+      } catch (err) {
+        const message = toErrorMessage(err, "Failed to upload evidence");
+        setError(message);
+        throw err;
+      }
+    },
+    [token, tradeId],
+  );
+
+  const resolveDispute = useCallback(
+    async (sellerGetsBps: number) => {
+      if (!token) {
+        throw new Error("Not authenticated");
+      }
+
+      setError(null);
+
+      try {
+        const { unsignedXdr } = await api.disputes.resolve(token, tradeId, {
+          sellerGetsBps,
+        });
+        return unsignedXdr;
+      } catch (err) {
+        const message = toErrorMessage(err, "Failed to resolve dispute");
+        setError(message);
+        throw err;
+      }
+    },
+    [token, tradeId],
+  );
+
+  return { dispute, evidence, isLoading, error, submitEvidence, resolveDispute };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,7 +15,10 @@ export type {
   DisputeResponse,
   EvidenceRecord,
   EvidenceResponse,
+  EvidenceUploadResponse,
   PathPaymentQuote,
+  ResolveDisputeRequest,
+  ResolveDisputeResponse,
   SearchResponse,
   SearchResultItem,
   TradeHistoryEvent,
@@ -28,6 +31,7 @@ export type {
 
 export const api = {
   auth: authApi,
+  disputes: disputesApi,
   search: searchApi,
   trades: tradesApi,
   wallet: walletApi,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -44,10 +44,11 @@ export const navigationHelpers = {
 function createHeaders(
   headers?: HeadersInit,
   token?: string | null,
+  isFormData = false,
 ): Record<string, string> {
-  const resolvedHeaders: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
+  const resolvedHeaders: Record<string, string> = isFormData
+    ? {}
+    : { "Content-Type": "application/json" };
 
   if (headers instanceof Headers) {
     headers.forEach((value, key) => {
@@ -91,11 +92,13 @@ export async function request<T>(
   const { token, skipAuth, headers, ...fetchOptions } = options;
 
   const authToken = token ?? (!skipAuth ? getStoredToken() : null);
+  const isFormData =
+    typeof FormData !== "undefined" && fetchOptions.body instanceof FormData;
 
   try {
     const response = await fetch(`${getApiBaseUrl()}${endpoint}`, {
       ...fetchOptions,
-      headers: createHeaders(headers, authToken),
+      headers: createHeaders(headers, authToken, isFormData),
     });
 
     const data = await response.json().catch(() => null);

--- a/frontend/src/lib/api/disputes.ts
+++ b/frontend/src/lib/api/disputes.ts
@@ -1,5 +1,10 @@
 import { createQueryString, request } from "./client";
-import type { DisputeListResponse } from "./types";
+import type {
+  DisputeListResponse,
+  DisputeResponse,
+  ResolveDisputeRequest,
+  ResolveDisputeResponse,
+} from "./types";
 
 export const disputesApi = {
   list: (token: string, params?: { status?: string; page?: number; limit?: number }) =>
@@ -11,4 +16,14 @@ export const disputesApi = {
       })}`,
       { token },
     ),
+
+  get: (token: string, tradeId: string) =>
+    request<DisputeResponse>(`/disputes/${tradeId}`, { token }),
+
+  resolve: (token: string, tradeId: string, data: ResolveDisputeRequest) =>
+    request<ResolveDisputeResponse>(`/disputes/${tradeId}/resolve`, {
+      method: "POST",
+      token,
+      body: JSON.stringify(data),
+    }),
 };

--- a/frontend/src/lib/api/trades.ts
+++ b/frontend/src/lib/api/trades.ts
@@ -4,6 +4,7 @@ import type {
   CreateTradeResponse,
   DepositResponse,
   EvidenceResponse,
+  EvidenceUploadResponse,
   SubmitManifestRequest,
   SubmitManifestResponse,
   TradeHistoryResponse,
@@ -31,6 +32,18 @@ export const tradesApi = {
 
   getEvidence: (token: string, id: string) =>
     request<EvidenceResponse>(`/trades/${id}/evidence`, { token }),
+
+  uploadEvidence: (token: string, tradeId: string, file: File) => {
+    const formData = new FormData();
+    formData.append("tradeId", tradeId);
+    formData.append("file", file);
+
+    return request<EvidenceUploadResponse>("/evidence/video", {
+      method: "POST",
+      token,
+      body: formData,
+    });
+  },
 
   submitManifest: (token: string, tradeId: string, data: SubmitManifestRequest) =>
     request<SubmitManifestResponse>(`/trades/${tradeId}/manifest`, {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -109,3 +109,43 @@ export interface SearchResponse {
   users: SearchResultItem[];
   contracts: SearchResultItem[];
 }
+
+export interface DisputeResponse {
+  id: number;
+  tradeId: string;
+  initiator: string;
+  reason: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt?: string | null;
+  trade: {
+    buyerAddress: string;
+    sellerAddress: string;
+    amountUsdc: string;
+  };
+}
+
+export interface DisputeListResponse {
+  items: DisputeResponse[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface ResolveDisputeRequest {
+  sellerGetsBps: number;
+}
+
+export interface ResolveDisputeResponse {
+  unsignedXdr: string;
+}
+
+export interface EvidenceUploadResponse {
+  evidenceId: string;
+  cid: string;
+  ipfsUrl: string;
+}


### PR DESCRIPTION
Implements frontend/src/hooks/useDispute.ts covering dispute detail and evidence loading, video evidence upload via the /evidence/video route, and dispute resolution returning an unsigned XDR for the resolve_dispute contract call.

Also wires up the disputesApi client (get/resolve), adds the uploadEvidence method to tradesApi, teaches the API client to skip the JSON content-type header for FormData bodies, and fills in the DisputeResponse/DisputeListResponse types plus the missing `disputes` entry on the `api` object — all of which were referenced by the mediator disputes page but never defined/wired, leaving it broken.

Closes #759

## Summary
Provide a brief summary of the changes introduced in this Pull Request and why they were made.

## Type of Change
Please check the option that applies:
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Refactor / Code Cleanup
- [ ] Documentation update
- [ ] CI / Infrastructure / Governance

## Changes Made
Detailed list of changes included in this PR:
- Change 1
- Change 2

## How Has This Been Tested?
Describe the tests conducted to verify your changes:
- [ ] Unit tests (`npm test` / `cargo test`)
- [ ] Integration / API endpoint testing
- [ ] Manual UI verification
- [ ] Staging / Docker stack validation (`./scripts/staging-up.sh`)

## Screenshots / Evidence (if applicable)
Add screenshots, terminal output logs, or GIF recordings demonstrating your fix or feature.

## Related Issues
- Closes # [issue number]
- Fixes # [issue number]

## Checklist
- [ ] My code follows the repository's coding style guidelines.
- [ ] I have performed a self-review of my code.
- [ ] I have added/updated relevant documentation and comments.
- [ ] My commits follow Conventional Commits formatting (`feat:`, `fix:`, `docs:`, etc.).
- [ ] No temporary debug code or AI generator disclaimers/signatures were committed.
- [ ] All automated tests pass cleanly without errors.
