### PR TITLE
feat: validate required env vars at startup with clear error messages  @m1s0g1

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -99,6 +99,10 @@ AUDIT_SIGNING_PUBLIC_KEY_PEM=
 WEBHOOK_URL=
 WEBHOOK_SECRET=
 
+# Trade notes encryption (AES-256-GCM) — dedicated key, NOT derived from JWT_SECRET
+# Generate with: openssl rand -base64 32
+TRADE_NOTES_ENCRYPTION_KEY=
+
 # Ops alert webhook (cache/DB failures; separate from trade webhooks)
 ALERT_WEBHOOK_URL=
 ALERT_WEBHOOK_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   workflow_dispatch:
   push:
@@ -142,6 +146,7 @@ jobs:
         run: |
           export NODE_ENV=test
           export JWT_SECRET=test-jwt-secret-value-with-minimum-length-32
+          export TRADE_NOTES_ENCRYPTION_KEY=test-trade-notes-encryption-key-base64-32chr
           pnpm test -- --coverage
         working-directory: backend
 
@@ -245,6 +250,7 @@ jobs:
         env:
           NODE_ENV: test
           JWT_SECRET: test-jwt-secret-value-with-minimum-length-32
+          TRADE_NOTES_ENCRYPTION_KEY: test-trade-notes-encryption-key-base64-32chr
         run: pnpm test:pact
         working-directory: backend
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,5 +1,9 @@
 name: Staging Deploy
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   workflow_dispatch:
   push:
@@ -59,6 +63,7 @@ jobs:
           STAGING_DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
           DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
           JWT_SECRET=${{ secrets.STAGING_JWT_SECRET }}
+          TRADE_NOTES_ENCRYPTION_KEY=${{ secrets.STAGING_TRADE_NOTES_ENCRYPTION_KEY }}
           EOF
 
       - name: Install backend dependencies

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -89,3 +89,7 @@ ALERT_COOLDOWN_MS=300000
 # Trust Score configuration
 TRUST_SCORE_DECAY_HALF_LIFE_DAYS=90
 TRUST_SCORE_RECALCULATION_INTERVAL_MS=3600000
+
+# Trade notes encryption (AES-256-GCM) — dedicated key, NOT derived from JWT_SECRET
+# Generate with: openssl rand -base64 32
+TRADE_NOTES_ENCRYPTION_KEY=

--- a/backend/README.md
+++ b/backend/README.md
@@ -84,6 +84,31 @@ npm test
 - `src/` contains the Express server, routes, middleware, services, and docs.
 - `dist/` is the compiled output directory created by `npm run build`.
 
+## Health & Readiness Checks
+
+The backend exposes several health endpoints for monitoring and orchestration:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /health` | Aggregate health — returns `healthy`, `degraded`, or `unhealthy` based on all dependency checks |
+| `GET /health/live` | Liveness probe — always returns `200` if the process is running |
+| `GET /health/ready` | Readiness probe — returns `200` only when critical dependencies (database, Redis, config) are up |
+| `GET /health/startup` | Startup check — fails with `503` if critical dependencies are down at boot |
+| `GET /health/detail` | Per-dependency latency & status for every external service |
+
+### Dependency checks performed
+
+| Dependency | Type | Critical for startup |
+|---|---|---|
+| **Database (Supabase/Prisma)** | SQL query `SELECT 1` with 200ms timeout | Yes |
+| **Redis** | `PING` with 3s timeout | Yes |
+| **Stellar node** | `loadAccount` call with 5s timeout | No (degraded if down) |
+| **IPFS/Pinata** | `testAuthentication` with 5s timeout | No (degraded if down) |
+| **Indexer** | Latest processed ledger age (<15s threshold) | No (unhealthy if lagging) |
+| **Configuration** | Validates critical env vars are present | Yes |
+
+Startup readiness (`GET /health/startup`) fails with `503` if **database**, **Redis**, or **config** checks fail. All other dependencies report as degraded without blocking startup.
+
 ## Repository Scope
 
 This backend service lives inside the `backend/` folder of the Amana monorepo and provides the API, database, and infrastructure integration for the project.

--- a/backend/src/__tests__/env.validator.test.ts
+++ b/backend/src/__tests__/env.validator.test.ts
@@ -1,0 +1,133 @@
+import { EnvValidator, EnvVarCategory } from '../config/envValidator';
+
+describe('EnvValidator', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('validate', () => {
+    it('returns valid when all critical vars are present', () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      process.env.JWT_SECRET = 'a-32-char-secret-for-testing-purposes!';
+      process.env.AMANA_ESCROW_CONTRACT_ID = 'C1234567890';
+      process.env.USDC_CONTRACT_ID = 'C0987654321';
+      process.env.STELLAR_NETWORK = 'testnet';
+      process.env.TRADE_NOTES_ENCRYPTION_KEY = 'test-trade-notes-encryption-key-base64-32chr';
+
+      const result = EnvValidator.validate();
+      expect(result.valid).toBe(true);
+      expect(result.missing).toHaveLength(0);
+      expect(result.invalid).toHaveLength(0);
+    });
+
+    it('reports missing critical vars', () => {
+      delete process.env.DATABASE_URL;
+      delete process.env.JWT_SECRET;
+      delete process.env.AMANA_ESCROW_CONTRACT_ID;
+      delete process.env.USDC_CONTRACT_ID;
+      delete process.env.TRADE_NOTES_ENCRYPTION_KEY;
+
+      const result = EnvValidator.validate();
+      expect(result.valid).toBe(false);
+      expect(result.missing).toContain('DATABASE_URL');
+      expect(result.missing).toContain('JWT_SECRET');
+      expect(result.missing).toContain('AMANA_ESCROW_CONTRACT_ID');
+      expect(result.missing).toContain('USDC_CONTRACT_ID');
+      expect(result.missing).toContain('TRADE_NOTES_ENCRYPTION_KEY');
+    });
+
+    it('reports invalid JWT_SECRET (too short)', () => {
+      process.env.JWT_SECRET = 'short';
+
+      const result = EnvValidator.validate();
+      expect(result.valid).toBe(false);
+      expect(result.invalid).toContain('JWT_SECRET');
+    });
+
+    it('reports invalid STELLAR_NETWORK value', () => {
+      process.env.STELLAR_NETWORK = 'invalid-net';
+
+      const result = EnvValidator.validate();
+      expect(result.valid).toBe(false);
+      expect(result.invalid).toContain('STELLAR_NETWORK');
+    });
+
+    it('does not report missing optional vars', () => {
+      delete process.env.PINATA_API_KEY;
+      delete process.env.SUPABASE_URL;
+
+      const result = EnvValidator.validate();
+      expect(result.missing).not.toContain('PINATA_API_KEY');
+      expect(result.missing).not.toContain('SUPABASE_URL');
+    });
+  });
+
+  describe('validateOrFail', () => {
+    it('throws when critical vars are missing', () => {
+      delete process.env.DATABASE_URL;
+
+      expect(() => EnvValidator.validateOrFail()).toThrow(
+        'Environment validation failed',
+      );
+    });
+
+    it('does not throw when all critical vars are present', () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      process.env.JWT_SECRET = 'a-32-char-secret-for-testing-purposes!';
+      process.env.AMANA_ESCROW_CONTRACT_ID = 'C1234567890';
+      process.env.USDC_CONTRACT_ID = 'C0987654321';
+      process.env.STELLAR_NETWORK = 'testnet';
+      process.env.TRADE_NOTES_ENCRYPTION_KEY = 'test-trade-notes-encryption-key-base64-32chr';
+
+      expect(() => EnvValidator.validateOrFail()).not.toThrow();
+    });
+  });
+
+  describe('validateVar', () => {
+    it('returns valid for present critical var', () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      const result = EnvValidator.validateVar('DATABASE_URL');
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns invalid for missing critical var', () => {
+      delete process.env.DATABASE_URL;
+      const result = EnvValidator.validateVar('DATABASE_URL');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('DATABASE_URL');
+    });
+
+    it('returns valid for unknown vars', () => {
+      const result = EnvValidator.validateVar('UNKNOWN_VAR');
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('getDefinitions', () => {
+    it('returns all definitions', () => {
+      const defs = EnvValidator.getDefinitions();
+      expect(defs.length).toBeGreaterThan(0);
+      expect(defs.some((d) => d.name === 'DATABASE_URL')).toBe(true);
+      expect(defs.some((d) => d.name === 'JWT_SECRET')).toBe(true);
+    });
+  });
+
+  describe('getConfigSummary', () => {
+    it('returns a summary with masked secrets', () => {
+      process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
+      process.env.JWT_SECRET = 'super-secret-value';
+      process.env.TRADE_NOTES_ENCRYPTION_KEY = 'test-key-for-encryption-purposes-12345';
+
+      const summary = EnvValidator.getConfigSummary();
+      expect(summary.DATABASE_URL).toBe('postgresql://localhost:5432/test');
+      expect(summary.JWT_SECRET).toBe('***MASKED***');
+    });
+  });
+});

--- a/backend/src/__tests__/setup.ts
+++ b/backend/src/__tests__/setup.ts
@@ -4,3 +4,4 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret-at-least-32-char
 process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
 process.env.AMANA_ESCROW_CONTRACT_ID = process.env.AMANA_ESCROW_CONTRACT_ID || "CTEST00000000000000000000000000000000000000000000000000000";
 process.env.USDC_CONTRACT_ID = process.env.USDC_CONTRACT_ID || "CUSDC00000000000000000000000000000000000000000000000000000";
+process.env.TRADE_NOTES_ENCRYPTION_KEY = process.env.TRADE_NOTES_ENCRYPTION_KEY || "test-trade-notes-encryption-key-base64-32chr";

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -43,6 +43,10 @@ import { createAdminEvidenceVerificationRouter } from "./routes/admin.evidence-v
 import { createTrustScoreRouter } from "./routes/trust-score.routes";
 import { webhooksRoutes } from "./routes/webhooks.routes";
 import { env } from "./config/env";
+import { validateEnvironment } from "./config/envValidator";
+
+// Fail fast at boot if required environment variables are missing
+validateEnvironment();
 
 /** Parse the CORS_ORIGINS env var into a usable allowlist.
  *  Value should be a comma-separated list of allowed origins, e.g.:

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -127,6 +127,14 @@ export const envSchema = z.object({
   // Trust Score configuration
   TRUST_SCORE_DECAY_HALF_LIFE_DAYS: z.coerce.number().int().positive().default(90),
   TRUST_SCORE_RECALCULATION_INTERVAL_MS: z.coerce.number().int().positive().default(3_600_000),
+
+  // Trade notes encryption (AES-256-GCM) — dedicated key, NOT derived from JWT_SECRET
+  // Validated as critical at startup via envValidator; optional here so existing configs don't break.
+  TRADE_NOTES_ENCRYPTION_KEY: z
+    .string()
+    .min(32)
+    .optional()
+    .describe('Base64-encoded 32-byte key for AES-256-GCM trade note encryption'),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -141,6 +149,7 @@ function buildProcessEnv(): Record<string, string | undefined> {
     processEnv.USDC_CONTRACT_ID ||= 'test-usdc-contract';
     processEnv.PINATA_API_KEY ||= 'test-pinata-api-key';
     processEnv.PINATA_SECRET ||= 'test-pinata-secret';
+    processEnv.TRADE_NOTES_ENCRYPTION_KEY ||= 'test-trade-notes-encryption-key-base64-32chr';
   }
 
   return processEnv;

--- a/backend/src/config/envValidator.ts
+++ b/backend/src/config/envValidator.ts
@@ -75,6 +75,14 @@ export class EnvValidator {
       description: 'Redis connection URL',
     },
 
+    // Trade notes encryption (required for AES-256-GCM)
+    {
+      name: 'TRADE_NOTES_ENCRYPTION_KEY',
+      category: EnvVarCategory.CRITICAL,
+      description: 'Base64-encoded 32-byte key for AES-256-GCM trade note encryption',
+      validator: (value) => value.length >= 32,
+    },
+
     // Optional - nice to have
     {
       name: 'PINATA_API_KEY',

--- a/backend/src/services/encryption.service.ts
+++ b/backend/src/services/encryption.service.ts
@@ -6,7 +6,7 @@ const IV_LENGTH = 12;
 const DEFAULT_KEY_VERSION = "v1";
 
 export class EncryptionService {
-  constructor(private readonly masterSecret: string = env.JWT_SECRET) {}
+  constructor(private readonly masterSecret: string = env.TRADE_NOTES_ENCRYPTION_KEY) {}
 
   encrypt(plaintext: string, tradeId: string, keyVersion: string = DEFAULT_KEY_VERSION): string {
     const key = this.deriveKey(tradeId, keyVersion);


### PR DESCRIPTION
## Changes Implemented

Added permissions: contents: read, pull-requests: read to CI/CD workflows
Documented all health/readiness endpoints & dependency checks
Added dedicated TRADE_NOTES_ENCRYPTION_KEY env var; EncryptionService uses it instead of JWT_SECRET
Wired validateEnvironment() into app.ts at boot; added TRADE_NOTES_ENCRYPTION_KEY to critical vars; comprehensive tests

**Checklist**

- #844 — CI/CD permissions set to contents: read + pull-requests: read
- #889 — Health/readiness endpoints documented in README with full dependency table
- #836 — TRADE_NOTES_ENCRYPTION_KEY env var added; encryption service uses dedicated key
- #800 — Env validation at startup with Zod schema + envValidator; tests cover all-present, missing required, and invalid types

Closes #844
Closes #889
Closes #836
Closes #800