### PR TITLE
fix: MAX_FEE_BPS consistency, json2csv pin, staging secrets hardening

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -54,10 +54,11 @@ jobs:
         run: |
           cp .env.staging.example .env.staging
           cat >> .env.staging <<'EOF'
-          STAGING_POSTGRES_PASSWORD=${{ secrets.STAGING_POSTGRES_PASSWORD || 'staging-password' }}
-          STAGING_REDIS_PASSWORD=${{ secrets.STAGING_REDIS_PASSWORD || 'staging-redis-pass' }}
-          STAGING_DATABASE_URL=${{ secrets.STAGING_DATABASE_URL || 'postgresql://postgres:staging-password@localhost:5434/amana_staging' }}
-          JWT_SECRET=${{ secrets.STAGING_JWT_SECRET || 'ci-staging-jwt-secret-placeholder-minimum-32' }}
+          STAGING_POSTGRES_PASSWORD=${{ secrets.STAGING_POSTGRES_PASSWORD }}
+          STAGING_REDIS_PASSWORD=${{ secrets.STAGING_REDIS_PASSWORD }}
+          STAGING_DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
+          DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
+          JWT_SECRET=${{ secrets.STAGING_JWT_SECRET }}
           EOF
 
       - name: Install backend dependencies

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,7 +44,7 @@
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",
     "ioredis": "^5.10.1",
-    "json2csv": "^6.0.0-alpha.2",
+    "json2csv": "6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",
     "pino": "^10.3.1",

--- a/contracts/amana_escrow/src/lib.rs
+++ b/contracts/amana_escrow/src/lib.rs
@@ -465,7 +465,7 @@ impl EscrowContract {
         if env.storage().instance().has(&DataKey::Initialized) {
             panic!("AlreadyInitialized");
         }
-        assert!(fee_bps <= 10_000, "fee_bps must not exceed 10000");
+        assert!(fee_bps <= MAX_FEE_BPS, "fee_bps must not exceed MAX_FEE_BPS (500)");
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()


### PR DESCRIPTION
## Summary

Four assigned issues — three required fixes, one already resolved in the codebase.

---

### #839 — Smart contract: `initialize` MAX_FEE_BPS inconsistency

`initialize()` accepted `fee_bps <= 10_000` (100%) while `update_fee_bps` enforces `MAX_FEE_BPS = 500` (5%). A contract initialized with fee > 500 bps can never be corrected via the intended update path.

**Fix:** Replace the hard-coded `10_000` assertion with `MAX_FEE_BPS` so both entry points share the same limit.

Closes #839

---

### #846 — Staging workflow: hardcoded fallback credentials + DATABASE_URL mismatch

`.github/workflows/staging.yml` silently used hardcoded passwords when secrets were unset, and wrote `STAGING_DATABASE_URL` while `backend/src/config/env.ts` reads `DATABASE_URL`.

**Fix:**
- Removed all `|| 'fallback-value'` defaults — secrets are now required
- Added `DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}` so the backend can connect

Closes #846

---

### #860 — Backend: `json2csv` pinned to alpha prerelease with caret

`^6.0.0-alpha.2` allows npm to silently resolve to any higher prerelease, risking unexpected breaking changes.

**Fix:** Remove the caret — pin to exact version `6.0.0-alpha.2`.

Closes #860

---

### #875 — Frontend: API client request timeout

Already implemented in `frontend/src/lib/api/client.ts`: `DEFAULT_REQUEST_TIMEOUT_MS = 30_000`, `AbortController` with configurable `timeoutMs` option. No changes needed.

Closes #875