### PR TITLE
fix: resolve issues #855, #868, #869, #920 (assigned to devdianax)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Frontend test
         if: matrix.stack == 'frontend'
-        run: pnpm test
+        run: pnpm test -- --coverage
         working-directory: frontend
 
       - name: Backend test
@@ -130,7 +130,7 @@ jobs:
         run: |
           export NODE_ENV=test
           export JWT_SECRET=test-jwt-secret-value-with-minimum-length-32
-          pnpm test
+          pnpm test -- --coverage
         working-directory: backend
 
       - name: Mobile type check

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -24,10 +24,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 60,
-      functions: 65,
-      lines: 70,
-      statements: 70,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
   forceExit: true,

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -30,10 +30,10 @@ const config: Config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 50,
-      functions: 55,
-      lines: 60,
-      statements: 60,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
 };

--- a/frontend/src/app/trades/create/TradeContext.tsx
+++ b/frontend/src/app/trades/create/TradeContext.tsx
@@ -1,5 +1,15 @@
 "use client";
-import { createContext, useContext, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+const STORAGE_KEY = "amana-trade-draft";
 
 export type TradeData = {
   // Step 1
@@ -16,13 +26,6 @@ export type TradeData = {
   notes: string;
 };
 
-type TradeContextType = {
-  step: number;
-  setStep: (s: number) => void;
-  data: TradeData;
-  update: (partial: Partial<TradeData>) => void;
-};
-
 const defaults: TradeData = {
   commodity: "",
   quantity: "",
@@ -36,20 +39,101 @@ const defaults: TradeData = {
   notes: "",
 };
 
-const TradeContext = createContext<TradeContextType>({} as TradeContextType);
+// --- Step context (only step navigation) ---
+type TradeStepContextType = {
+  step: number;
+  setStep: (s: number) => void;
+};
+
+const TradeStepContext = createContext<TradeStepContextType>({
+  step: 1,
+  setStep: () => {},
+});
+
+// --- Data context (only form data) ---
+type TradeDataContextType = {
+  data: TradeData;
+  update: (partial: Partial<TradeData>) => void;
+  clearDraft: () => void;
+};
+
+const TradeDataContext = createContext<TradeDataContextType>({
+  data: defaults,
+  update: () => {},
+  clearDraft: () => {},
+});
+
+function loadDraft(): TradeData {
+  if (typeof window === "undefined") return defaults;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<TradeData>;
+      return { ...defaults, ...parsed };
+    }
+  } catch {
+    // corrupted storage — ignore
+  }
+  return defaults;
+}
 
 export function TradeProvider({ children }: { children: React.ReactNode }) {
   const [step, setStep] = useState(1);
   const [data, setData] = useState<TradeData>(defaults);
+  const hydrated = useRef(false);
 
-  const update = (partial: Partial<TradeData>) =>
-    setData((prev) => ({ ...prev, ...partial }));
+  // Hydrate from localStorage on mount (client only)
+  useEffect(() => {
+    if (!hydrated.current) {
+      hydrated.current = true;
+      setData(loadDraft());
+    }
+  }, []);
+
+  // Persist draft to localStorage on every change
+  useEffect(() => {
+    if (hydrated.current && typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    }
+  }, [data]);
+
+  const update = useCallback(
+    (partial: Partial<TradeData>) =>
+      setData((prev) => ({ ...prev, ...partial })),
+    [],
+  );
+
+  const clearDraft = useCallback(() => {
+    setData(defaults);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const stepValue = useMemo(() => ({ step, setStep }), [step]);
+  const dataValue = useMemo(
+    () => ({ data, update, clearDraft }),
+    [data, update, clearDraft],
+  );
 
   return (
-    <TradeContext.Provider value={{ step, setStep, data, update }}>
-      {children}
-    </TradeContext.Provider>
+    <TradeStepContext.Provider value={stepValue}>
+      <TradeDataContext.Provider value={dataValue}>
+        {children}
+      </TradeDataContext.Provider>
+    </TradeStepContext.Provider>
   );
 }
 
-export const useTrade = () => useContext(TradeContext);
+/** Access step navigation — only re-renders when step changes */
+export const useTradeStep = () => useContext(TradeStepContext);
+
+/** Access form data + update — only re-renders when data changes */
+export const useTradeData = () => useContext(TradeDataContext);
+
+/** Legacy combined hook (backwards-compatible) */
+export function useTrade() {
+  const { step, setStep } = useTradeStep();
+  const { data, update } = useTradeData();
+  return { step, setStep, data, update };
+}

--- a/frontend/src/app/trades/create/page.tsx
+++ b/frontend/src/app/trades/create/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { TradeProvider, useTrade } from "./TradeContext";
+import { TradeProvider, useTradeStep } from "./TradeContext";
 import Step1Details from "./steps/Step1Details";
 import Step2Negotiation from "./steps/Step2Negotiation";
 import Step3Review from "./steps/Step3Review";
@@ -12,7 +12,7 @@ const STEPS = [
 ];
 
 function StepIndicator() {
-  const { step } = useTrade();
+  const { step } = useTradeStep();
   return (
     <div className="flex items-center gap-0 mb-8">
       {STEPS.map(({ index, label }, i) => (
@@ -49,7 +49,7 @@ function StepIndicator() {
 }
 
 function CreateTradeInner() {
-  const { step } = useTrade();
+  const { step } = useTradeStep();
   return (
     <div className="min-h-screen bg-bg-primary flex items-start justify-center px-4 py-12">
       <div className="w-full max-w-lg">

--- a/frontend/src/components/ui/Icon.tsx
+++ b/frontend/src/components/ui/Icon.tsx
@@ -11,8 +11,20 @@ const SIZE_MAP = {
   lg: 24,
 } as const;
 
+// Utility type: converts PascalCase Lucide icon keys to kebab-case
+type PascalToKebab<S extends string> = S extends `${infer First extends string}${infer Rest}`
+  ? First extends Uppercase<First>
+    ? First extends Lowercase<First>
+      ? `${First}${PascalToKebab<Rest>}`
+      : `${Lowercase<First>}${PascalToKebab<Rest>}`
+    : `${First}${PascalToKebab<Rest>}`
+  : "";
+
+// All valid kebab-case Lucide icon names derived from the icons registry
+export type IconName = PascalToKebab<keyof typeof icons & string>;
+
 export interface IconProps {
-  name: string;
+  name: IconName;
   size?: keyof typeof SIZE_MAP;
   className?: string;
   "aria-label"?: string;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -3,7 +3,7 @@
 export { StatusBadge } from "./StatusBadge";
 export type { StatusBadgeProps, TradeStatus } from "./StatusBadge";
 export { Icon } from "./Icon";
-export type { IconProps } from "./Icon";
+export type { IconProps, IconName } from "./Icon";
 export { BentoCard } from "./BentoCard";
 export { DriverManifestForm } from "./DriverManifestForm";
 export type { DriverManifestData } from "./DriverManifestForm";

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,27 @@
+const { getDefaultConfig } = require("expo/metro-config");
+
+const config = getDefaultConfig(__dirname);
+
+// Enable minification and optimize for production
+config.transformer.minifierConfig = {
+  mangle: { toplevel: true },
+  compress: {
+    drop_console: true,
+    passes: 2,
+    dead_code: true,
+    collapse_vars: true,
+    reduce_vars: true,
+    pure_getters: true,
+    unsafe: true,
+    unused: true,
+  },
+  output: { comments: false },
+};
+
+// Optimize asset handling
+config.resolver.assetExts = config.resolver.assetExts.filter(
+  (ext) => ext !== "svg",
+);
+config.resolver.assetExts.push("svg");
+
+module.exports = config;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,7 +13,8 @@
     "prebuild": "expo prebuild --clean",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "bundle:analyze": "npx expo export --dump-sourcemap && echo 'Bundle analysis complete. Check the output above for size details.'"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.17",

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -1,20 +1,30 @@
-import { useEffect } from 'react';
+import { Suspense, lazy, useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import type { LinkingOptions } from '@react-navigation/native';
 
 import type { RootStackParamList } from '../types/navigation';
-import { useAuthStore } from '../stores/authStore';
-import WalletConnectScreen from '../screens/WalletConnectScreen';
-import TradeListScreen from '../screens/TradeListScreen';
-import TradeDetailScreen from '../screens/TradeDetailScreen';
-import DisputeDetailScreen from '../screens/DisputeDetailScreen';
-import CreateTradeScreen from '../screens/CreateTradeScreen';
-import EvidenceCaptureScreen from '../screens/EvidenceCaptureScreen';
-import VaultDashboard from '../screens/VaultDashboard';
 import { useDeepLink } from '../hooks/useDeepLink';
 
+// Lazy-loaded screens — only bundled when navigated to
+const WalletConnectScreen = lazy(() => import('../screens/WalletConnectScreen'));
+const TradeListScreen = lazy(() => import('../screens/TradeListScreen'));
+const TradeDetailScreen = lazy(() => import('../screens/TradeDetailScreen'));
+const DisputeDetailScreen = lazy(() => import('../screens/DisputeDetailScreen'));
+const CreateTradeScreen = lazy(() => import('../screens/CreateTradeScreen'));
+const EvidenceCaptureScreen = lazy(() => import('../screens/EvidenceCaptureScreen'));
+const VaultDashboard = lazy(() => import('../screens/VaultDashboard'));
+
 const Stack = createStackNavigator<RootStackParamList>();
+
+function ScreenFallback() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ActivityIndicator size="large" color="#C8A23D" />
+    </View>
+  );
+}
 
 // Deep linking configuration
 const linking: LinkingOptions<RootStackParamList> = {
@@ -56,18 +66,20 @@ export function AppNavigator({ isAuthenticated }: AppNavigatorProps) {
         }
       }}
     >
-      <Stack.Navigator
-        initialRouteName={isAuthenticated ? 'TradeList' : 'WalletConnect'}
-        screenOptions={{ headerShown: false }}
-      >
-        <Stack.Screen name="WalletConnect" component={WalletConnectScreen} />
-        <Stack.Screen name="TradeList" component={TradeListScreen} />
-        <Stack.Screen name="TradeDetail" component={TradeDetailScreen} />
-        <Stack.Screen name="DisputeDetail" component={DisputeDetailScreen} />
-        <Stack.Screen name="CreateTrade" component={CreateTradeScreen} />
-        <Stack.Screen name="EvidenceCapture" component={EvidenceCaptureScreen} />
-        <Stack.Screen name="VaultDashboard" component={VaultDashboard} />
-      </Stack.Navigator>
+      <Suspense fallback={<ScreenFallback />}>
+        <Stack.Navigator
+          initialRouteName={isAuthenticated ? 'TradeList' : 'WalletConnect'}
+          screenOptions={{ headerShown: false }}
+        >
+          <Stack.Screen name="WalletConnect" component={WalletConnectScreen} />
+          <Stack.Screen name="TradeList" component={TradeListScreen} />
+          <Stack.Screen name="TradeDetail" component={TradeDetailScreen} />
+          <Stack.Screen name="DisputeDetail" component={DisputeDetailScreen} />
+          <Stack.Screen name="CreateTrade" component={CreateTradeScreen} />
+          <Stack.Screen name="EvidenceCapture" component={EvidenceCaptureScreen} />
+          <Stack.Screen name="VaultDashboard" component={VaultDashboard} />
+        </Stack.Navigator>
+      </Suspense>
     </NavigationContainer>
   );
 }


### PR DESCRIPTION
## Summary

Resolves 4 issues assigned to @devdianax:

### Closes #869 — Type-safe Icon component
- Added `PascalToKebab<S>` utility type to derive kebab-case icon names from Lucide's PascalCase registry
- Exported `IconName` union type and changed `IconProps.name` from `string` to `IconName`
- Compile-time autocomplete + error on invalid icon names with zero runtime cost

### Closes #868 — TradeContext optimization
- Split single context into `TradeStepContext` (step navigation) and `TradeDataContext` (form data) to prevent unnecessary re-renders
- Added localStorage persistence for draft state (`amana-trade-draft` key)
- Fixed unsafe `{} as TradeContextType` cast with proper default values
- Maintained backwards-compatible `useTrade()` hook

### Closes #855 — Enforce 80% coverage thresholds in CI
- Raised backend coverage thresholds from 60/65/70/70 → 80/80/80/80
- Raised frontend coverage thresholds from 50/55/60/60 → 80/80/80/80
- Added `--coverage` flag to CI test steps for explicit enforcement

### Closes #920 — Mobile bundle optimization
- Added `metro.config.js` with production optimizations (minification, console stripping, dead code elimination)
- Implemented lazy screen loading via `React.lazy` + `Suspense` in AppNavigator
- Added `bundle:analyze` script to package.json

## Files Changed
- `frontend/src/components/ui/Icon.tsx` — type-safe icon names
- `frontend/src/components/ui/index.ts` — export IconName
- `frontend/src/app/trades/create/TradeContext.tsx` — split contexts + persistence
- `frontend/src/app/trades/create/page.tsx` — use split context hooks
- `backend/jest.config.js` — 80% thresholds
- `frontend/jest.config.ts` — 80% thresholds
- `.github/workflows/ci.yml` — --coverage flag
- `mobile/metro.config.js` — new production config
- `mobile/package.json` — bundle:analyze script
- `mobile/src/navigation/AppNavigator.tsx` — lazy screen loading