### PR TITLE
Pilot checklist, Stellar path payments, and mobile notification opt-in fixes

### DIFF
--- a/backend/docs/path-payments.md
+++ b/backend/docs/path-payments.md
@@ -1,0 +1,91 @@
+# Stellar Path Payments
+
+Path payments let one account send a payment in asset A while the recipient
+receives a different asset B, using Stellar's built-in DEX to route the
+conversion atomically in a single transaction. This is useful for Amana
+whenever a buyer or seller wants to settle in a currency other than the
+trade's escrow asset (e.g. paying in XLM while the seller receives cNGN/USDC).
+
+The helpers live in [`src/lib/stellarPathPayment.ts`](../src/lib/stellarPathPayment.ts)
+and wrap the two path payment operations exposed by `@stellar/stellar-sdk`:
+
+| Variant | You fix | Network solves for | SDK operation |
+|---|---|---|---|
+| Strict send | The amount you send | The (variable, minimum-bounded) amount the recipient gets | `Operation.pathPaymentStrictSend` |
+| Strict receive | The amount the recipient gets | The (variable, maximum-bounded) amount you pay | `Operation.pathPaymentStrictReceive` |
+
+## Finding a path before building the payment
+
+Before building a transaction, it's usually worth quoting a path so you can
+set a sane `destMin` / `sendMax` and avoid excessive slippage:
+
+```ts
+import { Asset } from "@stellar/stellar-sdk";
+import { findStrictSendPaths, findStrictReceivePaths } from "../src/lib/stellarPathPayment";
+
+const xlm = Asset.native();
+const usdc = new Asset("USDC", usdcIssuer);
+
+// "If I send 100 XLM, how much USDC could the recipient get?"
+const sendPaths = await findStrictSendPaths(xlm, "100", [usdc]);
+
+// "If the recipient must get exactly 10 USDC, how much XLM would I pay?"
+const receivePaths = await findStrictReceivePaths([xlm], usdc, "10");
+```
+
+## Building a strict-send payment
+
+```ts
+import { Asset, Keypair } from "@stellar/stellar-sdk";
+import { buildPathPaymentStrictSend, submitPathPayment } from "../src/lib/stellarPathPayment";
+
+const tx = await buildPathPaymentStrictSend({
+  sourcePublicKey: sourceKeypair.publicKey(),
+  destinationPublicKey: destinationKeypair.publicKey(),
+  sendAsset: Asset.native(),
+  sendAmount: "100",
+  destAsset: usdc,
+  destMin: "9", // reject if the recipient would get less than this
+});
+
+tx.sign(sourceKeypair);
+const result = await submitPathPayment(tx);
+```
+
+## Building a strict-receive payment
+
+```ts
+import { buildPathPaymentStrictReceive, submitPathPayment } from "../src/lib/stellarPathPayment";
+
+const tx = await buildPathPaymentStrictReceive({
+  sourcePublicKey: sourceKeypair.publicKey(),
+  destinationPublicKey: destinationKeypair.publicKey(),
+  sendAsset: Asset.native(),
+  sendMax: "110", // refuse to pay more than this
+  destAsset: usdc,
+  destAmount: "10",
+});
+
+tx.sign(sourceKeypair);
+const result = await submitPathPayment(tx);
+```
+
+## Error handling
+
+Submission errors from `submitPathPayment` (or any other Horizon/RPC call)
+should be run through the existing `classifyStellarError` /
+`classifyStellarServiceError` helpers in
+[`src/services/stellar.service.ts`](../src/services/stellar.service.ts) and
+[`src/errors/service.errors.ts`](../src/errors/service.errors.ts) so failures
+are categorized (timeout, rate limited, invalid XDR, etc.) consistently with
+the rest of the Stellar integration.
+
+## Runnable example
+
+See [`backend/scripts/path-payment-example.ts`](../scripts/path-payment-example.ts)
+for a runnable script that quotes both kinds of paths and builds (but does
+not sign/submit) both payment variants:
+
+```bash
+npx tsx backend/scripts/path-payment-example.ts
+```

--- a/backend/scripts/path-payment-example.ts
+++ b/backend/scripts/path-payment-example.ts
@@ -1,0 +1,85 @@
+/**
+ * Example: building a Stellar path payment with the helpers in
+ * `src/lib/stellarPathPayment.ts`.
+ *
+ * This script is illustrative — it builds transactions but does not sign or
+ * submit them (signing requires a real secret key, which should never be
+ * hardcoded). See docs/backend/path-payments.md for the full walkthrough.
+ *
+ * Run with: npx tsx backend/scripts/path-payment-example.ts
+ */
+import { Asset, Keypair } from "@stellar/stellar-sdk";
+import {
+  buildPathPaymentStrictSend,
+  buildPathPaymentStrictReceive,
+  findStrictSendPaths,
+  findStrictReceivePaths,
+} from "../src/lib/stellarPathPayment";
+import { USDC_ISSUER_TESTNET } from "../src/config/stellar";
+
+async function main() {
+  const sourceKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const usdc = new Asset("USDC", USDC_ISSUER_TESTNET);
+  const nativeXlm = Asset.native();
+
+  // --- Strict send: "I will send exactly 100 XLM, recipient gets at least 9 USDC" ---
+  const sendPaths = await findStrictSendPaths(nativeXlm, "100", [usdc]).catch(
+    () => [],
+  );
+  console.log("Strict-send candidate paths:", sendPaths.length);
+
+  const strictSendTx = await buildPathPaymentStrictSend({
+    sourcePublicKey: sourceKeypair.publicKey(),
+    destinationPublicKey: destinationKeypair.publicKey(),
+    sendAsset: nativeXlm,
+    sendAmount: "100",
+    destAsset: usdc,
+    destMin: "9",
+    memo: "example strict-send",
+  }).catch((error) => {
+    console.log(
+      "Skipping build (no funded source account on this network):",
+      error.message,
+    );
+    return null;
+  });
+
+  if (strictSendTx) {
+    console.log("Strict-send transaction XDR:", strictSendTx.toXDR());
+  }
+
+  // --- Strict receive: "Recipient gets exactly 10 USDC, I pay at most 110 XLM" ---
+  const receivePaths = await findStrictReceivePaths(
+    [nativeXlm],
+    usdc,
+    "10",
+  ).catch(() => []);
+  console.log("Strict-receive candidate paths:", receivePaths.length);
+
+  const strictReceiveTx = await buildPathPaymentStrictReceive({
+    sourcePublicKey: sourceKeypair.publicKey(),
+    destinationPublicKey: destinationKeypair.publicKey(),
+    sendAsset: nativeXlm,
+    sendMax: "110",
+    destAsset: usdc,
+    destAmount: "10",
+    memo: "example strict-receive",
+  }).catch((error) => {
+    console.log(
+      "Skipping build (no funded source account on this network):",
+      error.message,
+    );
+    return null;
+  });
+
+  if (strictReceiveTx) {
+    console.log("Strict-receive transaction XDR:", strictReceiveTx.toXDR());
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/src/__tests__/stellarPathPayment.test.ts
+++ b/backend/src/__tests__/stellarPathPayment.test.ts
@@ -1,0 +1,137 @@
+import { Asset, Keypair } from "@stellar/stellar-sdk";
+
+const mockLoadAccount = jest.fn();
+const mockStrictSendPaths = jest.fn();
+const mockStrictReceivePaths = jest.fn();
+const mockSubmitTransaction = jest.fn();
+
+jest.mock("../config/stellar", () => ({
+  horizonServer: {
+    loadAccount: (...args: unknown[]) => mockLoadAccount(...args),
+    strictSendPaths: (...args: unknown[]) => mockStrictSendPaths(...args),
+    strictReceivePaths: (...args: unknown[]) => mockStrictReceivePaths(...args),
+    submitTransaction: (...args: unknown[]) => mockSubmitTransaction(...args),
+  },
+  sorobanRpcClient: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+import {
+  buildPathPaymentStrictSend,
+  buildPathPaymentStrictReceive,
+  findStrictSendPaths,
+  findStrictReceivePaths,
+  submitPathPayment,
+} from "../lib/stellarPathPayment";
+
+const SOURCE_PUBLIC_KEY = Keypair.random().publicKey();
+const DEST_PUBLIC_KEY = Keypair.random().publicKey();
+const USDC_ISSUER = "GDDD3FRCH55BSYNKISYY242HQNIBOH35CQP42NSJABR62XK2JOV5MED6";
+
+function mockAccount(sequence = "10") {
+  return {
+    accountId: () => SOURCE_PUBLIC_KEY,
+    sequenceNumber: () => sequence,
+  };
+}
+
+describe("stellarPathPayment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadAccount.mockResolvedValue(mockAccount());
+  });
+
+  it("builds a strict-send path payment transaction with the correct operation", async () => {
+    const usdc = new Asset("USDC", USDC_ISSUER);
+
+    const tx = await buildPathPaymentStrictSend({
+      sourcePublicKey: SOURCE_PUBLIC_KEY,
+      destinationPublicKey: DEST_PUBLIC_KEY,
+      sendAsset: Asset.native(),
+      sendAmount: "100",
+      destAsset: usdc,
+      destMin: "9",
+    });
+
+    expect(mockLoadAccount).toHaveBeenCalledWith(SOURCE_PUBLIC_KEY);
+    expect(tx.operations).toHaveLength(1);
+    expect(tx.operations[0]?.type).toBe("pathPaymentStrictSend");
+  });
+
+  it("builds a strict-receive path payment transaction with the correct operation", async () => {
+    const usdc = new Asset("USDC", USDC_ISSUER);
+
+    const tx = await buildPathPaymentStrictReceive({
+      sourcePublicKey: SOURCE_PUBLIC_KEY,
+      destinationPublicKey: DEST_PUBLIC_KEY,
+      sendAsset: Asset.native(),
+      sendMax: "110",
+      destAsset: usdc,
+      destAmount: "10",
+    });
+
+    expect(tx.operations).toHaveLength(1);
+    expect(tx.operations[0]?.type).toBe("pathPaymentStrictReceive");
+  });
+
+  it("attaches a text memo when provided", async () => {
+    const usdc = new Asset("USDC", USDC_ISSUER);
+
+    const tx = await buildPathPaymentStrictSend({
+      sourcePublicKey: SOURCE_PUBLIC_KEY,
+      destinationPublicKey: DEST_PUBLIC_KEY,
+      sendAsset: Asset.native(),
+      sendAmount: "100",
+      destAsset: usdc,
+      destMin: "9",
+      memo: "hello",
+    });
+
+    expect(tx.memo.value).toBe("hello");
+  });
+
+  it("delegates strict-send path lookups to Horizon", async () => {
+    const usdc = new Asset("USDC", USDC_ISSUER);
+    const records = [{ source_amount: "100" }];
+    mockStrictSendPaths.mockReturnValue({
+      call: jest.fn().mockResolvedValue({ records }),
+    });
+
+    const result = await findStrictSendPaths(Asset.native(), "100", [usdc]);
+
+    expect(mockStrictSendPaths).toHaveBeenCalledWith(
+      Asset.native(),
+      "100",
+      [usdc],
+    );
+    expect(result).toEqual(records);
+  });
+
+  it("delegates strict-receive path lookups to Horizon", async () => {
+    const usdc = new Asset("USDC", USDC_ISSUER);
+    const records = [{ destination_amount: "10" }];
+    mockStrictReceivePaths.mockReturnValue({
+      call: jest.fn().mockResolvedValue({ records }),
+    });
+
+    const result = await findStrictReceivePaths([Asset.native()], usdc, "10");
+
+    expect(mockStrictReceivePaths).toHaveBeenCalledWith(
+      [Asset.native()],
+      usdc,
+      "10",
+    );
+    expect(result).toEqual(records);
+  });
+
+  it("submits a signed transaction via Horizon", async () => {
+    const fakeResponse = { hash: "abc123", successful: true };
+    mockSubmitTransaction.mockResolvedValue(fakeResponse);
+
+    const tx = { toXDR: () => "fake" } as any;
+    const result = await submitPathPayment(tx);
+
+    expect(mockSubmitTransaction).toHaveBeenCalledWith(tx);
+    expect(result).toBe(fakeResponse);
+  });
+});

--- a/backend/src/lib/stellarPathPayment.ts
+++ b/backend/src/lib/stellarPathPayment.ts
@@ -1,0 +1,204 @@
+import {
+  Account,
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Memo,
+  Operation,
+  TransactionBuilder,
+  type Transaction,
+} from "@stellar/stellar-sdk";
+import { horizonServer, networkPassphrase } from "../config/stellar";
+
+/**
+ * Utilities for building Stellar path payments (cross-asset conversions in a
+ * single transaction) and for finding conversion paths ahead of time.
+ *
+ * Path payments let a sender pay in one asset while the recipient receives a
+ * different asset, using the Stellar network's built-in DEX to route the
+ * conversion atomically. Two variants are supported by the network and both
+ * are exposed here:
+ *
+ *  - **strict send**: the sender fixes the amount they send; the recipient
+ *    gets "whatever the path yields", bounded by a minimum.
+ *  - **strict receive**: the recipient's amount is fixed; the sender pays
+ *    "whatever the path costs", bounded by a maximum.
+ *
+ * See https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations#path-payment-strict-send
+ */
+
+export interface PathPaymentStrictSendParams {
+  /** Public key of the account funding/signing the transaction. */
+  sourcePublicKey: string;
+  /** Destination account public key that will receive `destAsset`. */
+  destinationPublicKey: string;
+  /** Asset the sender is spending. */
+  sendAsset: Asset;
+  /** Exact amount of `sendAsset` to spend, as a decimal string (e.g. "10.5"). */
+  sendAmount: string;
+  /** Asset the destination account will receive. */
+  destAsset: Asset;
+  /**
+   * Minimum acceptable amount of `destAsset` the destination should receive,
+   * as a decimal string. Protects the sender against slippage.
+   */
+  destMin: string;
+  /** Optional intermediate assets forming the conversion path. Defaults to none (direct or auto-routed by Horizon's path-finding). */
+  path?: Asset[];
+  /** Memo text to attach to the transaction, if any. */
+  memo?: string;
+  /** Transaction fee in stroops. Defaults to `BASE_FEE`. */
+  fee?: string;
+  /** Transaction timeout in seconds. Defaults to 30. */
+  timeoutSeconds?: number;
+}
+
+export interface PathPaymentStrictReceiveParams {
+  /** Public key of the account funding/signing the transaction. */
+  sourcePublicKey: string;
+  /** Destination account public key that will receive `destAsset`. */
+  destinationPublicKey: string;
+  /** Asset the sender is spending. */
+  sendAsset: Asset;
+  /**
+   * Maximum amount of `sendAsset` the sender is willing to spend, as a
+   * decimal string. Protects the sender against slippage.
+   */
+  sendMax: string;
+  /** Asset the destination account will receive. */
+  destAsset: Asset;
+  /** Exact amount of `destAsset` the destination should receive, as a decimal string. */
+  destAmount: string;
+  /** Optional intermediate assets forming the conversion path. */
+  path?: Asset[];
+  /** Memo text to attach to the transaction, if any. */
+  memo?: string;
+  /** Transaction fee in stroops. Defaults to `BASE_FEE`. */
+  fee?: string;
+  /** Transaction timeout in seconds. Defaults to 30. */
+  timeoutSeconds?: number;
+}
+
+/**
+ * Loads the current sequence number for `publicKey` from Horizon and returns
+ * an `Account` object usable as a transaction source.
+ */
+export async function loadSourceAccount(publicKey: string): Promise<Account> {
+  const account = await horizonServer.loadAccount(publicKey);
+  return new Account(account.accountId(), account.sequenceNumber());
+}
+
+/**
+ * Builds (but does not sign or submit) a path-payment-strict-send
+ * transaction: "I will send exactly `sendAmount` of `sendAsset`; the
+ * recipient gets at least `destMin` of `destAsset`."
+ *
+ * Callers are responsible for signing the returned transaction with the
+ * source account's keypair and submitting it via `submitPathPayment`.
+ */
+export async function buildPathPaymentStrictSend(
+  params: PathPaymentStrictSendParams,
+): Promise<Transaction> {
+  const sourceAccount = await loadSourceAccount(params.sourcePublicKey);
+
+  const transaction = new TransactionBuilder(sourceAccount, {
+    fee: params.fee ?? BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.pathPaymentStrictSend({
+        sendAsset: params.sendAsset,
+        sendAmount: params.sendAmount,
+        destination: params.destinationPublicKey,
+        destAsset: params.destAsset,
+        destMin: params.destMin,
+        path: params.path ?? [],
+      }),
+    )
+    .setTimeout(params.timeoutSeconds ?? 30);
+
+  if (params.memo) {
+    transaction.addMemo(Memo.text(params.memo));
+  }
+
+  return transaction.build();
+}
+
+/**
+ * Builds (but does not sign or submit) a path-payment-strict-receive
+ * transaction: "The recipient will get exactly `destAmount` of `destAsset`;
+ * I will pay at most `sendMax` of `sendAsset`."
+ *
+ * Callers are responsible for signing the returned transaction with the
+ * source account's keypair and submitting it via `submitPathPayment`.
+ */
+export async function buildPathPaymentStrictReceive(
+  params: PathPaymentStrictReceiveParams,
+): Promise<Transaction> {
+  const sourceAccount = await loadSourceAccount(params.sourcePublicKey);
+
+  const transaction = new TransactionBuilder(sourceAccount, {
+    fee: params.fee ?? BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.pathPaymentStrictReceive({
+        sendAsset: params.sendAsset,
+        sendMax: params.sendMax,
+        destination: params.destinationPublicKey,
+        destAsset: params.destAsset,
+        destAmount: params.destAmount,
+        path: params.path ?? [],
+      }),
+    )
+    .setTimeout(params.timeoutSeconds ?? 30);
+
+  if (params.memo) {
+    transaction.addMemo(Memo.text(params.memo));
+  }
+
+  return transaction.build();
+}
+
+/**
+ * Finds candidate conversion paths from `sourceAssets` to `destAsset` for a
+ * fixed destination amount, using Horizon's `/paths/strict-receive` endpoint.
+ * Useful for quoting a `sendMax` before building a strict-receive payment.
+ */
+export async function findStrictReceivePaths(
+  sourceAssets: Asset[],
+  destAsset: Asset,
+  destAmount: string,
+): Promise<Horizon.ServerApi.PaymentPathRecord[]> {
+  const response = await horizonServer
+    .strictReceivePaths(sourceAssets, destAsset, destAmount)
+    .call();
+  return response.records;
+}
+
+/**
+ * Finds candidate conversion paths for a fixed source amount, using
+ * Horizon's `/paths/strict-send` endpoint. Useful for quoting a `destMin`
+ * before building a strict-send payment.
+ */
+export async function findStrictSendPaths(
+  sourceAsset: Asset,
+  sourceAmount: string,
+  destinationAssets: Asset[],
+): Promise<Horizon.ServerApi.PaymentPathRecord[]> {
+  const response = await horizonServer
+    .strictSendPaths(sourceAsset, sourceAmount, destinationAssets)
+    .call();
+  return response.records;
+}
+
+/**
+ * Submits an already-signed transaction to Horizon and returns the
+ * submission result. Left as a thin wrapper so callers can reuse the
+ * existing error classification helpers in `stellar.service.ts` around it.
+ */
+export async function submitPathPayment(
+  signedTransaction: Transaction,
+): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
+  return horizonServer.submitTransaction(signedTransaction);
+}

--- a/docs/PUBLIC_PILOT_CHECKLIST.md
+++ b/docs/PUBLIC_PILOT_CHECKLIST.md
@@ -1,0 +1,89 @@
+# Public Pilot Launch Checklist
+
+This checklist operationalizes the launch of a regional public pilot, building on the
+research plan in [`USER_RESEARCH_PLAN_PILOT_REGIONS.md`](./USER_RESEARCH_PLAN_PILOT_REGIONS.md).
+It is meant to be copied into a tracked issue/board per region and checked off by the
+ops owner before go-live, and revisited during the pilot.
+
+Owner: Ops lead for the pilot region. Each section lists a suggested owner; adjust to
+the team actually running the region.
+
+## 1. Legal Review
+
+- [ ] Confirm the pilot region is not subject to licensing/regulatory restrictions that
+      would block escrow or payment-facilitation activity (legal counsel sign-off).
+- [ ] Terms of Service and Privacy Policy reviewed for region-specific requirements
+      (data residency, consumer protection, KYC/AML obligations).
+- [ ] Confirm dispute/arbitration clauses in the ToS match the actual dispute process
+      used in this pilot (see Section 4).
+- [ ] Data processing agreements in place for any third-party services used in region
+      (SMS/notification providers, payment rails, storage).
+- [ ] Escrow/custody structure reviewed against local money-transmission rules; document
+      the determination (exempt / licensed / requires local partner).
+- [ ] Sign-off recorded (name, date, scope of approval) before onboarding starts.
+
+## 2. User Onboarding
+
+- [ ] Onboarding flow (mobile + web) tested end-to-end for the target user segments
+      (buyers, sellers, drivers, cooperative leaders) as defined in the research plan.
+- [ ] Identity verification / KYC steps configured for the region's requirements.
+- [ ] Local-language copy reviewed for onboarding screens, ToS summary, and support
+      materials.
+- [ ] Support channel (WhatsApp/SMS/phone) set up and staffed for onboarding questions.
+- [ ] Cooperative leaders / regional partners briefed and given a point of contact.
+- [ ] Test accounts created and a full trade lifecycle (create → fund → deliver →
+      release) run against the pilot environment before real users onboard.
+- [ ] Rollout capped (invite codes / waitlist / staged cohort) so onboarding volume can
+      be throttled if support or infra can't keep up.
+
+## 3. Monitoring & Alerting
+
+- [ ] Dashboards in place for: trade creation rate, funding rate, dispute rate,
+      release/settlement latency, and Stellar transaction failure rate (see
+      [`docs/METRICS.md`](./METRICS.md) and [`docs/PROMETHEUS_METRICS.md`](./PROMETHEUS_METRICS.md)).
+- [ ] Alerting thresholds configured for: elevated dispute rate, elevated Stellar
+      submission failures, webhook delivery failures, and API error-rate spikes.
+- [ ] On-call rotation defined for the pilot window with an escalation path.
+- [ ] Logging confirmed to capture enough context to investigate a disputed trade
+      without exposing PII beyond what's necessary (see [`docs/audit-logging.md`](./audit-logging.md)).
+- [ ] Synthetic/canary trade scheduled on a fixed cadence to catch silent regressions.
+
+## 4. Dispute Handling
+
+- [ ] Dispute intake path (in-app + support channel) tested and documented.
+- [ ] Dispute categories and SLAs defined and communicated to the ops/mediator team
+      (see [`docs/mediator-dashboard-spec.md`](./mediator-dashboard-spec.md)).
+- [ ] Mediator(s) assigned for the pilot region with access to the mediator dashboard.
+- [ ] Evidence submission flow (photos/manifest) verified for the devices/network
+      conditions expected in-region.
+- [ ] Escalation path defined for disputes the mediator cannot resolve (legal, refund
+      authority, loss-sharing exceptions).
+- [ ] Dispute outcomes tracked and reviewed weekly during the pilot to catch systemic
+      issues early.
+
+## 5. Communications Plan
+
+- [ ] Internal announcement drafted (what's launching, region, dates, success metrics,
+      who to contact for issues).
+- [ ] External/user-facing messaging drafted for onboarding invites, in-app banners,
+      and support scripts.
+- [ ] Incident communication template prepared (what we tell users if the pilot has a
+      P1 outage or a paused-trades event).
+- [ ] Post-pilot debrief scheduled (date fixed at launch) to review metrics against the
+      research plan's success criteria and decide on next steps (expand, iterate, stop).
+- [ ] Stakeholder update cadence agreed (e.g., weekly summary to leadership during the
+      pilot window).
+
+## Sign-off
+
+- [ ] Ops review complete — all sections above checked or explicitly waived with a
+      documented reason.
+- [ ] Go/no-go decision recorded with date and approver.
+
+| Section | Owner | Reviewed by | Date |
+|---|---|---|---|
+| Legal Review | | | |
+| User Onboarding | | | |
+| Monitoring & Alerting | | | |
+| Dispute Handling | | | |
+| Communications Plan | | | |

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -10,7 +10,7 @@ import {
   registerForPushNotifications,
   storePushTokenOnBackend,
   setupNotificationListeners,
-  checkNotificationPermissions,
+  getNotificationOptInPreference,
 } from './services/notification.service';
 import type { RootStackParamList } from './types/navigation';
 import { AppNavigator } from './navigation/AppNavigator';
@@ -29,9 +29,14 @@ export default function App() {
     if (!token) return;
 
     const setupNotifications = async () => {
-      const hasPermission = await checkNotificationPermissions();
-      if (!hasPermission) return;
+      // Respect a prior in-app opt-out: don't re-prompt or re-register on
+      // every launch once the user has explicitly declined.
+      const preference = await getNotificationOptInPreference();
+      if (preference === 'denied') return;
 
+      // For a first-time user (preference === 'unset') this triggers the
+      // native permission prompt; for a returning user who already granted
+      // permission it resolves immediately with the existing token.
       const pushToken = await registerForPushNotifications();
       if (pushToken) {
         await storePushTokenOnBackend(pushToken, token);

--- a/mobile/src/services/notification.service.ts
+++ b/mobile/src/services/notification.service.ts
@@ -3,14 +3,9 @@ import { Platform } from "react-native";
 import * as SecureStore from "expo-secure-store";
 
 const PUSH_TOKEN_KEY = "amana_push_token";
+const OPT_IN_PREFERENCE_KEY = "amana_notification_opt_in";
 
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: true,
-    shouldSetBadge: true,
-  }),
-});
+export type NotificationOptInPreference = "granted" | "denied" | "unset";
 
 export interface NotificationData {
   type?: "trade" | "dispute" | "general";
@@ -19,8 +14,86 @@ export interface NotificationData {
   screen?: string;
 }
 
+/**
+ * Reads the user's in-app opt-in preference. This is distinct from the OS
+ * permission status: a user can grant OS notification permission but still
+ * choose to opt out of notifications within the app (e.g. via a settings
+ * toggle), and this preference is what we honor for that case.
+ */
+export async function getNotificationOptInPreference(): Promise<NotificationOptInPreference> {
+  try {
+    const value = await SecureStore.getItemAsync(OPT_IN_PREFERENCE_KEY);
+    if (value === "granted" || value === "denied") {
+      return value;
+    }
+    return "unset";
+  } catch {
+    return "unset";
+  }
+}
+
+async function setNotificationOptInPreference(
+  preference: NotificationOptInPreference,
+): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(OPT_IN_PREFERENCE_KEY, preference);
+  } catch {
+    // Best-effort persistence; a failure here just means we'll re-check next launch.
+  }
+}
+
+// The handler only controls how a notification is displayed once we've
+// already decided to show it (foreground alert/sound/badge). Whether we
+// register for notifications at all is gated separately by the user's
+// opt-in preference below.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+  }),
+});
+
+/**
+ * Ensures the Android notification channel exists. Safe to call multiple
+ * times and independent of permission status — channels can be configured
+ * before permission is granted.
+ */
+export async function ensureAndroidNotificationChannel(): Promise<void> {
+  if (Platform.OS !== "android") return;
+
+  await Notifications.setNotificationChannelAsync("default", {
+    name: "default",
+    importance: Notifications.AndroidImportance.MAX,
+    vibrationPattern: [0, 250, 250, 250],
+    lightColor: "#FF231F7C",
+  });
+}
+
+/**
+ * Returns the current OS-level permission status without prompting the
+ * user.
+ */
+export async function getNotificationPermissionStatus(): Promise<Notifications.PermissionStatus> {
+  const { status } = await Notifications.getPermissionsAsync();
+  return status;
+}
+
+/**
+ * Requests OS notification permission if not already determined, then
+ * (when granted) fetches and persists the Expo push token. This is the
+ * function that should back an explicit "enable notifications" opt-in
+ * action in the UI — it surfaces the native permission prompt on first
+ * call.
+ *
+ * On success, also records the user's in-app opt-in preference as
+ * "granted"; on denial, records "denied" so the UI has a single source of
+ * truth to render an opt-in prompt vs. a "notifications disabled" state.
+ */
 export async function registerForPushNotifications(): Promise<string | null> {
   try {
+    await ensureAndroidNotificationChannel();
+
     const { status: existingStatus } =
       await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
@@ -31,6 +104,7 @@ export async function registerForPushNotifications(): Promise<string | null> {
     }
 
     if (finalStatus !== "granted") {
+      await setNotificationOptInPreference("denied");
       return null;
     }
 
@@ -38,10 +112,36 @@ export async function registerForPushNotifications(): Promise<string | null> {
     const pushToken = token.data;
 
     await SecureStore.setItemAsync(PUSH_TOKEN_KEY, pushToken);
+    await setNotificationOptInPreference("granted");
     return pushToken;
   } catch {
     return null;
   }
+}
+
+/**
+ * Lets the user opt out of notifications from within the app (e.g. a
+ * settings toggle). We can't revoke OS permission programmatically, so this
+ * clears the locally stored push token and records the preference as
+ * "denied" so the app stops treating the user as subscribed (and callers
+ * should stop sending the token to the backend / re-registering it).
+ */
+export async function optOutOfNotifications(): Promise<void> {
+  await setNotificationOptInPreference("denied");
+  try {
+    await SecureStore.deleteItemAsync(PUSH_TOKEN_KEY);
+  } catch {
+    // Ignore — nothing to clean up if it was never stored.
+  }
+}
+
+/**
+ * Re-enables notifications after a prior in-app opt-out, re-registering for
+ * a push token (which may re-prompt for OS permission if it was never
+ * determined, or resolve immediately if it was already granted).
+ */
+export async function optInToNotifications(): Promise<string | null> {
+  return registerForPushNotifications();
 }
 
 export async function getStoredPushToken(): Promise<string | null> {
@@ -118,16 +218,14 @@ export async function scheduleLocalNotification(
   return identifier;
 }
 
+/**
+ * @deprecated Use `getNotificationPermissionStatus` (to check without
+ * prompting) together with `ensureAndroidNotificationChannel`, or
+ * `registerForPushNotifications` (to check-and-request in one call). Kept
+ * for backward compatibility with existing call sites.
+ */
 export async function checkNotificationPermissions(): Promise<boolean> {
-  if (Platform.OS === "android") {
-    await Notifications.setNotificationChannelAsync("default", {
-      name: "default",
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 250, 250, 250],
-      lightColor: "#FF231F7C",
-    });
-  }
-
-  const { status } = await Notifications.getPermissionsAsync();
+  await ensureAndroidNotificationChannel();
+  const status = await getNotificationPermissionStatus();
   return status === "granted";
 }


### PR DESCRIPTION
- **#938**: Adds `docs/PUBLIC_PILOT_CHECKLIST.md`, an operational checklist for launching a regional public pilot covering legal review, user onboarding, monitoring/alerting, dispute handling, and a communications plan, cross-linked with the existing `USER_RESEARCH_PLAN_PILOT_REGIONS.md`.
- **#931**: Adds `backend/src/lib/stellarPathPayment.ts` with reusable helpers for building strict-send and strict-receive Stellar path payment transactions and quoting conversion paths via Horizon, a runnable example script (`backend/scripts/path-payment-example.ts`), and docs (`backend/docs/path-payments.md`). This complements the existing strict-send quote lookup in `pathPayment.service.ts`.
- **#907**: Fixes the mobile push notification opt-in flow. Previously, `checkNotificationPermissions` returning `false` (permission not yet granted) caused the app to silently skip ever requesting permission, so first-time users were never prompted. `notification.service.ts` now separates OS permission checks from an explicit in-app opt-in/opt-out preference (`getNotificationOptInPreference`, `optInToNotifications`, `optOutOfNotifications`), adds `ensureAndroidNotificationChannel` independent of permission state, and `App.tsx` now actually triggers the permission prompt for first-time users while respecting a prior in-app opt-out on subsequent launches.

## Test plan

- [x] `backend`: added `src/__tests__/stellarPathPayment.test.ts` (6 tests, all passing) covering strict-send/strict-receive transaction building, memo attachment, path lookups, and submission.
- [x] `backend`: `npx jest src/__tests__/stellarPathPayment.test.ts` passes.
- [ ] `backend`: full `npx tsc --noEmit` / `npx jest` in this workspace has pre-existing, unrelated failures (Prisma client types not generated in this environment, e.g. `Module '"@prisma/client"' has no exported member 'TradeStatus'`) — out of scope for this PR, not introduced by these changes.
- [x] `mobile`: `npx tsc --noEmit` shows no errors in the changed files (`App.tsx`, `notification.service.ts`); remaining errors are pre-existing and unrelated (e.g. `useDeepLink.test.ts`, `AppNavigator.tsx` missing `DisputeDetailScreen`).
- [x] `mobile`: existing `src/services/__tests__` suite passes (9/9).
- [ ] Manual: verify on a real Android/iOS Expo build that a first-time user is prompted for notification permission and that opting out in-app stops re-registration on next launch.

Closes #938
Closes #931
Closes #907
Closes #863 