### PR TITLE
Add useWallet hook for Freighter connection status, network, and bala…

### DIFF
--- a/frontend/src/__tests__/TradeDetailPage.test.tsx
+++ b/frontend/src/__tests__/TradeDetailPage.test.tsx
@@ -9,7 +9,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TradeDetailPage from "@/app/trades/[id]/page";
 import { useTradeDetail } from "@/hooks/useTradeDetail";
-import { useWallet } from "@/hooks/useWallet";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
 import { useAuth } from "@/hooks/useAuth";
 import { api } from "@/lib/api";
 import { signTransaction } from "@stellar/freighter-api";
@@ -22,7 +22,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/hooks/useTradeDetail");
-jest.mock("@/hooks/useWallet");
+jest.mock("@/hooks/useWalletBalance");
 jest.mock("@/hooks/useAuth");
 jest.mock("@/lib/api", () => ({
   api: {
@@ -53,7 +53,7 @@ jest.mock("@stellar/freighter-api", () => ({
 }));
 
 const mockUseTradeDetail = useTradeDetail as jest.MockedFunction<typeof useTradeDetail>;
-const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
+const mockUseWalletBalance = useWalletBalance as jest.MockedFunction<typeof useWalletBalance>;
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockSignTransaction = signTransaction as jest.MockedFunction<typeof signTransaction>;
 const mockDeposit = api.trades.deposit as jest.MockedFunction<typeof api.trades.deposit>;
@@ -96,7 +96,7 @@ function mockAuth(address: string) {
 }
 
 function mockWallet() {
-  mockUseWallet.mockReturnValue({
+  mockUseWalletBalance.mockReturnValue({
     balance: "1000",
     asset: "cNGN",
     loading: false,

--- a/frontend/src/__tests__/VaultPage.test.tsx
+++ b/frontend/src/__tests__/VaultPage.test.tsx
@@ -8,7 +8,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import VaultPage from "@/app/vault/page";
 import { useAuth } from "@/hooks/useAuth";
-import { useWallet } from "@/hooks/useWallet";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
 import { api } from "@/lib/api";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
@@ -22,7 +22,7 @@ jest.mock("next/link", () => {
 });
 
 jest.mock("@/hooks/useAuth");
-jest.mock("@/hooks/useWallet");
+jest.mock("@/hooks/useWalletBalance");
 jest.mock("@/lib/api", () => ({
   api: {
     trades: {
@@ -52,7 +52,7 @@ jest.mock("@/components/ui", () => ({
 }));
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
-const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
+const mockUseWalletBalance = useWalletBalance as jest.MockedFunction<typeof useWalletBalance>;
 const mockGetStats = api.trades.getStats as jest.MockedFunction<typeof api.trades.getStats>;
 const mockList = api.trades.list as jest.MockedFunction<typeof api.trades.list>;
 
@@ -97,7 +97,7 @@ const MOCK_TRADES = {
 };
 
 function mockWalletDefault() {
-  mockUseWallet.mockReturnValue({
+  mockUseWalletBalance.mockReturnValue({
     balance: "1000",
     asset: "cNGN",
     loading: false,

--- a/frontend/src/app/trades/[id]/page.tsx
+++ b/frontend/src/app/trades/[id]/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { signTransaction } from "@stellar/freighter-api";
 import { useAuth } from "@/hooks/useAuth";
 import { useTradeDetail } from "@/hooks/useTradeDetail";
-import { useWallet } from "@/hooks/useWallet";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
 import { api, ApiError } from "@/lib/api";
 import { apiConfig } from "@/lib/api";
 
@@ -79,7 +79,7 @@ export default function TradeDetailPage() {
 
   const { token, address, isAuthenticated } = useAuth();
   const { trade, loading, error, refetch } = useTradeDetail(tradeId);
-  const { balance, asset } = useWallet();
+  const { balance, asset } = useWalletBalance();
 
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);

--- a/frontend/src/app/vault/page.tsx
+++ b/frontend/src/app/vault/page.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/vault";
 import { DriverManifestForm, LoadingState, type DriverManifestData } from "@/components/ui";
 import { useAuth } from "@/hooks/useAuth";
-import { useWallet } from "@/hooks/useWallet";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
 import {
   api,
   apiConfig,
@@ -58,7 +58,7 @@ export default function VaultPage() {
     authenticate,
   } = useAuth();
 
-  const { balance, asset } = useWallet();
+  const { balance, asset } = useWalletBalance();
 
   const [stats, setStats] = useState<TradeStatsResponse | null>(null);
   const [recentTrades, setRecentTrades] = useState<TradeListResponse | null>(null);

--- a/frontend/src/hooks/__tests__/useWallet.test.ts
+++ b/frontend/src/hooks/__tests__/useWallet.test.ts
@@ -1,0 +1,185 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useWallet } from "../useWallet";
+import {
+  getAddress,
+  getNetwork,
+  isAllowed,
+  isConnected,
+} from "@stellar/freighter-api";
+import { Horizon } from "@stellar/stellar-sdk";
+
+jest.mock("@stellar/freighter-api", () => ({
+  getAddress: jest.fn(),
+  getNetwork: jest.fn(),
+  isAllowed: jest.fn(),
+  isConnected: jest.fn(),
+}));
+
+const mockLoadAccount = jest.fn();
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: mockLoadAccount,
+    })),
+  },
+}));
+
+const mockGetAddress = getAddress as jest.MockedFunction<typeof getAddress>;
+const mockGetNetwork = getNetwork as jest.MockedFunction<typeof getNetwork>;
+const mockIsAllowed = isAllowed as jest.MockedFunction<typeof isAllowed>;
+const mockIsConnected = isConnected as jest.MockedFunction<typeof isConnected>;
+const MockServer = Horizon.Server as unknown as jest.Mock;
+
+const PUBLIC_KEY = "GBUYER123456789012345678901234567890123456789012345678";
+
+function connectedWallet() {
+  mockIsConnected.mockResolvedValue({ isConnected: true });
+  mockIsAllowed.mockResolvedValue({ isAllowed: true });
+  mockGetAddress.mockResolvedValue({ address: PUBLIC_KEY });
+  mockGetNetwork.mockResolvedValue({
+    network: "TESTNET",
+    networkPassphrase: "Test SDF Network ; September 2015",
+  });
+}
+
+function testnetAccount() {
+  mockLoadAccount.mockResolvedValue({
+    balances: [
+      { asset_type: "native", balance: "100.5000000" },
+      {
+        asset_type: "credit_alphanum4",
+        asset_code: "USDC",
+        asset_issuer: "GISSUER123",
+        balance: "250.0000000",
+      },
+    ],
+  });
+}
+
+describe("useWallet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts in a connecting state", () => {
+    mockIsConnected.mockImplementation(() => new Promise(() => {}));
+    mockIsAllowed.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useWallet());
+
+    expect(result.current.isConnecting).toBe(true);
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+  });
+
+  it("resolves as disconnected when Freighter is not connected", async () => {
+    mockIsConnected.mockResolvedValue({ isConnected: false });
+    mockIsAllowed.mockResolvedValue({ isAllowed: false });
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.isConnecting).toBe(false));
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.network).toBeNull();
+    expect(result.current.balances).toEqual({});
+    expect(mockGetAddress).not.toHaveBeenCalled();
+  });
+
+  it("connects and loads public key, network, and balances", async () => {
+    connectedWallet();
+    testnetAccount();
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.isConnecting).toBe(false));
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.publicKey).toBe(PUBLIC_KEY);
+    expect(result.current.network).toBe("TESTNET");
+    expect(result.current.balances).toEqual({
+      XLM: "100.5000000",
+      USDC: "250.0000000",
+    });
+    expect(result.current.error).toBeNull();
+    expect(MockServer).toHaveBeenCalledWith("https://horizon-testnet.stellar.org");
+  });
+
+  it("sets an error message when balance fetching fails", async () => {
+    connectedWallet();
+    mockLoadAccount.mockRejectedValue(new Error("Horizon request failed"));
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.isConnecting).toBe(false));
+
+    expect(result.current.error).toBe("Horizon request failed");
+    expect(result.current.publicKey).toBe(PUBLIC_KEY);
+  });
+
+  it("detects a network switch and refetches balances for the new network", async () => {
+    connectedWallet();
+    testnetAccount();
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.isConnecting).toBe(false));
+    expect(result.current.network).toBe("TESTNET");
+
+    mockGetNetwork.mockResolvedValue({
+      network: "PUBLIC",
+      networkPassphrase: "Public Global Stellar Network ; September 2015",
+    });
+    mockLoadAccount.mockResolvedValue({
+      balances: [{ asset_type: "native", balance: "42.0000000" }],
+    });
+
+    await act(async () => {
+      await result.current.refreshBalances();
+    });
+
+    await waitFor(() => expect(result.current.network).toBe("PUBLIC"));
+    expect(result.current.balances).toEqual({ XLM: "42.0000000" });
+    expect(MockServer).toHaveBeenLastCalledWith("https://horizon.stellar.org");
+  });
+
+  it("detects a disconnect on the next refresh cycle", async () => {
+    connectedWallet();
+    testnetAccount();
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.isConnecting).toBe(false));
+    expect(result.current.isConnected).toBe(true);
+
+    mockIsAllowed.mockResolvedValue({ isAllowed: false });
+
+    await act(async () => {
+      await result.current.refreshBalances();
+    });
+
+    await waitFor(() => expect(result.current.isConnected).toBe(false));
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.balances).toEqual({});
+  });
+
+  it("refreshes balances automatically every 30 seconds", async () => {
+    jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+    connectedWallet();
+    testnetAccount();
+
+    renderHook(() => useWallet());
+
+    await waitFor(() => expect(mockLoadAccount).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,48 +1,123 @@
+"use client";
+
 import { useCallback, useEffect, useState } from "react";
-import { api, ApiError } from "@/lib/api";
-import { useAuth } from "./useAuth";
+import {
+  getAddress,
+  getNetwork,
+  isAllowed,
+  isConnected,
+} from "@stellar/freighter-api";
+import { Horizon } from "@stellar/stellar-sdk";
+import { getStellarHorizonUrl } from "@/lib/api/env";
+
+const BALANCE_REFRESH_INTERVAL_MS = 30_000;
 
 interface UseWalletResult {
-  balance: string | null;
-  asset: string | null;
-  loading: boolean;
+  publicKey: string | null;
+  network: string | null;
+  balances: Record<string, string>;
+  isConnected: boolean;
+  isConnecting: boolean;
   error: string | null;
-  refetch: () => Promise<void>;
+  refreshBalances: () => Promise<void>;
+}
+
+async function fetchBalances(
+  publicKey: string,
+  horizonUrl: string,
+): Promise<Record<string, string>> {
+  const server = new Horizon.Server(horizonUrl);
+  const account = await server.loadAccount(publicKey);
+
+  const balances: Record<string, string> = { XLM: "0" };
+  for (const line of account.balances) {
+    if (line.asset_type === "native") {
+      balances.XLM = line.balance;
+    } else if ("asset_code" in line) {
+      balances[line.asset_code] = line.balance;
+    }
+  }
+  return balances;
 }
 
 export function useWallet(): UseWalletResult {
-  const { token, isAuthenticated } = useAuth();
-  const [balance, setBalance] = useState<string | null>(null);
-  const [asset, setAsset] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [network, setNetwork] = useState<string | null>(null);
+  const [balances, setBalances] = useState<Record<string, string>>({});
+  const [walletConnected, setWalletConnected] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchBalance = useCallback(async () => {
-    if (!isAuthenticated || !token) return;
-
-    setLoading(true);
+  const refreshBalances = useCallback(async () => {
     setError(null);
 
     try {
-      const data = await api.wallet.getBalance(token);
-      setBalance(data.balance);
-      setAsset(data.asset);
+      const [connectedResult, allowedResult] = await Promise.all([
+        isConnected(),
+        isAllowed(),
+      ]);
+
+      const hasWallet =
+        connectedResult.error === undefined && connectedResult.isConnected;
+      const hasPermission =
+        allowedResult.error === undefined && allowedResult.isAllowed;
+
+      if (!hasWallet || !hasPermission) {
+        setWalletConnected(false);
+        setPublicKey(null);
+        setNetwork(null);
+        setBalances({});
+        return;
+      }
+
+      const [addressResult, networkResult] = await Promise.all([
+        getAddress(),
+        getNetwork(),
+      ]);
+
+      if (addressResult.error !== undefined) {
+        throw new Error("Failed to retrieve wallet address");
+      }
+      if (networkResult.error !== undefined) {
+        throw new Error("Failed to retrieve wallet network");
+      }
+
+      setPublicKey(addressResult.address);
+      setNetwork(networkResult.network);
+      setWalletConnected(true);
+
+      const horizonUrl = getStellarHorizonUrl(networkResult.network);
+      const fetchedBalances = await fetchBalances(
+        addressResult.address,
+        horizonUrl,
+      );
+      setBalances(fetchedBalances);
     } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? err.message
-          : err instanceof Error
-            ? err.message
-            : "Failed to load wallet balance";
-      setError(message);
+      setError(err instanceof Error ? err.message : "Failed to load wallet");
     } finally {
-      setLoading(false);
+      setIsConnecting(false);
     }
-  }, [token, isAuthenticated]);
+  }, []);
 
   useEffect(() => {
-    void fetchBalance();
-  }, [fetchBalance]);
+    void refreshBalances();
+  }, [refreshBalances]);
 
-  return { balance, asset, loading, error, refetch: fetchBalance };
+  useEffect(() => {
+    const interval = setInterval(() => {
+      void refreshBalances();
+    }, BALANCE_REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [refreshBalances]);
+
+  return {
+    publicKey,
+    network,
+    balances,
+    isConnected: walletConnected,
+    isConnecting,
+    error,
+    refreshBalances,
+  };
 }

--- a/frontend/src/hooks/useWalletBalance.ts
+++ b/frontend/src/hooks/useWalletBalance.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, ApiError } from "@/lib/api";
+import { useAuth } from "./useAuth";
+
+interface UseWalletBalanceResult {
+  balance: string | null;
+  asset: string | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useWalletBalance(): UseWalletBalanceResult {
+  const { token, isAuthenticated } = useAuth();
+  const [balance, setBalance] = useState<string | null>(null);
+  const [asset, setAsset] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBalance = useCallback(async () => {
+    if (!isAuthenticated || !token) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await api.wallet.getBalance(token);
+      setBalance(data.balance);
+      setAsset(data.asset);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "Failed to load wallet balance";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, isAuthenticated]);
+
+  useEffect(() => {
+    void fetchBalance();
+  }, [fetchBalance]);
+
+  return { balance, asset, loading, error, refetch: fetchBalance };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,12 @@
 import { authApi } from "./api/auth";
 import { ApiError } from "./api/client";
 import { disputesApi } from "./api/disputes";
-import { getApiBaseUrl, getStellarNetworkPassphrase, getStellarRpcUrl } from "./api/env";
+import {
+  getApiBaseUrl,
+  getStellarHorizonUrl,
+  getStellarNetworkPassphrase,
+  getStellarRpcUrl,
+} from "./api/env";
 import { searchApi } from "./api/search";
 import { tradesApi } from "./api/trades";
 import { walletApi } from "./api/wallet";
@@ -37,6 +42,7 @@ export const apiConfig = {
   getBaseUrl: getApiBaseUrl,
   getStellarRpcUrl,
   getStellarNetworkPassphrase,
+  getStellarHorizonUrl,
 };
 
 export { ApiError };

--- a/frontend/src/lib/api/env.ts
+++ b/frontend/src/lib/api/env.ts
@@ -18,3 +18,13 @@ export function getStellarNetworkPassphrase(): string {
     "Test SDF Network ; September 2015"
   );
 }
+
+export function getStellarHorizonUrl(network?: string | null): string {
+  if (process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL) {
+    return process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL;
+  }
+
+  return network?.toUpperCase() === "PUBLIC"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+}


### PR DESCRIPTION
…nces

Implements frontend/src/hooks/useWallet.ts per issue #758: connects to Freighter to read the public key and network (testnet/mainnet), loads XLM/USDC balances from Horizon, and auto-refreshes balances on a 30-second interval. Each refresh cycle also re-checks connection state, so network switches and disconnects are picked up live.

The existing frontend/src/hooks/useWallet.ts (backend USDC balance fetcher used by the vault and trade detail pages) is renamed to useWalletBalance to free up the useWallet name/shape for this hook, per the issue's exact requested path and return signature. Its two call sites and their test mocks are updated accordingly; behavior is unchanged.

Adds getStellarHorizonUrl() to lib/api/env.ts (network-aware Horizon endpoint, overridable via NEXT_PUBLIC_STELLAR_HORIZON_URL).

Closes #758

## Summary
Provide a brief summary of the changes introduced in this Pull Request and why they were made.

## Type of Change
Please check the option that applies:
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Refactor / Code Cleanup
- [ ] Documentation update
- [ ] CI / Infrastructure / Governance

## Changes Made
Detailed list of changes included in this PR:
- Change 1
- Change 2

## How Has This Been Tested?
Describe the tests conducted to verify your changes:
- [ ] Unit tests (`npm test` / `cargo test`)
- [ ] Integration / API endpoint testing
- [ ] Manual UI verification
- [ ] Staging / Docker stack validation (`./scripts/staging-up.sh`)

## Screenshots / Evidence (if applicable)
Add screenshots, terminal output logs, or GIF recordings demonstrating your fix or feature.

## Related Issues
- Closes # [issue number]
- Fixes # [issue number]

## Checklist
- [ ] My code follows the repository's coding style guidelines.
- [ ] I have performed a self-review of my code.
- [ ] I have added/updated relevant documentation and comments.
- [ ] My commits follow Conventional Commits formatting (`feat:`, `fix:`, `docs:`, etc.).
- [ ] No temporary debug code or AI generator disclaimers/signatures were committed.
- [ ] All automated tests pass cleanly without errors.
