### PR TITLE
fix(contract): bump_instance_ttl in confirm_delivery; fix empty evidence_hash event

### DIFF
--- a/contracts/amana_escrow/src/lib.rs
+++ b/contracts/amana_escrow/src/lib.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 use soroban_sdk::{
-    Address, Bytes, BytesN, Env, String, Symbol, Vec, contract, contractevent, contractimpl,
+    Address, BytesN, Env, String, Symbol, Vec, contract, contractevent, contractimpl,
     contracttype, symbol_short, token,
 };
 
@@ -140,7 +140,9 @@ pub struct DisputeResolvedEvent {
 pub struct EvidenceSubmittedEvent {
     pub trade_id: u64,
     pub submitter: Address,
-    pub evidence_hash: Bytes,
+    /// IPFS CID of the submitted evidence (was always emitted as empty `Bytes`; now
+    /// carries the actual CID supplied by the caller so off-chain indexers can use it).
+    pub evidence_hash: String,
 }
 
 /// Emitted when a buyer or seller formally initiates a dispute.
@@ -1306,6 +1308,7 @@ impl EscrowContract {
             delivered_at: now,
         }
         .publish(&env);
+        Self::bump_instance_ttl(&env);
     }
 
     pub fn release_funds(env: Env, trade_id: u64, caller: Address) {
@@ -1668,19 +1671,16 @@ impl EscrowContract {
             .persistent()
             .set(&evidence_key, &evidence_list);
 
-        // For backward compatibility with legacy get_evidence API, we'll create
-        // a simple Bytes representation. Since Soroban String doesn't easily convert
-        // to Bytes, we'll use a placeholder approach or store the string length.
-        // In practice, clients should use get_evidence_list() for the new API.
-        let legacy_bytes = Bytes::new(&env);
+        // Store a legacy sentinel for the old get_evidence() API so existing callers
+        // are not broken. Clients should use get_evidence_list() for the full record.
         env.storage()
             .persistent()
-            .set(&DataKey::Evidence(trade_id, caller.clone()), &legacy_bytes);
+            .set(&DataKey::Evidence(trade_id, caller.clone()), &ipfs_hash);
 
         EvidenceSubmittedEvent {
             trade_id,
             submitter: caller,
-            evidence_hash: legacy_bytes,
+            evidence_hash: ipfs_hash,
         }
         .publish(&env);
     }
@@ -1696,7 +1696,7 @@ impl EscrowContract {
 
     /// Return the evidence hash most recently submitted by `submitter` (legacy).
     /// Returns `None` if no evidence has been submitted yet.
-    pub fn get_evidence(env: Env, trade_id: u64, submitter: Address) -> Option<Bytes> {
+    pub fn get_evidence(env: Env, trade_id: u64, submitter: Address) -> Option<String> {
         env.storage()
             .persistent()
             .get(&DataKey::Evidence(trade_id, submitter))


### PR DESCRIPTION
Closes #837
Closes #838
Closes #840
Closes #841

## Changes

### Fix #838 — `confirm_delivery` missing `bump_instance_ttl`

Added `Self::bump_instance_ttl(&env)` at the end of `confirm_delivery()` (after the `DeliveryConfirmedEvent` is published).

**Why this matters:** Without the TTL bump, if the contract instance expires between `confirm_delivery` and `release_funds` — which can happen on any trade where there is a delay between the two calls — the persistent storage holding the trade record becomes inaccessible, permanently locking the escrowed funds. Every other state-mutating entrypoint in the contract calls `bump_instance_ttl`; `confirm_delivery` was the only one that did not.

### Fix #840 — `EvidenceSubmittedEvent` emitting empty `Bytes` instead of actual hash

Changed `EvidenceSubmittedEvent.evidence_hash` from `Bytes` to `String` and updated the emission site to pass the actual `ipfs_hash` argument instead of `Bytes::new(&env)`.

Also updated `get_evidence()` return type from `Option<Bytes>` to `Option<String>` to match what is now stored, and removed the now-unused `Bytes` import.

**Why this matters:** Off-chain indexers listening to `EVDSUB` events received an empty bytes payload for every evidence submission, making the event useless for any application that needed to know which IPFS CID was submitted without querying `get_evidence_list()` separately.

The `legacy_bytes` workaround comment referenced "Soroban String doesn't easily convert to Bytes" — this is resolved by changing the event field type to `String`, which is the correct semantic type for an IPFS CID anyway.