### PR TITLE
Add useTrades hook with debounced pagination and filtering

### DIFF
--- a/frontend/src/hooks/__tests__/useTrades.test.ts
+++ b/frontend/src/hooks/__tests__/useTrades.test.ts
@@ -1,0 +1,236 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useTrades } from "../useTrades";
+import { useAuth } from "../useAuth";
+import { api, ApiError } from "@/lib/api";
+
+jest.mock("../useAuth");
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    trades: {
+      list: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    data: unknown;
+    constructor(status: number, message: string, data?: unknown) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+      this.data = data;
+    }
+  },
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockList = api.trades.list as jest.MockedFunction<typeof api.trades.list>;
+const mockCreate = api.trades.create as jest.MockedFunction<typeof api.trades.create>;
+
+const MOCK_TRADE = {
+  tradeId: "trade-001",
+  buyerAddress: "GBUYER123456789012345678901234567890123456789012345678",
+  sellerAddress: "GSELLER12345678901234567890123456789012345678901234567",
+  amountCngn: "10000",
+  buyerLossBps: 5000,
+  sellerLossBps: 5000,
+  status: "PENDING",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+function authed() {
+  mockUseAuth.mockReturnValue({
+    token: "token-123",
+    isAuthenticated: true,
+  } as unknown as ReturnType<typeof useAuth>);
+}
+
+describe("useTrades", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts in a loading state", () => {
+    authed();
+    mockList.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useTrades());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.trades).toEqual([]);
+    expect(result.current.total).toBe(0);
+  });
+
+  it("fetches trades after the debounce window elapses", async () => {
+    jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+    authed();
+    mockList.mockResolvedValue({
+      items: [MOCK_TRADE],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
+
+    const { result } = renderHook(() => useTrades({ status: "FUNDED", page: 2, limit: 10 }));
+
+    expect(mockList).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(300);
+    });
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(mockList).toHaveBeenCalledWith("token-123", {
+      status: "FUNDED",
+      page: 2,
+      limit: 10,
+      sort: undefined,
+    });
+    expect(result.current.trades).toEqual([MOCK_TRADE]);
+    expect(result.current.total).toBe(1);
+    expect(result.current.page).toBe(2);
+    expect(result.current.limit).toBe(10);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("defaults page and limit when not provided", async () => {
+    authed();
+    mockList.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+
+    const { result } = renderHook(() => useTrades());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.limit).toBe(20);
+  });
+
+  it("debounces rapid param changes into a single fetch with the latest params", async () => {
+    jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+    authed();
+    mockList.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+
+    const { rerender } = renderHook(({ page }: { page: number }) => useTrades({ page }), {
+      initialProps: { page: 1 },
+    });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(100);
+    });
+    rerender({ page: 2 });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(100);
+    });
+    rerender({ page: 3 });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(300);
+    });
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(mockList).toHaveBeenCalledWith(
+      "token-123",
+      expect.objectContaining({ page: 3 }),
+    );
+  });
+
+  it("sets an error message when the fetch fails", async () => {
+    authed();
+    mockList.mockRejectedValue(new ApiError(500, "Server unavailable"));
+
+    const { result } = renderHook(() => useTrades());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("Server unavailable");
+    expect(result.current.trades).toEqual([]);
+  });
+
+  it("skips fetching and clears loading when not authenticated", async () => {
+    mockUseAuth.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    const { result } = renderHook(() => useTrades());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.trades).toEqual([]);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("refetch() fetches immediately, bypassing the debounce", async () => {
+    authed();
+    mockList.mockResolvedValue({
+      items: [MOCK_TRADE],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
+
+    const { result } = renderHook(() => useTrades());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+
+  it("createTrade() calls the create API and returns the created trade", async () => {
+    authed();
+    mockList.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+    mockCreate.mockResolvedValue({ tradeId: "trade-999", unsignedXdr: "created-xdr" });
+
+    const { result } = renderHook(() => useTrades());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const createRequest = {
+      sellerAddress: "GSELLER12345678901234567890123456789012345678901234567",
+      amountCngn: "5000",
+      buyerLossBps: 5000,
+      sellerLossBps: 5000,
+    };
+    const response = await result.current.createTrade(createRequest);
+
+    expect(mockCreate).toHaveBeenCalledWith("token-123", createRequest);
+    expect(response).toEqual({ tradeId: "trade-999", unsignedXdr: "created-xdr" });
+  });
+
+  it("createTrade() rejects when there is no auth token", async () => {
+    mockUseAuth.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+    } as unknown as ReturnType<typeof useAuth>);
+    mockList.mockResolvedValue({
+      items: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+
+    const { result } = renderHook(() => useTrades());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(result.current.createTrade({
+      sellerAddress: "GSELLER12345678901234567890123456789012345678901234567",
+      amountCngn: "5000",
+      buyerLossBps: 5000,
+      sellerLossBps: 5000,
+    })).rejects.toThrow("Not authenticated");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useTrades.ts
+++ b/frontend/src/hooks/useTrades.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  api,
+  ApiError,
+  type CreateTradeRequest,
+  type CreateTradeResponse,
+  type TradeResponse,
+} from "@/lib/api";
+import { useAuth } from "./useAuth";
+
+const DEBOUNCE_MS = 300;
+
+interface UseTradesParams {
+  status?: string;
+  page?: number;
+  limit?: number;
+  sort?: string;
+}
+
+interface UseTradesResult {
+  trades: TradeResponse[];
+  total: number;
+  page: number;
+  limit: number;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  createTrade: (data: CreateTradeRequest) => Promise<CreateTradeResponse>;
+}
+
+export function useTrades(params: UseTradesParams = {}): UseTradesResult {
+  const { token, isAuthenticated } = useAuth();
+  const { status, page = 1, limit = 20, sort } = params;
+
+  const [trades, setTrades] = useState<TradeResponse[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTrades = useCallback(async () => {
+    if (!isAuthenticated || !token) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await api.trades.list(token, { status, page, limit, sort });
+      setTrades(data.items);
+      setTotal(data.pagination.total);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "Failed to load trades";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, isAuthenticated, status, page, limit, sort]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      void fetchTrades();
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timeout);
+  }, [fetchTrades]);
+
+  const createTrade = useCallback(
+    async (data: CreateTradeRequest) => {
+      if (!token) throw new Error("Not authenticated");
+      return api.trades.create(token, data);
+    },
+    [token],
+  );
+
+  return {
+    trades,
+    total,
+    page,
+    limit,
+    isLoading,
+    error,
+    refetch: fetchTrades,
+    createTrade,
+  };
+}

--- a/frontend/src/lib/api/trades.ts
+++ b/frontend/src/lib/api/trades.ts
@@ -13,12 +13,13 @@ import type {
 } from "./types";
 
 export const tradesApi = {
-  list: (token: string, params?: { status?: string; page?: number; limit?: number }) =>
+  list: (token: string, params?: { status?: string; page?: number; limit?: number; sort?: string }) =>
     request<TradeListResponse>(
       `/trades${createQueryString({
         status: params?.status,
         page: params?.page,
         limit: params?.limit,
+        sort: params?.sort,
       })}`,
       { token },
     ),


### PR DESCRIPTION
Implements frontend/src/hooks/useTrades.ts per issue #756: accepts { status?, page?, limit?, sort? }, returns { trades, total, page, limit, isLoading, error, refetch }, and debounces (300ms) the auto-refetch triggered by param changes so rapid filter/page/sort changes collapse into a single request. Exposes createTrade(), which calls the trades API and returns the created trade (tradeId + unsignedXdr for the caller to sign).

Adds the missing `sort` passthrough to tradesApi.list() in lib/api/trades.ts — the backend's GET /trades already accepts a sort query param (trade.schemas.ts / trade.service.ts parseSort), but the frontend client had no way to send it.

Closes #756

## Summary
Provide a brief summary of the changes introduced in this Pull Request and why they were made.

## Type of Change
Please check the option that applies:
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Refactor / Code Cleanup
- [ ] Documentation update
- [ ] CI / Infrastructure / Governance

## Changes Made
Detailed list of changes included in this PR:
- Change 1
- Change 2

## How Has This Been Tested?
Describe the tests conducted to verify your changes:
- [ ] Unit tests (`npm test` / `cargo test`)
- [ ] Integration / API endpoint testing
- [ ] Manual UI verification
- [ ] Staging / Docker stack validation (`./scripts/staging-up.sh`)

## Screenshots / Evidence (if applicable)
Add screenshots, terminal output logs, or GIF recordings demonstrating your fix or feature.

## Related Issues
- Closes # [issue number]
- Fixes # [issue number]

## Checklist
- [ ] My code follows the repository's coding style guidelines.
- [ ] I have performed a self-review of my code.
- [ ] I have added/updated relevant documentation and comments.
- [ ] My commits follow Conventional Commits formatting (`feat:`, `fix:`, `docs:`, etc.).
- [ ] No temporary debug code or AI generator disclaimers/signatures were committed.
- [ ] All automated tests pass cleanly without errors.
