### PR TITLE
Add polling and mutation functions to useTradeDetail hook

### DIFF
--- a/frontend/src/__tests__/TradeDetailPage.test.tsx
+++ b/frontend/src/__tests__/TradeDetailPage.test.tsx
@@ -11,7 +11,6 @@ import TradeDetailPage from "@/app/trades/[id]/page";
 import { useTradeDetail } from "@/hooks/useTradeDetail";
 import { useWallet } from "@/hooks/useWallet";
 import { useAuth } from "@/hooks/useAuth";
-import { api } from "@/lib/api";
 import { signTransaction } from "@stellar/freighter-api";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
@@ -25,14 +24,6 @@ jest.mock("@/hooks/useTradeDetail");
 jest.mock("@/hooks/useWallet");
 jest.mock("@/hooks/useAuth");
 jest.mock("@/lib/api", () => ({
-  api: {
-    trades: {
-      deposit: jest.fn(),
-      confirmDelivery: jest.fn(),
-      releaseFunds: jest.fn(),
-      initiateDispute: jest.fn(),
-    },
-  },
   ApiError: class ApiError extends Error {
     status: number;
     data: unknown;
@@ -56,9 +47,6 @@ const mockUseTradeDetail = useTradeDetail as jest.MockedFunction<typeof useTrade
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockSignTransaction = signTransaction as jest.MockedFunction<typeof signTransaction>;
-const mockDeposit = api.trades.deposit as jest.MockedFunction<typeof api.trades.deposit>;
-const mockConfirmDelivery = api.trades.confirmDelivery as jest.MockedFunction<typeof api.trades.confirmDelivery>;
-const mockReleaseFunds = api.trades.releaseFunds as jest.MockedFunction<typeof api.trades.releaseFunds>;
 
 const BUYER_ADDRESS = "GBUYER123456789012345678901234567890123456789012345678";
 const SELLER_ADDRESS = "GSELLER12345678901234567890123456789012345678901234567";
@@ -105,6 +93,22 @@ function mockWallet() {
   });
 }
 
+function mockTradeDetail(
+  overrides: Partial<ReturnType<typeof useTradeDetail>> = {},
+) {
+  mockUseTradeDetail.mockReturnValue({
+    trade: null,
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    deposit: jest.fn(),
+    confirmDelivery: jest.fn(),
+    releaseFunds: jest.fn(),
+    raiseDispute: jest.fn(),
+    ...overrides,
+  });
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockWallet();
@@ -116,12 +120,7 @@ beforeEach(() => {
 describe("Trade Detail — loading state", () => {
   it("shows a spinner while loading", () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: null,
-      loading: true,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: null, isLoading: true });
     render(<TradeDetailPage />);
     expect(document.querySelector("svg.animate-spin")).toBeInTheDocument();
   });
@@ -132,13 +131,7 @@ describe("Trade Detail — loading state", () => {
 describe("Trade Detail — error state", () => {
   it("shows the error message and a retry button", () => {
     mockAuth(BUYER_ADDRESS);
-    const refetch = jest.fn();
-    mockUseTradeDetail.mockReturnValue({
-      trade: null,
-      loading: false,
-      error: "Trade not found",
-      refetch,
-    });
+    mockTradeDetail({ trade: null, error: "Trade not found" });
     render(<TradeDetailPage />);
     expect(screen.getByText("Trade not found")).toBeInTheDocument();
     expect(screen.getByText(/retry/i)).toBeInTheDocument();
@@ -147,12 +140,7 @@ describe("Trade Detail — error state", () => {
   it("calls refetch when retry is clicked", async () => {
     mockAuth(BUYER_ADDRESS);
     const refetch = jest.fn();
-    mockUseTradeDetail.mockReturnValue({
-      trade: null,
-      loading: false,
-      error: "Fetch failed",
-      refetch,
-    });
+    mockTradeDetail({ trade: null, error: "Fetch failed", refetch });
     render(<TradeDetailPage />);
     await userEvent.click(screen.getByText(/retry/i));
     expect(refetch).toHaveBeenCalledTimes(1);
@@ -166,12 +154,7 @@ describe("Trade Detail — trade status display", () => {
     "shows %s status badge",
     (status) => {
       mockAuth(BUYER_ADDRESS);
-      mockUseTradeDetail.mockReturnValue({
-        trade: makeTrade(status),
-        loading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
+      mockTradeDetail({ trade: makeTrade(status) });
       render(<TradeDetailPage />);
       expect(screen.getByText(status)).toBeInTheDocument();
     }
@@ -183,84 +166,49 @@ describe("Trade Detail — trade status display", () => {
 describe("Trade Detail — role-based action buttons", () => {
   it("shows Deposit button for buyer in PENDING status", () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("PENDING"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("PENDING") });
     render(<TradeDetailPage />);
     expect(screen.getByTestId("action-deposit")).toBeInTheDocument();
   });
 
   it("does NOT show Deposit button for seller in PENDING status", () => {
     mockAuth(SELLER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("PENDING"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("PENDING") });
     render(<TradeDetailPage />);
     expect(screen.queryByTestId("action-deposit")).not.toBeInTheDocument();
   });
 
   it("shows Confirm Delivery for buyer in FUNDED status", () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("FUNDED") });
     render(<TradeDetailPage />);
     expect(screen.getByTestId("action-confirm-delivery")).toBeInTheDocument();
   });
 
   it("shows Release Funds for seller in FUNDED status", () => {
     mockAuth(SELLER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("FUNDED") });
     render(<TradeDetailPage />);
     expect(screen.getByTestId("action-release-funds")).toBeInTheDocument();
   });
 
   it("shows Initiate Dispute for buyer in FUNDED status", () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("FUNDED") });
     render(<TradeDetailPage />);
     expect(screen.getByTestId("action-dispute")).toBeInTheDocument();
   });
 
   it("shows Initiate Dispute for seller in FUNDED status", () => {
     mockAuth(SELLER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("FUNDED") });
     render(<TradeDetailPage />);
     expect(screen.getByTestId("action-dispute")).toBeInTheDocument();
   });
 
   it("shows no actions for observer", () => {
     mockAuth("GOBSERVER000000000000000000000000000000000000000000000000");
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("FUNDED") });
     render(<TradeDetailPage />);
     expect(screen.queryByTestId("action-deposit")).not.toBeInTheDocument();
     expect(screen.queryByTestId("action-confirm-delivery")).not.toBeInTheDocument();
@@ -270,12 +218,7 @@ describe("Trade Detail — role-based action buttons", () => {
 
   it("shows settled message for SETTLED status", () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("SETTLED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
+    mockTradeDetail({ trade: makeTrade("SETTLED") });
     render(<TradeDetailPage />);
     expect(screen.getByText(/no further actions are available/i)).toBeInTheDocument();
   });
@@ -284,20 +227,15 @@ describe("Trade Detail — role-based action buttons", () => {
 // ── Signing flow ───────────────────────────────────────────────────────────────
 
 describe("Trade Detail — Freighter signing flow", () => {
-  it("calls deposit API and signTransaction when Deposit is clicked", async () => {
+  it("calls the hook's deposit mutation and signTransaction when Deposit is clicked", async () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("PENDING"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-    mockDeposit.mockResolvedValue({ unsignedXdr: "unsigned-xdr-payload" });
+    const deposit = jest.fn().mockResolvedValue({ unsignedXdr: "unsigned-xdr-payload" });
+    mockTradeDetail({ trade: makeTrade("PENDING"), deposit });
 
     render(<TradeDetailPage />);
     await userEvent.click(screen.getByTestId("action-deposit"));
 
-    await waitFor(() => expect(mockDeposit).toHaveBeenCalledWith("jwt-token", "trade-123"));
+    await waitFor(() => expect(deposit).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(mockSignTransaction).toHaveBeenCalledWith(
       "unsigned-xdr-payload",
       expect.objectContaining({ networkPassphrase: "Test SDF Network ; September 2015" })
@@ -306,13 +244,8 @@ describe("Trade Detail — Freighter signing flow", () => {
 
   it("shows success message after successful signing", async () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("PENDING"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-    mockDeposit.mockResolvedValue({ unsignedXdr: "xdr-payload" });
+    const deposit = jest.fn().mockResolvedValue({ unsignedXdr: "xdr-payload" });
+    mockTradeDetail({ trade: makeTrade("PENDING"), deposit });
 
     render(<TradeDetailPage />);
     await userEvent.click(screen.getByTestId("action-deposit"));
@@ -324,13 +257,8 @@ describe("Trade Detail — Freighter signing flow", () => {
 
   it("shows error message when signTransaction fails", async () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("PENDING"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-    mockDeposit.mockResolvedValue({ unsignedXdr: "xdr-payload" });
+    const deposit = jest.fn().mockResolvedValue({ unsignedXdr: "xdr-payload" });
+    mockTradeDetail({ trade: makeTrade("PENDING"), deposit });
     mockSignTransaction.mockResolvedValue({
       error: { message: "User cancelled signing" },
     } as unknown as Awaited<ReturnType<typeof signTransaction>>);
@@ -343,35 +271,53 @@ describe("Trade Detail — Freighter signing flow", () => {
     );
   });
 
-  it("calls confirmDelivery API when Confirm Delivery is clicked", async () => {
+  it("shows error message when the deposit mutation itself fails", async () => {
     mockAuth(BUYER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-    mockConfirmDelivery.mockResolvedValue({ unsignedXdr: "confirm-xdr" });
+    const deposit = jest.fn().mockRejectedValue(new Error("Trade already funded"));
+    mockTradeDetail({ trade: makeTrade("PENDING"), deposit });
+
+    render(<TradeDetailPage />);
+    await userEvent.click(screen.getByTestId("action-deposit"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/trade already funded/i)).toBeInTheDocument()
+    );
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it("calls the hook's confirmDelivery mutation when Confirm Delivery is clicked", async () => {
+    mockAuth(BUYER_ADDRESS);
+    const confirmDelivery = jest.fn().mockResolvedValue({ unsignedXdr: "confirm-xdr" });
+    mockTradeDetail({ trade: makeTrade("FUNDED"), confirmDelivery });
 
     render(<TradeDetailPage />);
     await userEvent.click(screen.getByTestId("action-confirm-delivery"));
 
-    await waitFor(() => expect(mockConfirmDelivery).toHaveBeenCalledWith("jwt-token", "trade-123"));
+    await waitFor(() => expect(confirmDelivery).toHaveBeenCalledTimes(1));
   });
 
-  it("calls releaseFunds API when Release Funds is clicked", async () => {
+  it("calls the hook's releaseFunds mutation when Release Funds is clicked", async () => {
     mockAuth(SELLER_ADDRESS);
-    mockUseTradeDetail.mockReturnValue({
-      trade: makeTrade("FUNDED"),
-      loading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-    mockReleaseFunds.mockResolvedValue({ unsignedXdr: "release-xdr" });
+    const releaseFunds = jest.fn().mockResolvedValue({ unsignedXdr: "release-xdr" });
+    mockTradeDetail({ trade: makeTrade("FUNDED"), releaseFunds });
 
     render(<TradeDetailPage />);
     await userEvent.click(screen.getByTestId("action-release-funds"));
 
-    await waitFor(() => expect(mockReleaseFunds).toHaveBeenCalledWith("jwt-token", "trade-123"));
+    await waitFor(() => expect(releaseFunds).toHaveBeenCalledTimes(1));
+  });
+
+  it("calls the hook's raiseDispute mutation with the entered reason", async () => {
+    mockAuth(BUYER_ADDRESS);
+    const raiseDispute = jest.fn().mockResolvedValue({ unsignedXdr: "dispute-xdr" });
+    mockTradeDetail({ trade: makeTrade("FUNDED"), raiseDispute });
+    jest.spyOn(window, "prompt").mockReturnValue("Item never arrived");
+
+    render(<TradeDetailPage />);
+    await userEvent.click(screen.getByTestId("action-dispute"));
+
+    await waitFor(() =>
+      expect(raiseDispute).toHaveBeenCalledWith("Item never arrived", "other"),
+    );
   });
 });

--- a/frontend/src/app/trades/[id]/page.tsx
+++ b/frontend/src/app/trades/[id]/page.tsx
@@ -7,7 +7,7 @@ import { signTransaction } from "@stellar/freighter-api";
 import { useAuth } from "@/hooks/useAuth";
 import { useTradeDetail } from "@/hooks/useTradeDetail";
 import { useWallet } from "@/hooks/useWallet";
-import { api, ApiError } from "@/lib/api";
+import { ApiError } from "@/lib/api";
 import { apiConfig } from "@/lib/api";
 
 function formatDate(dateString: string) {
@@ -78,7 +78,8 @@ export default function TradeDetailPage() {
   const tradeId = params?.id ?? "UNKNOWN";
 
   const { token, address, isAuthenticated } = useAuth();
-  const { trade, loading, error, refetch } = useTradeDetail(tradeId);
+  const { trade, isLoading, error, refetch, deposit, confirmDelivery, releaseFunds, raiseDispute } =
+    useTradeDetail(tradeId);
   const { balance, asset } = useWallet();
 
   const [actionLoading, setActionLoading] = useState(false);
@@ -130,15 +131,15 @@ export default function TradeDetailPage() {
   }
 
   function handleDeposit() {
-    void runAction("Deposit", () => api.trades.deposit(token!, tradeId));
+    void runAction("Deposit", () => deposit());
   }
 
   function handleConfirmDelivery() {
-    void runAction("Confirm Delivery", () => api.trades.confirmDelivery(token!, tradeId));
+    void runAction("Confirm Delivery", () => confirmDelivery());
   }
 
   function handleReleaseFunds() {
-    void runAction("Release Funds", () => api.trades.releaseFunds(token!, tradeId));
+    void runAction("Release Funds", () => releaseFunds());
   }
 
   function handleInitiateDispute() {
@@ -147,9 +148,7 @@ export default function TradeDetailPage() {
       setActionError("Dispute reason must be at least 10 characters.");
       return;
     }
-    void runAction("Initiate Dispute", () =>
-      api.trades.initiateDispute(token!, tradeId, reason, "other"),
-    );
+    void runAction("Initiate Dispute", () => raiseDispute(reason, "other"));
   }
 
   return (
@@ -165,7 +164,7 @@ export default function TradeDetailPage() {
       </div>
 
       {/* Loading state */}
-      {loading && (
+      {isLoading && (
         <div className="flex items-center justify-center py-12">
           <svg className="animate-spin w-8 h-8 text-gold" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
@@ -174,7 +173,7 @@ export default function TradeDetailPage() {
         </div>
       )}
 
-      {error && !loading && (
+      {error && !isLoading && (
         <div className="rounded-lg border border-status-danger/20 bg-red-500/10 px-4 py-3 text-center">
           <p className="text-status-danger text-sm">{error}</p>
           <button
@@ -187,7 +186,7 @@ export default function TradeDetailPage() {
       )}
 
       {/* Trade data */}
-      {!loading && !error && trade && (
+      {!isLoading && !error && trade && (
         <div className="space-y-6">
           {/* Identity row */}
           <div className="rounded-lg border border-border-default bg-bg-card p-5">
@@ -337,7 +336,7 @@ export default function TradeDetailPage() {
       )}
 
       {/* Not found */}
-      {!loading && !error && !trade && (
+      {!isLoading && !error && !trade && (
         <div className="rounded-lg border border-border-default bg-bg-card dark:bg-surface-1 p-8 text-center">
           <p className="text-text-muted">Trade not found</p>
         </div>

--- a/frontend/src/hooks/__tests__/useTradeDetail.test.ts
+++ b/frontend/src/hooks/__tests__/useTradeDetail.test.ts
@@ -1,0 +1,278 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useTradeDetail } from "../useTradeDetail";
+import { useAuth } from "../useAuth";
+import { api, ApiError } from "@/lib/api";
+
+jest.mock("../useAuth");
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    trades: {
+      get: jest.fn(),
+      deposit: jest.fn(),
+      confirmDelivery: jest.fn(),
+      releaseFunds: jest.fn(),
+      initiateDispute: jest.fn(),
+    },
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    data: unknown;
+    constructor(status: number, message: string, data?: unknown) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+      this.data = data;
+    }
+  },
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockGet = api.trades.get as jest.MockedFunction<typeof api.trades.get>;
+const mockDeposit = api.trades.deposit as jest.MockedFunction<typeof api.trades.deposit>;
+const mockConfirmDelivery = api.trades.confirmDelivery as jest.MockedFunction<typeof api.trades.confirmDelivery>;
+const mockReleaseFunds = api.trades.releaseFunds as jest.MockedFunction<typeof api.trades.releaseFunds>;
+const mockInitiateDispute = api.trades.initiateDispute as jest.MockedFunction<typeof api.trades.initiateDispute>;
+
+const TRADE_ID = "trade-123";
+
+function makeTrade(status: string) {
+  return {
+    tradeId: TRADE_ID,
+    buyerAddress: "GBUYER123456789012345678901234567890123456789012345678",
+    sellerAddress: "GSELLER12345678901234567890123456789012345678901234567",
+    amountCngn: "5000",
+    buyerLossBps: 100,
+    sellerLossBps: 200,
+    status,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+  };
+}
+
+function authed() {
+  mockUseAuth.mockReturnValue({
+    token: "token-123",
+    isAuthenticated: true,
+  } as unknown as ReturnType<typeof useAuth>);
+}
+
+describe("useTradeDetail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts in a loading state before the fetch resolves", () => {
+    authed();
+    mockGet.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.trade).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("loads the trade on success", async () => {
+    authed();
+    mockGet.mockResolvedValue(makeTrade("PENDING"));
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.trade?.status).toBe("PENDING");
+    expect(result.current.error).toBeNull();
+    expect(mockGet).toHaveBeenCalledWith("token-123", TRADE_ID);
+  });
+
+  it("sets an error message when the fetch fails", async () => {
+    authed();
+    mockGet.mockRejectedValue(new ApiError(404, "Trade not found"));
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.trade).toBeNull();
+    expect(result.current.error).toBe("Trade not found");
+  });
+
+  it("skips fetching and clears loading when not authenticated", async () => {
+    mockUseAuth.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.trade).toBeNull();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it.each(["FUNDED", "IN_TRANSIT"])(
+    "polls every 10 seconds while the trade is in %s status",
+    async (status) => {
+      jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+      authed();
+      mockGet.mockResolvedValue(makeTrade(status));
+
+      renderHook(() => useTradeDetail(TRADE_ID));
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mockGet).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mockGet).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it.each(["PENDING", "COMPLETED", "DISPUTED", "CANCELLED"])(
+    "does not poll while the trade is in the terminal/non-polling status %s",
+    async (status) => {
+      jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+      authed();
+      mockGet.mockResolvedValue(makeTrade(status));
+
+      renderHook(() => useTradeDetail(TRADE_ID));
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(30_000);
+      });
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("stops polling once a poll resolves with a terminal status", async () => {
+    jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+    authed();
+    mockGet.mockResolvedValueOnce(makeTrade("FUNDED"));
+
+    renderHook(() => useTradeDetail(TRADE_ID));
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    mockGet.mockResolvedValue(makeTrade("COMPLETED"));
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10_000);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches manually via refetch()", async () => {
+    authed();
+    mockGet.mockResolvedValue(makeTrade("PENDING"));
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("deposit() calls the deposit mutation and returns the unsigned XDR", async () => {
+    authed();
+    mockGet.mockResolvedValue(makeTrade("PENDING"));
+    mockDeposit.mockResolvedValue({ unsignedXdr: "deposit-xdr" });
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const response = await result.current.deposit();
+
+    expect(mockDeposit).toHaveBeenCalledWith("token-123", TRADE_ID);
+    expect(response).toEqual({ unsignedXdr: "deposit-xdr" });
+  });
+
+  it("confirmDelivery() calls the confirmDelivery mutation", async () => {
+    authed();
+    mockGet.mockResolvedValue(makeTrade("FUNDED"));
+    mockConfirmDelivery.mockResolvedValue({ unsignedXdr: "confirm-xdr" });
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const response = await result.current.confirmDelivery();
+
+    expect(mockConfirmDelivery).toHaveBeenCalledWith("token-123", TRADE_ID);
+    expect(response).toEqual({ unsignedXdr: "confirm-xdr" });
+  });
+
+  it("releaseFunds() calls the releaseFunds mutation", async () => {
+    authed();
+    mockGet.mockResolvedValue(makeTrade("FUNDED"));
+    mockReleaseFunds.mockResolvedValue({ unsignedXdr: "release-xdr" });
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const response = await result.current.releaseFunds();
+
+    expect(mockReleaseFunds).toHaveBeenCalledWith("token-123", TRADE_ID);
+    expect(response).toEqual({ unsignedXdr: "release-xdr" });
+  });
+
+  it("raiseDispute() calls initiateDispute with the reason and category", async () => {
+    authed();
+    mockGet.mockResolvedValue(makeTrade("FUNDED"));
+    mockInitiateDispute.mockResolvedValue({ unsignedXdr: "dispute-xdr" });
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const response = await result.current.raiseDispute("Item not delivered", "quality");
+
+    expect(mockInitiateDispute).toHaveBeenCalledWith(
+      "token-123",
+      TRADE_ID,
+      "Item not delivered",
+      "quality",
+    );
+    expect(response).toEqual({ unsignedXdr: "dispute-xdr" });
+  });
+
+  it("rejects mutations when there is no auth token", async () => {
+    mockUseAuth.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    const { result } = renderHook(() => useTradeDetail(TRADE_ID));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(result.current.deposit()).rejects.toThrow("Not authenticated");
+    expect(mockDeposit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useTradeDetail.ts
+++ b/frontend/src/hooks/useTradeDetail.ts
@@ -2,26 +2,33 @@ import { useCallback, useEffect, useState } from "react";
 import { api, ApiError, type TradeResponse } from "@/lib/api";
 import { useAuth } from "./useAuth";
 
+const POLL_INTERVAL_MS = 10_000;
+const POLLING_STATUSES = new Set(["FUNDED", "IN_TRANSIT"]);
+
 interface UseTradeDetailResult {
   trade: TradeResponse | null;
-  loading: boolean;
+  isLoading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
+  deposit: () => Promise<{ unsignedXdr: string }>;
+  confirmDelivery: () => Promise<{ unsignedXdr: string }>;
+  releaseFunds: () => Promise<{ unsignedXdr: string }>;
+  raiseDispute: (reason: string, category: string) => Promise<{ unsignedXdr: string }>;
 }
 
 export function useTradeDetail(tradeId: string): UseTradeDetailResult {
   const { token, isAuthenticated } = useAuth();
   const [trade, setTrade] = useState<TradeResponse | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchTrade = useCallback(async () => {
     if (!isAuthenticated || !token) {
-      setLoading(false);
+      setIsLoading(false);
       return;
     }
 
-    setLoading(true);
+    setIsLoading(true);
     setError(null);
 
     try {
@@ -36,7 +43,7 @@ export function useTradeDetail(tradeId: string): UseTradeDetailResult {
             : "Failed to load trade";
       setError(message);
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [token, isAuthenticated, tradeId]);
 
@@ -44,5 +51,51 @@ export function useTradeDetail(tradeId: string): UseTradeDetailResult {
     void fetchTrade();
   }, [fetchTrade]);
 
-  return { trade, loading, error, refetch: fetchTrade };
+  useEffect(() => {
+    const status = trade?.status?.toUpperCase();
+    if (!status || !POLLING_STATUSES.has(status)) return;
+
+    const interval = setInterval(() => {
+      void fetchTrade();
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [trade?.status, fetchTrade]);
+
+  const requireToken = useCallback(() => {
+    if (!token) throw new Error("Not authenticated");
+    return token;
+  }, [token]);
+
+  const deposit = useCallback(
+    async () => api.trades.deposit(requireToken(), tradeId),
+    [requireToken, tradeId],
+  );
+
+  const confirmDelivery = useCallback(
+    async () => api.trades.confirmDelivery(requireToken(), tradeId),
+    [requireToken, tradeId],
+  );
+
+  const releaseFunds = useCallback(
+    async () => api.trades.releaseFunds(requireToken(), tradeId),
+    [requireToken, tradeId],
+  );
+
+  const raiseDispute = useCallback(
+    async (reason: string, category: string) =>
+      api.trades.initiateDispute(requireToken(), tradeId, reason, category),
+    [requireToken, tradeId],
+  );
+
+  return {
+    trade,
+    isLoading,
+    error,
+    refetch: fetchTrade,
+    deposit,
+    confirmDelivery,
+    releaseFunds,
+    raiseDispute,
+  };
 }


### PR DESCRIPTION
Enhances frontend/src/hooks/useTradeDetail.ts per issue #757: renames the loading flag to isLoading, polls every 10 seconds while the trade is FUNDED or IN_TRANSIT (stopping once it reaches a terminal status), and exposes deposit/confirmDelivery/releaseFunds/raiseDispute mutation functions that call the trades API and return the unsigned XDR for the caller to sign.

Updates the trade detail page to source its mutations from the hook instead of calling api.trades.* directly, and updates its test suite (mock shape rename + signing-flow tests now assert against the hook's mutation functions rather than the api client).

Closes #757

## Summary
Provide a brief summary of the changes introduced in this Pull Request and why they were made.

## Type of Change
Please check the option that applies:
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Refactor / Code Cleanup
- [ ] Documentation update
- [ ] CI / Infrastructure / Governance

## Changes Made
Detailed list of changes included in this PR:
- Change 1
- Change 2

## How Has This Been Tested?
Describe the tests conducted to verify your changes:
- [ ] Unit tests (`npm test` / `cargo test`)
- [ ] Integration / API endpoint testing
- [ ] Manual UI verification
- [ ] Staging / Docker stack validation (`./scripts/staging-up.sh`)

## Screenshots / Evidence (if applicable)
Add screenshots, terminal output logs, or GIF recordings demonstrating your fix or feature.

## Related Issues
- Closes # [issue number]
- Fixes # [issue number]

## Checklist
- [ ] My code follows the repository's coding style guidelines.
- [ ] I have performed a self-review of my code.
- [ ] I have added/updated relevant documentation and comments.
- [ ] My commits follow Conventional Commits formatting (`feat:`, `fix:`, `docs:`, etc.).
- [ ] No temporary debug code or AI generator disclaimers/signatures were committed.
- [ ] All automated tests pass cleanly without errors.
