### PR TITLE
feat: platform fee accounting and privacy-first analytics

### DIFF
--- a/backend/prisma/migrations/20260729000001_add_platform_fee_event/migration.sql
+++ b/backend/prisma/migrations/20260729000001_add_platform_fee_event/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "PlatformFeeEvent" (
+    "id" SERIAL NOT NULL,
+    "tradeId" VARCHAR(255) NOT NULL,
+    "tradeAmountUsdc" VARCHAR(100) NOT NULL,
+    "feeUsdc" VARCHAR(100) NOT NULL,
+    "collectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ledgerSequence" INTEGER,
+
+    CONSTRAINT "PlatformFeeEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlatformFeeEvent_tradeId_key" ON "PlatformFeeEvent"("tradeId");
+
+-- CreateIndex
+CREATE INDEX "PlatformFeeEvent_collectedAt_idx" ON "PlatformFeeEvent"("collectedAt");
+
+-- CreateIndex
+CREATE INDEX "PlatformFeeEvent_tradeId_idx" ON "PlatformFeeEvent"("tradeId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -468,6 +468,21 @@ model TradeNote {
   @@index([authorAddress])
 }
 
+/// PlatformFeeEvent records the 1% platform fee deducted on each completed trade.
+/// feeUsdc is stored as a string (e.g. "1.00") to preserve decimal precision.
+/// tradeAmountUsdc is a snapshot of the trade amount at the time the fee was collected.
+model PlatformFeeEvent {
+  id                Int      @id @default(autoincrement())
+  tradeId           String   @unique @db.VarChar(255)
+  tradeAmountUsdc   String   @db.VarChar(100)
+  feeUsdc           String   @db.VarChar(100)
+  collectedAt       DateTime @default(now())
+  ledgerSequence    Int?
+
+  @@index([collectedAt])
+  @@index([tradeId])
+}
+
 /// EscrowReleaseMilestone represents one pre-defined partial release point.
 /// releasedAt is set after the matching on-chain release event is confirmed.
 model EscrowReleaseMilestone {

--- a/backend/src/__tests__/feeAccounting.service.test.ts
+++ b/backend/src/__tests__/feeAccounting.service.test.ts
@@ -1,0 +1,257 @@
+import { FeeAccountingService, FEE_RATE } from "../services/feeAccounting.service";
+
+// ─── Mock Prisma ────────────────────────────────────────────────────────────────
+
+function makeMockTx() {
+  return {
+    platformFeeEvent: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+}
+
+function makeMockDb() {
+  return {
+    platformFeeEvent: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+}
+
+describe("FeeAccountingService", () => {
+  describe("recordFee", () => {
+    it("calculates 1% fee and creates a record", async () => {
+      const tx = makeMockTx();
+      const created = {
+        id: 1,
+        tradeId: "trade-001",
+        tradeAmountUsdc: "100.00",
+        feeUsdc: "1.000000",
+        collectedAt: new Date(),
+        ledgerSequence: 42,
+      };
+      tx.platformFeeEvent.findUnique.mockResolvedValue(null);
+      tx.platformFeeEvent.create.mockResolvedValue(created);
+
+      const svc = new FeeAccountingService({} as any);
+      const result = await svc.recordFee(tx as any, "trade-001", "100.00", 42);
+
+      expect(tx.platformFeeEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tradeId: "trade-001",
+            tradeAmountUsdc: "100.00",
+            feeUsdc: (100 * FEE_RATE).toFixed(6),
+            ledgerSequence: 42,
+          }),
+        }),
+      );
+      expect(result.tradeId).toBe("trade-001");
+    });
+
+    it("is idempotent — returns existing record without re-creating", async () => {
+      const tx = makeMockTx();
+      const existing = {
+        id: 1,
+        tradeId: "trade-001",
+        tradeAmountUsdc: "100.00",
+        feeUsdc: "1.000000",
+        collectedAt: new Date(),
+        ledgerSequence: 42,
+      };
+      tx.platformFeeEvent.findUnique.mockResolvedValue(existing);
+
+      const svc = new FeeAccountingService({} as any);
+      const result = await svc.recordFee(tx as any, "trade-001", "100.00", 42);
+
+      expect(tx.platformFeeEvent.create).not.toHaveBeenCalled();
+      expect(result).toBe(existing);
+    });
+
+    it("handles non-numeric amountUsdc as zero fee", async () => {
+      const tx = makeMockTx();
+      tx.platformFeeEvent.findUnique.mockResolvedValue(null);
+      tx.platformFeeEvent.create.mockResolvedValue({
+        id: 2,
+        tradeId: "trade-002",
+        tradeAmountUsdc: "NaN",
+        feeUsdc: "0.000000",
+        collectedAt: new Date(),
+        ledgerSequence: null,
+      });
+
+      const svc = new FeeAccountingService({} as any);
+      await svc.recordFee(tx as any, "trade-002", "NaN");
+
+      expect(tx.platformFeeEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ feeUsdc: "0.000000" }),
+        }),
+      );
+    });
+
+    it("stores null ledgerSequence when not provided", async () => {
+      const tx = makeMockTx();
+      tx.platformFeeEvent.findUnique.mockResolvedValue(null);
+      tx.platformFeeEvent.create.mockResolvedValue({
+        id: 3,
+        tradeId: "trade-003",
+        tradeAmountUsdc: "50.00",
+        feeUsdc: "0.500000",
+        collectedAt: new Date(),
+        ledgerSequence: null,
+      });
+
+      const svc = new FeeAccountingService({} as any);
+      await svc.recordFee(tx as any, "trade-003", "50.00");
+
+      expect(tx.platformFeeEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ ledgerSequence: null }),
+        }),
+      );
+    });
+  });
+
+  describe("listFees", () => {
+    it("returns paginated results", async () => {
+      const db = makeMockDb();
+      const record = {
+        id: 1,
+        tradeId: "trade-001",
+        tradeAmountUsdc: "100.00",
+        feeUsdc: "1.000000",
+        collectedAt: new Date(),
+        ledgerSequence: 42,
+      };
+      db.platformFeeEvent.findMany.mockResolvedValue([record]);
+      db.platformFeeEvent.count.mockResolvedValue(1);
+
+      const svc = new FeeAccountingService(db as any);
+      const result = await svc.listFees({ page: 1, limit: 10 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.pagination.total).toBe(1);
+      expect(result.pagination.page).toBe(1);
+      expect(result.pagination.totalPages).toBe(1);
+    });
+
+    it("applies date range filter", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([]);
+      db.platformFeeEvent.count.mockResolvedValue(0);
+
+      const dateFrom = new Date("2026-01-01");
+      const dateTo = new Date("2026-12-31");
+
+      const svc = new FeeAccountingService(db as any);
+      await svc.listFees({ dateFrom, dateTo });
+
+      expect(db.platformFeeEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            collectedAt: { gte: dateFrom, lte: dateTo },
+          }),
+        }),
+      );
+    });
+
+    it("clamps limit to 100", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([]);
+      db.platformFeeEvent.count.mockResolvedValue(0);
+
+      const svc = new FeeAccountingService(db as any);
+      await svc.listFees({ limit: 9999 });
+
+      expect(db.platformFeeEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+  });
+
+  describe("aggregateFees", () => {
+    it("sums fee amounts correctly", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([
+        { feeUsdc: "1.000000" },
+        { feeUsdc: "2.500000" },
+        { feeUsdc: "0.750000" },
+      ]);
+
+      const svc = new FeeAccountingService(db as any);
+      const result = await svc.aggregateFees({});
+
+      expect(result.totalFeesUsdc).toBe("4.250000");
+      expect(result.totalTrades).toBe(3);
+      expect(result.dateFrom).toBeNull();
+      expect(result.dateTo).toBeNull();
+    });
+
+    it("returns zero total when no records exist", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([]);
+
+      const svc = new FeeAccountingService(db as any);
+      const result = await svc.aggregateFees({});
+
+      expect(result.totalFeesUsdc).toBe("0.000000");
+      expect(result.totalTrades).toBe(0);
+    });
+
+    it("includes date range in result when provided", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([]);
+
+      const dateFrom = new Date("2026-01-01T00:00:00.000Z");
+      const dateTo = new Date("2026-06-30T00:00:00.000Z");
+
+      const svc = new FeeAccountingService(db as any);
+      const result = await svc.aggregateFees({ dateFrom, dateTo });
+
+      expect(result.dateFrom).toBe(dateFrom.toISOString());
+      expect(result.dateTo).toBe(dateTo.toISOString());
+    });
+  });
+
+  describe("exportCsv", () => {
+    it("produces CSV with correct headers and rows", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([
+        {
+          id: 1,
+          tradeId: "trade-001",
+          tradeAmountUsdc: "100.00",
+          feeUsdc: "1.000000",
+          collectedAt: new Date("2026-07-01T00:00:00.000Z"),
+          ledgerSequence: 42,
+        },
+      ]);
+
+      const svc = new FeeAccountingService(db as any);
+      const csv = await svc.exportCsv({});
+
+      expect(csv).toContain('"id"');
+      expect(csv).toContain('"tradeId"');
+      expect(csv).toContain('"feeUsdc"');
+      expect(csv).toContain('"tradeAmountUsdc"');
+      expect(csv).toContain("trade-001");
+      expect(csv).toContain("1.000000");
+    });
+
+    it("returns empty CSV rows when no records", async () => {
+      const db = makeMockDb();
+      db.platformFeeEvent.findMany.mockResolvedValue([]);
+
+      const svc = new FeeAccountingService(db as any);
+      const csv = await svc.exportCsv({});
+
+      // Headers still present, no data rows beyond header
+      expect(csv).toContain('"id"');
+      const lines = csv.trim().split("\n");
+      expect(lines).toHaveLength(1); // header only
+    });
+  });
+});

--- a/backend/src/__tests__/fees.routes.test.ts
+++ b/backend/src/__tests__/fees.routes.test.ts
@@ -1,0 +1,275 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { createFeeAccountingRouter } from "../routes/fees.routes";
+import { AuthService } from "../services/auth.service";
+import { errorHandler } from "../middleware/errorHandler";
+
+// ─── Auth mocks ────────────────────────────────────────────────────────────────
+
+jest.mock("../services/auth.service", () => ({
+  AuthService: {
+    validateToken: jest.fn(async (token: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const jwtLib = require("jsonwebtoken");
+      return jwtLib.decode(token);
+    }),
+    isTokenRevoked: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+jest.mock("../lib/accessControl", () => ({
+  isMediatorAddress: jest.fn(),
+}));
+
+const { isMediatorAddress } = jest.requireMock("../lib/accessControl");
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+const adminAddress = StellarSdk.Keypair.random().publicKey();
+const nonAdminAddress = StellarSdk.Keypair.random().publicKey();
+
+function makeToken(walletAddress: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  return jwt.sign(
+    {
+      walletAddress,
+      jti: `jti-${walletAddress.slice(0, 8)}`,
+      iss: process.env.JWT_ISSUER,
+      aud: process.env.JWT_AUDIENCE,
+      nbf: now - 1,
+    },
+    process.env.JWT_SECRET!,
+    { algorithm: "HS256" },
+  );
+}
+
+const feeRecord = {
+  id: 1,
+  tradeId: "trade-001",
+  tradeAmountUsdc: "100.00",
+  feeUsdc: "1.000000",
+  collectedAt: new Date("2026-07-01T00:00:00.000Z"),
+  ledgerSequence: 42,
+};
+
+// ─── Test setup ────────────────────────────────────────────────────────────────
+
+function buildApp(mockPrisma: any) {
+  const app = express();
+  app.use(express.json());
+  app.use("/fees", createFeeAccountingRouter(mockPrisma));
+  app.use(errorHandler);
+  return app;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Fee accounting routes", () => {
+  let adminToken: string;
+  let nonAdminToken: string;
+  let mockPrisma: any;
+  let app: express.Application;
+
+  beforeAll(() => {
+    adminToken = makeToken(adminAddress);
+    nonAdminToken = makeToken(nonAdminAddress);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(AuthService, "isTokenRevoked").mockResolvedValue(false);
+
+    mockPrisma = {
+      platformFeeEvent: {
+        findMany: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+    app = buildApp(mockPrisma);
+  });
+
+  // ── Authorization ─────────────────────────────────────────────────────────
+
+  describe("GET /fees — authorization", () => {
+    it("returns 401 when no token provided", async () => {
+      const res = await request(app).get("/fees");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when non-admin token provided", async () => {
+      (isMediatorAddress as jest.Mock).mockReturnValue(false);
+      const res = await request(app)
+        .get("/fees")
+        .set("Authorization", `Bearer ${nonAdminToken}`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /fees/summary — authorization", () => {
+    it("returns 401 when no token provided", async () => {
+      const res = await request(app).get("/fees/summary");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when non-admin token provided", async () => {
+      (isMediatorAddress as jest.Mock).mockReturnValue(false);
+      const res = await request(app)
+        .get("/fees/summary")
+        .set("Authorization", `Bearer ${nonAdminToken}`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── GET /fees — JSON ────────────────────────────────────────────────────────
+
+  describe("GET /fees (JSON)", () => {
+    beforeEach(() => {
+      (isMediatorAddress as jest.Mock).mockReturnValue(true);
+    });
+
+    it("returns paginated fee list", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([feeRecord]);
+      mockPrisma.platformFeeEvent.count.mockResolvedValue(1);
+
+      const res = await request(app)
+        .get("/fees?format=json&page=1&limit=10")
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].tradeId).toBe("trade-001");
+      expect(res.body.pagination).toMatchObject({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      });
+    });
+
+    it("returns empty list when no fees recorded", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([]);
+      mockPrisma.platformFeeEvent.count.mockResolvedValue(0);
+
+      const res = await request(app)
+        .get("/fees")
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.items).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+
+    it("passes date range to the service", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([]);
+      mockPrisma.platformFeeEvent.count.mockResolvedValue(0);
+
+      const res = await request(app)
+        .get(
+          "/fees?format=json&dateFrom=2026-01-01T00:00:00.000Z&dateTo=2026-06-30T00:00:00.000Z",
+        )
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.platformFeeEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            collectedAt: {
+              gte: new Date("2026-01-01T00:00:00.000Z"),
+              lte: new Date("2026-06-30T00:00:00.000Z"),
+            },
+          }),
+        }),
+      );
+    });
+
+    it("rejects invalid date range (dateFrom after dateTo)", async () => {
+      const res = await request(app)
+        .get(
+          "/fees?dateFrom=2026-12-31T00:00:00.000Z&dateTo=2026-01-01T00:00:00.000Z",
+        )
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── GET /fees — CSV ─────────────────────────────────────────────────────────
+
+  describe("GET /fees (CSV)", () => {
+    beforeEach(() => {
+      (isMediatorAddress as jest.Mock).mockReturnValue(true);
+    });
+
+    it("returns CSV with BOM and correct headers", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([feeRecord]);
+
+      const res = await request(app)
+        .get("/fees?format=csv")
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/text\/csv/);
+      expect(res.headers["content-disposition"]).toContain(
+        "platform-fees-export.csv",
+      );
+      // BOM character
+      expect(res.text.charCodeAt(0)).toBe(0xfeff);
+      expect(res.text).toContain('"tradeId"');
+      expect(res.text).toContain('"feeUsdc"');
+      expect(res.text).toContain("trade-001");
+    });
+  });
+
+  // ── GET /fees/summary ───────────────────────────────────────────────────────
+
+  describe("GET /fees/summary", () => {
+    beforeEach(() => {
+      (isMediatorAddress as jest.Mock).mockReturnValue(true);
+    });
+
+    it("returns aggregated totals", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([
+        { feeUsdc: "1.000000" },
+        { feeUsdc: "2.500000" },
+      ]);
+
+      const res = await request(app)
+        .get("/fees/summary")
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalFeesUsdc).toBe("3.500000");
+      expect(res.body.totalTrades).toBe(2);
+      expect(res.body.dateFrom).toBeNull();
+      expect(res.body.dateTo).toBeNull();
+    });
+
+    it("includes date range in summary when provided", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([]);
+
+      const res = await request(app)
+        .get(
+          "/fees/summary?dateFrom=2026-01-01T00:00:00.000Z&dateTo=2026-06-30T00:00:00.000Z",
+        )
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.dateFrom).toBe("2026-01-01T00:00:00.000Z");
+      expect(res.body.dateTo).toBe("2026-06-30T00:00:00.000Z");
+    });
+
+    it("returns zero total when no fees collected", async () => {
+      mockPrisma.platformFeeEvent.findMany.mockResolvedValue([]);
+
+      const res = await request(app)
+        .get("/fees/summary")
+        .set("Authorization", `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalFeesUsdc).toBe("0.000000");
+      expect(res.body.totalTrades).toBe(0);
+    });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,6 +30,7 @@ import { createMetricsRouter } from "./routes/metrics.routes";
 import { disputeRoutes } from "./routes/dispute.routes";
 import { disputeCategoryRoutes } from "./routes/disputeCategory.routes";
 import { createTreasuryRouter } from "./routes/treasury.routes";
+import { createFeeAccountingRouter } from "./routes/fees.routes";
 import userRoutes from "./routes/user.routes";
 import reputationRoutes from "./routes/reputation.routes";
 import { stellarFeesRoutes } from "./routes/stellar.fees";
@@ -194,6 +195,9 @@ export function createApp(): express.Application {
 
   // Treasury management
   app.use("/treasury", createTreasuryRouter());
+
+  // Platform fee accounting & reporting (admin-only)
+  app.use("/fees", createFeeAccountingRouter());
 
   // Feature flags (admin-managed)
   app.use(createAdminFeaturesRouter());

--- a/backend/src/routes/fees.routes.ts
+++ b/backend/src/routes/fees.routes.ts
@@ -1,0 +1,101 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import { PrismaClient } from "@prisma/client";
+import { prisma as defaultPrisma } from "../lib/db";
+import { authMiddleware } from "../middleware/auth.middleware";
+import { adminMiddleware } from "../middleware/admin.middleware";
+import { validateRequest } from "../middleware/validateRequest";
+import { FeeAccountingService } from "../services/feeAccounting.service";
+import { AuthRequest } from "../services/auth.service";
+import { appLogger } from "../middleware/logger";
+
+const feesQuerySchema = z.object({
+  format: z.enum(["csv", "json"]).default("json"),
+  dateFrom: z.string().datetime().optional(),
+  dateTo: z.string().datetime().optional(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(50),
+}).refine(
+  (v) => !v.dateFrom || !v.dateTo || new Date(v.dateFrom) <= new Date(v.dateTo),
+  { message: "dateFrom must be before or equal to dateTo", path: ["dateFrom"] },
+);
+
+const aggregateQuerySchema = z.object({
+  dateFrom: z.string().datetime().optional(),
+  dateTo: z.string().datetime().optional(),
+});
+
+export function createFeeAccountingRouter(prisma: PrismaClient = defaultPrisma): Router {
+  const router = Router();
+  const feeService = new FeeAccountingService(prisma);
+
+  /**
+   * GET /fees
+   * Admin-only. Lists all platform fee events with optional date filtering.
+   * Supports ?format=csv for CSV download or ?format=json (default) for paginated JSON.
+   */
+  router.get(
+    "/",
+    authMiddleware,
+    adminMiddleware,
+    validateRequest({ query: feesQuerySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const query = req.query as unknown as z.infer<typeof feesQuerySchema>;
+        const dateFrom = query.dateFrom ? new Date(query.dateFrom) : undefined;
+        const dateTo = query.dateTo ? new Date(query.dateTo) : undefined;
+
+        if (query.format === "csv") {
+          const csv = await feeService.exportCsv({ dateFrom, dateTo });
+          res.setHeader("Content-Type", "text/csv; charset=utf-8");
+          res.setHeader(
+            "Content-Disposition",
+            "attachment; filename=\"platform-fees-export.csv\"",
+          );
+          res.status(200).send(`\ufeff${csv}`);
+          return;
+        }
+
+        const result = await feeService.listFees({
+          dateFrom,
+          dateTo,
+          page: query.page,
+          limit: query.limit,
+        });
+
+        res.status(200).json(result);
+      } catch (error) {
+        appLogger.error({ error }, "Failed to list fee events");
+        next(error);
+      }
+    },
+  );
+
+  /**
+   * GET /fees/summary
+   * Admin-only. Returns aggregated totals (total fees, total trades) for a date range.
+   */
+  router.get(
+    "/summary",
+    authMiddleware,
+    adminMiddleware,
+    validateRequest({ query: aggregateQuerySchema }),
+    async (req: AuthRequest, res: Response, next) => {
+      try {
+        const query = req.query as unknown as z.infer<typeof aggregateQuerySchema>;
+        const dateFrom = query.dateFrom ? new Date(query.dateFrom) : undefined;
+        const dateTo = query.dateTo ? new Date(query.dateTo) : undefined;
+
+        const summary = await feeService.aggregateFees({ dateFrom, dateTo });
+        res.status(200).json(summary);
+      } catch (error) {
+        appLogger.error({ error }, "Failed to aggregate fee events");
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}
+
+export const feeAccountingRoutes = createFeeAccountingRouter();

--- a/backend/src/services/eventHandlers.ts
+++ b/backend/src/services/eventHandlers.ts
@@ -3,6 +3,7 @@ import { EventType, ParsedEvent, EVENT_TO_STATUS } from "../types/events";
 import { appLogger } from "../middleware/logger";
 import { webhookService } from "./webhook.service";
 import { logEscrowEvent } from "../lib/escrowAudit";
+import { feeAccountingService } from "./feeAccounting.service";
 
 type TradeCreatePayload = {
   tradeId: string;
@@ -131,6 +132,11 @@ export async function handleFundsReleased(tx: Prisma.TransactionClient, event: P
     status: EVENT_TO_STATUS[EventType.FundsReleased],
     version: 1,
   });
+
+  // Record the 1% platform fee for this completed trade
+  const amountUsdc = event.data.amount_usdc != null ? String(event.data.amount_usdc) : "0";
+  await feeAccountingService.recordFee(tx, event.tradeId, amountUsdc, event.ledgerSequence);
+
   logEscrowEvent({
     tradeId: event.tradeId,
     eventType: "FundsReleased",
@@ -173,6 +179,11 @@ export async function handleDisputeResolved(tx: Prisma.TransactionClient, event:
     status: EVENT_TO_STATUS[EventType.DisputeResolved],
     version: 1,
   });
+
+  // Record the 1% platform fee for dispute-resolved (completed) trades
+  const amountUsdc = event.data.amount_usdc != null ? String(event.data.amount_usdc) : "0";
+  await feeAccountingService.recordFee(tx, event.tradeId, amountUsdc, event.ledgerSequence);
+
   logEscrowEvent({
     tradeId: event.tradeId,
     eventType: "DisputeResolved",

--- a/backend/src/services/feeAccounting.service.ts
+++ b/backend/src/services/feeAccounting.service.ts
@@ -1,0 +1,198 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { Parser } from "json2csv";
+import { prisma as defaultPrisma } from "../lib/db";
+import { appLogger } from "../middleware/logger";
+
+export const FEE_RATE = 0.01; // 1% platform fee
+
+export interface FeeEventRecord {
+  id: number;
+  tradeId: string;
+  tradeAmountUsdc: string;
+  feeUsdc: string;
+  collectedAt: Date;
+  ledgerSequence: number | null;
+}
+
+export interface FeeAggregation {
+  totalFeesUsdc: string;
+  totalTrades: number;
+  dateFrom: string | null;
+  dateTo: string | null;
+}
+
+export interface FeeListResult {
+  items: FeeEventRecord[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export class FeeAccountingService {
+  constructor(private readonly db: PrismaClient = defaultPrisma) {}
+
+  /**
+   * Calculate and record the 1% platform fee for a completed trade.
+   * Idempotent: if a fee event already exists for this tradeId, it is a no-op
+   * and returns the existing record.
+   */
+  async recordFee(
+    tx: Prisma.TransactionClient,
+    tradeId: string,
+    tradeAmountUsdc: string,
+    ledgerSequence?: number,
+  ): Promise<FeeEventRecord> {
+    const existing = await tx.platformFeeEvent.findUnique({
+      where: { tradeId },
+    });
+
+    if (existing) {
+      appLogger.debug(
+        { tradeId },
+        "[FeeAccounting] Fee already recorded, skipping duplicate",
+      );
+      return existing;
+    }
+
+    const amount = parseFloat(tradeAmountUsdc);
+    const fee = Number.isFinite(amount) ? amount * FEE_RATE : 0;
+    const feeUsdc = fee.toFixed(6);
+
+    const record = await tx.platformFeeEvent.create({
+      data: {
+        tradeId,
+        tradeAmountUsdc,
+        feeUsdc,
+        ledgerSequence: ledgerSequence ?? null,
+        collectedAt: new Date(),
+      },
+    });
+
+    appLogger.info(
+      { tradeId, tradeAmountUsdc, feeUsdc, ledgerSequence },
+      "[FeeAccounting] Platform fee recorded",
+    );
+
+    return record;
+  }
+
+  /**
+   * List fee events with optional date range filtering and pagination.
+   */
+  async listFees(params: {
+    dateFrom?: Date;
+    dateTo?: Date;
+    page?: number;
+    limit?: number;
+  }): Promise<FeeListResult> {
+    const page = Math.max(1, params.page ?? 1);
+    const limit = Math.min(100, Math.max(1, params.limit ?? 50));
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.PlatformFeeEventWhereInput = {};
+    if (params.dateFrom || params.dateTo) {
+      where.collectedAt = {
+        ...(params.dateFrom ? { gte: params.dateFrom } : {}),
+        ...(params.dateTo ? { lte: params.dateTo } : {}),
+      };
+    }
+
+    const [items, total] = await Promise.all([
+      this.db.platformFeeEvent.findMany({
+        where,
+        orderBy: [{ collectedAt: "desc" }, { id: "desc" }],
+        skip,
+        take: limit,
+      }),
+      this.db.platformFeeEvent.count({ where }),
+    ]);
+
+    return {
+      items,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    };
+  }
+
+  /**
+   * Aggregate total fees collected within an optional date range.
+   */
+  async aggregateFees(params: {
+    dateFrom?: Date;
+    dateTo?: Date;
+  }): Promise<FeeAggregation> {
+    const where: Prisma.PlatformFeeEventWhereInput = {};
+    if (params.dateFrom || params.dateTo) {
+      where.collectedAt = {
+        ...(params.dateFrom ? { gte: params.dateFrom } : {}),
+        ...(params.dateTo ? { lte: params.dateTo } : {}),
+      };
+    }
+
+    const records = await this.db.platformFeeEvent.findMany({
+      where,
+      select: { feeUsdc: true },
+    });
+
+    const total = records.reduce((sum, r) => {
+      const v = parseFloat(r.feeUsdc);
+      return sum + (Number.isFinite(v) ? v : 0);
+    }, 0);
+
+    return {
+      totalFeesUsdc: total.toFixed(6),
+      totalTrades: records.length,
+      dateFrom: params.dateFrom?.toISOString() ?? null,
+      dateTo: params.dateTo?.toISOString() ?? null,
+    };
+  }
+
+  /**
+   * Export all fee events in the date range as a CSV string.
+   */
+  async exportCsv(params: { dateFrom?: Date; dateTo?: Date }): Promise<string> {
+    const where: Prisma.PlatformFeeEventWhereInput = {};
+    if (params.dateFrom || params.dateTo) {
+      where.collectedAt = {
+        ...(params.dateFrom ? { gte: params.dateFrom } : {}),
+        ...(params.dateTo ? { lte: params.dateTo } : {}),
+      };
+    }
+
+    const records = await this.db.platformFeeEvent.findMany({
+      where,
+      orderBy: [{ collectedAt: "desc" }, { id: "desc" }],
+    });
+
+    const rows = records.map((r) => ({
+      id: r.id,
+      tradeId: r.tradeId,
+      tradeAmountUsdc: r.tradeAmountUsdc,
+      feeUsdc: r.feeUsdc,
+      collectedAt: r.collectedAt.toISOString(),
+      ledgerSequence: r.ledgerSequence ?? "",
+    }));
+
+    const parser = new Parser({
+      fields: [
+        "id",
+        "tradeId",
+        "tradeAmountUsdc",
+        "feeUsdc",
+        "collectedAt",
+        "ledgerSequence",
+      ],
+    });
+
+    return parser.parse(rows);
+  }
+}
+
+export const feeAccountingService = new FeeAccountingService();

--- a/frontend/docs/analytics.md
+++ b/frontend/docs/analytics.md
@@ -1,0 +1,157 @@
+# Analytics & Privacy
+
+Amana uses a privacy-first, opt-out analytics layer to collect anonymous usage
+telemetry. No personally identifiable information (PII) is ever sent.
+
+---
+
+## What is collected
+
+| Event | Properties sent | PII? |
+|-------|----------------|------|
+| `page_view` | Route name (e.g. `/trades`) | No |
+| `funnel_step` (trade creation) | Step name (`details`, `negotiation`, `review`, `submitted`, `confirmed`) | No |
+| `trade_status_change` | New status label | No |
+| `dispute_event` | Action label (`initiated`, `evidence_uploaded`, `resolved`) | No |
+| `auth_event` | Step name + `success`/`failed` | No |
+| `api_failure` | Endpoint path + HTTP status code | No |
+| `ui_failure` | Error type label | No |
+
+## What is never collected
+
+- Wallet addresses or Stellar public keys
+- Trade amounts, fee values, or any financial data
+- User names, email addresses, or phone numbers
+- IP addresses
+- Browser fingerprints or device identifiers
+- Query parameters from URLs
+
+All payloads are passed through `scrubProperties()` in
+`frontend/src/lib/analytics.ts` before dispatch, which automatically redacts
+strings matching email, IP, and wallet-address patterns, as well as any
+properties whose key contains sensitive terms (`email`, `name`, `wallet`,
+`token`, etc.).
+
+---
+
+## Analytics providers
+
+The provider is selected via the `NEXT_PUBLIC_ANALYTICS_PROVIDER` environment
+variable:
+
+| Value | Behaviour |
+|-------|-----------|
+| `plausible` | Sends events to Plausible via `window.plausible`. Requires the Plausible script on the page. |
+| `custom` | POSTs JSON to `NEXT_PUBLIC_ANALYTICS_ENDPOINT` via `navigator.sendBeacon` (fallback: `fetch`). |
+| *(unset)* | No-op in production; logs to `console.debug` in development. |
+
+---
+
+## How to opt out
+
+### In the UI
+
+Go to **Settings → Privacy & Analytics** and toggle **Usage analytics** off.
+The preference is stored in `localStorage` under the key `amana_analytics_opt_out`
+and takes effect immediately — no page reload required.
+
+### Programmatically
+
+```ts
+import { setAnalyticsOptOut, isAnalyticsOptedOut } from "@/lib/analytics";
+
+// Opt out
+setAnalyticsOptOut(true);
+
+// Check current preference
+isAnalyticsOptedOut(); // → true
+
+// Opt back in
+setAnalyticsOptOut(false);
+```
+
+The `publishEvent` function in `analytics.ts` checks `isAnalyticsOptedOut()`
+before every dispatch, so opting out suppresses all subsequent events for the
+session.
+
+---
+
+## Using the analytics functions
+
+```ts
+import {
+  trackPageView,
+  trackTradeCreationStep,
+  trackTradeStatusChange,
+  trackDisputeEvent,
+  trackAuthEvent,
+  trackFailure,
+  trackApiFailure,
+} from "@/lib/analytics";
+
+// Page view (use route segment, never include IDs or query params with PII)
+trackPageView("/trades");
+
+// Trade creation funnel
+trackTradeCreationStep("details");       // step 1 started
+trackTradeCreationStep("negotiation");   // step 2
+trackTradeCreationStep("review");        // step 3
+trackTradeCreationStep("submitted");     // form submitted
+
+// Trade status change
+trackTradeStatusChange("FUNDED");
+trackTradeStatusChange("COMPLETED");
+
+// Dispute flow
+trackDisputeEvent("initiated");
+trackDisputeEvent("evidence_uploaded");
+trackDisputeEvent("resolved");
+
+// Auth events
+trackAuthEvent("wallet_connect", "started");
+trackAuthEvent("challenge_sign", "success");
+
+// Errors
+trackFailure("dispute_modal_crash");
+trackApiFailure("/trades", 500);
+```
+
+Or via the React context (recommended inside components):
+
+```tsx
+import { useAnalytics } from "@/components/AnalyticsProvider";
+
+function TradeDetailPage() {
+  const { trackTradeStatusChange, trackDisputeEvent } = useAnalytics();
+
+  // ...
+  trackTradeStatusChange("DISPUTED");
+  trackDisputeEvent("initiated");
+}
+```
+
+---
+
+## Architecture
+
+```
+analytics.ts
+├── scrubProperties()           — strips PII from any payload
+├── isAnalyticsOptedOut()       — reads localStorage opt-out flag
+├── setAnalyticsOptOut()        — writes localStorage opt-out flag
+├── publishEvent()              — dispatches (no-op when opted out)
+│   ├── sendToPlausible()       — plausible provider
+│   └── sendToCustomEndpoint()  — custom provider (sendBeacon / fetch)
+├── trackEvent()                — generic event
+├── trackFunnelStep()           — funnel wrapper
+├── trackPageView()             — page view
+├── trackTradeCreationStep()    — trade creation funnel
+├── trackTradeStatusChange()    — trade status change
+├── trackDisputeEvent()         — dispute lifecycle
+├── trackAuthEvent()            — auth flow
+├── trackFailure()              — UI errors
+└── trackApiFailure()           — API errors
+
+AnalyticsProvider.tsx           — React context wrapping all functions
+settings/page.tsx               — opt-out toggle (Privacy & Analytics section)
+```

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useLocaleStore } from "@/stores/localeStore";
 import type { Locale } from "@/i18n";
+import { isAnalyticsOptedOut, setAnalyticsOptOut } from "@/lib/analytics";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -181,6 +182,17 @@ export default function SettingsPage() {
   const [validationErrors, setValidationErrors] = useState<ValidationErrors>(
     {},
   );
+  const [analyticsOptOut, setAnalyticsOptOutState] = useState(false);
+
+  // Hydrate opt-out state from localStorage after mount (SSR-safe)
+  useEffect(() => {
+    setAnalyticsOptOutState(isAnalyticsOptedOut());
+  }, []);
+
+  function handleAnalyticsOptOutChange(optOut: boolean) {
+    setAnalyticsOptOut(optOut);
+    setAnalyticsOptOutState(optOut);
+  }
 
   function setNotif<K extends keyof NotificationPrefs>(
     key: K,
@@ -559,6 +571,42 @@ export default function SettingsPage() {
                 {t("settings.preferences.saved")}
               </span>
             )}
+          </div>
+        </SectionCard>
+
+        {/* ── Privacy & Analytics ── */}
+        <SectionCard
+          title="Privacy & Analytics"
+          description="Control how Amana collects anonymous usage data to improve the platform."
+        >
+          <div className="space-y-4">
+            <Toggle
+              label="Usage analytics"
+              description="Allow Amana to collect anonymous, aggregated usage telemetry — no wallet addresses, names, or financial data are ever sent. See the privacy policy for full details."
+              checked={!analyticsOptOut}
+              onChange={(enabled) => handleAnalyticsOptOutChange(!enabled)}
+            />
+            <Divider />
+            <div className="rounded-xl border border-border-default bg-bg-elevated px-4 py-3 space-y-1.5">
+              <p className="text-xs font-semibold text-text-primary uppercase tracking-widest">
+                What we collect
+              </p>
+              <ul className="text-xs text-text-secondary space-y-1 list-disc list-inside">
+                <li>Page views (route names only, no query params)</li>
+                <li>Trade funnel step completions (no amounts or addresses)</li>
+                <li>UI errors and failed API calls (endpoint + status code only)</li>
+                <li>Auth flow events (step name + success/failure)</li>
+              </ul>
+              <p className="text-xs font-semibold text-text-primary uppercase tracking-widest mt-3">
+                What we never collect
+              </p>
+              <ul className="text-xs text-text-secondary space-y-1 list-disc list-inside">
+                <li>Wallet addresses or public keys</li>
+                <li>Trade amounts or financial data</li>
+                <li>Names, email addresses, or IP addresses</li>
+                <li>Any personally identifiable information (PII)</li>
+              </ul>
+            </div>
           </div>
         </SectionCard>
 

--- a/frontend/src/components/AnalyticsProvider.tsx
+++ b/frontend/src/components/AnalyticsProvider.tsx
@@ -2,11 +2,17 @@
 
 import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
 import {
+  isAnalyticsOptedOut,
+  setAnalyticsOptOut,
   trackApiFailure,
   trackAuthEvent,
+  trackDisputeEvent,
   trackEvent,
   trackFailure,
   trackFunnelStep,
+  trackPageView,
+  trackTradeCreationStep,
+  trackTradeStatusChange,
 } from "@/lib/analytics";
 
 interface AnalyticsContextValue {
@@ -15,6 +21,12 @@ interface AnalyticsContextValue {
   trackFailure: (errorType: string, metadata?: Record<string, unknown>) => void;
   trackApiFailure: (endpoint: string, status: number, metadata?: Record<string, unknown>) => void;
   trackAuthEvent: (step: string, status: "started" | "success" | "failed", metadata?: Record<string, unknown>) => void;
+  trackPageView: (page: string) => void;
+  trackTradeCreationStep: (step: string, metadata?: Record<string, unknown>) => void;
+  trackTradeStatusChange: (toStatus: string, metadata?: Record<string, unknown>) => void;
+  trackDisputeEvent: (action: string, metadata?: Record<string, unknown>) => void;
+  isOptedOut: () => boolean;
+  setOptOut: (optOut: boolean) => void;
 }
 
 const AnalyticsContext = createContext<AnalyticsContextValue | null>(null);
@@ -24,36 +36,67 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
     (eventName: string, payload: Record<string, unknown> = {}) => {
       trackEvent(eventName, payload);
     },
-    []
+    [],
   );
 
   const trackFunnel = useCallback(
     (step: string, metadata: Record<string, unknown> = {}) => {
       trackFunnelStep(step, metadata);
     },
-    []
+    [],
   );
 
   const trackFailureCallback = useCallback(
     (errorType: string, metadata: Record<string, unknown> = {}) => {
       trackFailure(errorType, metadata);
     },
-    []
+    [],
   );
 
   const trackApiFailureCallback = useCallback(
     (endpoint: string, status: number, metadata: Record<string, unknown> = {}) => {
       trackApiFailure(endpoint, status, metadata);
     },
-    []
+    [],
   );
 
   const trackAuthEventCallback = useCallback(
     (step: string, status: "started" | "success" | "failed", metadata: Record<string, unknown> = {}) => {
       trackAuthEvent(step, status, metadata);
     },
-    []
+    [],
   );
+
+  const trackPageViewCallback = useCallback((page: string) => {
+    trackPageView(page);
+  }, []);
+
+  const trackTradeCreationStepCallback = useCallback(
+    (step: string, metadata: Record<string, unknown> = {}) => {
+      trackTradeCreationStep(step, metadata);
+    },
+    [],
+  );
+
+  const trackTradeStatusChangeCallback = useCallback(
+    (toStatus: string, metadata: Record<string, unknown> = {}) => {
+      trackTradeStatusChange(toStatus, metadata);
+    },
+    [],
+  );
+
+  const trackDisputeEventCallback = useCallback(
+    (action: string, metadata: Record<string, unknown> = {}) => {
+      trackDisputeEvent(action, metadata);
+    },
+    [],
+  );
+
+  const isOptedOut = useCallback(() => isAnalyticsOptedOut(), []);
+
+  const setOptOut = useCallback((optOut: boolean) => {
+    setAnalyticsOptOut(optOut);
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -62,8 +105,26 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
       trackFailure: trackFailureCallback,
       trackApiFailure: trackApiFailureCallback,
       trackAuthEvent: trackAuthEventCallback,
+      trackPageView: trackPageViewCallback,
+      trackTradeCreationStep: trackTradeCreationStepCallback,
+      trackTradeStatusChange: trackTradeStatusChangeCallback,
+      trackDisputeEvent: trackDisputeEventCallback,
+      isOptedOut,
+      setOptOut,
     }),
-    [trackEventCallback, trackFailureCallback, trackFunnel, trackApiFailureCallback, trackAuthEventCallback]
+    [
+      trackEventCallback,
+      trackFailureCallback,
+      trackFunnel,
+      trackApiFailureCallback,
+      trackAuthEventCallback,
+      trackPageViewCallback,
+      trackTradeCreationStepCallback,
+      trackTradeStatusChangeCallback,
+      trackDisputeEventCallback,
+      isOptedOut,
+      setOptOut,
+    ],
   );
 
   return <AnalyticsContext.Provider value={value}>{children}</AnalyticsContext.Provider>;

--- a/frontend/src/lib/__tests__/analytics.test.ts
+++ b/frontend/src/lib/__tests__/analytics.test.ts
@@ -1,7 +1,38 @@
-import { scrubProperties } from "@/lib/analytics";
+import {
+  isAnalyticsOptedOut,
+  scrubProperties,
+  setAnalyticsOptOut,
+  trackDisputeEvent,
+  trackEvent,
+  trackPageView,
+  trackTradeCreationStep,
+  trackTradeStatusChange,
+} from "@/lib/analytics";
 
-describe("analytics scrubProperties", () => {
-  it("should redact sensitive keys", () => {
+// ─── localStorage mock ────────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+// ─── scrubProperties ──────────────────────────────────────────────────────────
+
+describe("scrubProperties", () => {
+  it("redacts sensitive keys", () => {
     const input = {
       email: "alice@example.com",
       firstName: "Alice",
@@ -17,7 +48,7 @@ describe("analytics scrubProperties", () => {
     expect(output.safeValue).toBe("hello");
   });
 
-  it("should redact embedded PII patterns", () => {
+  it("redacts embedded PII patterns in string values", () => {
     const input = {
       message: "Contact bob@domain.com for support",
       ip: "192.168.0.1",
@@ -31,5 +62,171 @@ describe("analytics scrubProperties", () => {
     expect(output.message).toBe("[REDACTED]");
     expect(output.ip).toBe("[REDACTED]");
     expect((output.nested as { wallet: string }).wallet).toBe("[REDACTED]");
+  });
+
+  it("passes through safe scalar values unchanged", () => {
+    const input = { step: "details", count: 3, flag: true };
+    const output = scrubProperties(input);
+    expect(output.step).toBe("details");
+    expect(output.count).toBe(3);
+    expect(output.flag).toBe(true);
+  });
+
+  it("redacts array items that contain PII", () => {
+    const input = { tags: ["bob@domain.com", "safe-label"] };
+    const output = scrubProperties(input);
+    const tags = output.tags as string[];
+    expect(tags[0]).toBe("[REDACTED]");
+    expect(tags[1]).toBe("safe-label");
+  });
+});
+
+// ─── Opt-out helpers ──────────────────────────────────────────────────────────
+
+describe("analytics opt-out", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("is opted in by default", () => {
+    expect(isAnalyticsOptedOut()).toBe(false);
+  });
+
+  it("persists opt-out to localStorage", () => {
+    setAnalyticsOptOut(true);
+    expect(isAnalyticsOptedOut()).toBe(true);
+    expect(localStorageMock.getItem("amana_analytics_opt_out")).toBe("true");
+  });
+
+  it("removes the key when opting back in", () => {
+    setAnalyticsOptOut(true);
+    setAnalyticsOptOut(false);
+    expect(isAnalyticsOptedOut()).toBe(false);
+    expect(localStorageMock.getItem("amana_analytics_opt_out")).toBeNull();
+  });
+});
+
+// ─── publishEvent respects opt-out ────────────────────────────────────────────
+
+describe("publishEvent respects opt-out", () => {
+  const consoleSpy = jest
+    .spyOn(console, "debug")
+    .mockImplementation(() => {});
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    consoleSpy.mockClear();
+    (process.env as Record<string, string>).NODE_ENV = "development";
+  });
+
+  afterAll(() => {
+    consoleSpy.mockRestore();
+    (process.env as Record<string, string>).NODE_ENV = originalEnv;
+  });
+
+  it("emits console.debug in development when opted in", () => {
+    setAnalyticsOptOut(false);
+    trackEvent("test_event", { foo: "bar" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Analytics event:",
+      "test_event",
+      expect.any(Object),
+    );
+  });
+
+  it("suppresses all events when opted out", () => {
+    setAnalyticsOptOut(true);
+    trackEvent("test_event", { foo: "bar" });
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Trade lifecycle tracking helpers ────────────────────────────────────────
+// Use a custom endpoint provider so events are dispatched via fetch.
+// We assign a mock fetch to global since jsdom may not provide it.
+
+describe("trade lifecycle tracking helpers", () => {
+  let originalProvider: string | undefined;
+  let originalEndpoint: string | undefined;
+  let mockFetch: jest.Mock;
+
+  beforeAll(() => {
+    originalProvider = process.env.NEXT_PUBLIC_ANALYTICS_PROVIDER;
+    originalEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+    (process.env as Record<string, string>).NEXT_PUBLIC_ANALYTICS_PROVIDER = "custom";
+    (process.env as Record<string, string>).NEXT_PUBLIC_ANALYTICS_ENDPOINT =
+      "https://analytics.example.com/events";
+
+    // Stub sendBeacon to return false so the code falls through to fetch
+    Object.defineProperty(navigator, "sendBeacon", {
+      writable: true,
+      configurable: true,
+      value: jest.fn().mockReturnValue(false),
+    });
+  });
+
+  afterAll(() => {
+    if (originalProvider === undefined) {
+      delete (process.env as Record<string, string>).NEXT_PUBLIC_ANALYTICS_PROVIDER;
+    } else {
+      (process.env as Record<string, string>).NEXT_PUBLIC_ANALYTICS_PROVIDER = originalProvider;
+    }
+    if (originalEndpoint === undefined) {
+      delete (process.env as Record<string, string>).NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+    } else {
+      (process.env as Record<string, string>).NEXT_PUBLIC_ANALYTICS_ENDPOINT = originalEndpoint;
+    }
+  });
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    // Assign mock fetch directly to global so the module can call it
+    mockFetch = jest.fn().mockResolvedValue({ ok: true });
+    (global as unknown as Record<string, unknown>).fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    delete (global as unknown as Record<string, unknown>).fetch;
+  });
+
+  it("trackPageView dispatches an event when opted in", () => {
+    setAnalyticsOptOut(false);
+    trackPageView("/trades");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://analytics.example.com/events");
+  });
+
+  it("trackTradeCreationStep dispatches an event when opted in", () => {
+    setAnalyticsOptOut(false);
+    trackTradeCreationStep("details");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("trackTradeCreationStep with metadata dispatches an event", () => {
+    setAnalyticsOptOut(false);
+    trackTradeCreationStep("review", { hasManifest: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("trackTradeStatusChange dispatches an event when opted in", () => {
+    setAnalyticsOptOut(false);
+    trackTradeStatusChange("FUNDED");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("trackDisputeEvent dispatches an event when opted in", () => {
+    setAnalyticsOptOut(false);
+    trackDisputeEvent("initiated");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("all helpers are suppressed when opted out", () => {
+    setAnalyticsOptOut(true);
+    trackPageView("/trades");
+    trackTradeCreationStep("details");
+    trackTradeStatusChange("COMPLETED");
+    trackDisputeEvent("resolved");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 type AnalyticsPayload = Record<string, unknown>;
+type AnalyticsPayload = Record<string, unknown>;
 
 type AnalyticsEvent = {
   eventName: string;
@@ -23,6 +24,28 @@ const SENSITIVE_KEYS = [
 const EMAIL_REGEX = /\b[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}\b/;
 const IP_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
 const WALLET_REGEX = /\b0x[a-fA-F0-9]{40}\b|\b[46][a-zA-Z0-9]{48,56}\b/;
+
+// ─── Opt-out ──────────────────────────────────────────────────────────────────
+
+const OPT_OUT_KEY = "amana_analytics_opt_out";
+
+/** Returns true when the user has opted out of analytics. */
+export function isAnalyticsOptedOut(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(OPT_OUT_KEY) === "true";
+}
+
+/** Persist the user's analytics opt-out preference to localStorage. */
+export function setAnalyticsOptOut(optOut: boolean): void {
+  if (typeof window === "undefined") return;
+  if (optOut) {
+    localStorage.setItem(OPT_OUT_KEY, "true");
+  } else {
+    localStorage.removeItem(OPT_OUT_KEY);
+  }
+}
+
+// ─── PII scrubbing ─────────────────────────────────────────────────────────── 
 
 function scrubValue(value: unknown): unknown {
   if (typeof value === "string") {
@@ -102,6 +125,9 @@ function sendToCustomEndpoint(eventName: string, payload: AnalyticsPayload) {
 }
 
 function publishEvent(event: AnalyticsEvent): void {
+  // Respect user opt-out preference
+  if (isAnalyticsOptedOut()) return;
+
   const payload = event.payload ?? {};
   const provider = getAnalyticsProvider();
 
@@ -143,6 +169,49 @@ export function trackApiFailure(endpoint: string, status: number, metadata: Anal
 
 export function trackAuthEvent(step: string, status: "started" | "success" | "failed", metadata: AnalyticsPayload = {}): void {
   trackEvent("auth_event", { step, status, ...scrubProperties(metadata) });
+}
+
+// ─── Trade lifecycle instrumentation ─────────────────────────────────────────
+
+/**
+ * Track a page view. The path should never contain PII — only route segments
+ * like "/trades/[id]" (with the real ID stripped) are safe to send.
+ */
+export function trackPageView(page: string): void {
+  trackEvent("page_view", { page });
+}
+
+/**
+ * Track a step in the trade creation funnel.
+ * step: "details" | "negotiation" | "review" | "submitted" | "confirmed"
+ */
+export function trackTradeCreationStep(
+  step: string,
+  metadata: AnalyticsPayload = {},
+): void {
+  trackFunnelStep(`trade_create:${step}`, metadata);
+}
+
+/**
+ * Track a trade lifecycle transition (status change).
+ * No addresses or amounts are included — only the status label.
+ */
+export function trackTradeStatusChange(
+  toStatus: string,
+  metadata: AnalyticsPayload = {},
+): void {
+  trackEvent("trade_status_change", { toStatus, ...metadata });
+}
+
+/**
+ * Track a dispute lifecycle event.
+ * action: "initiated" | "evidence_uploaded" | "resolved"
+ */
+export function trackDisputeEvent(
+  action: string,
+  metadata: AnalyticsPayload = {},
+): void {
+  trackEvent("dispute_event", { action, ...metadata });
 }
 /**
  * Privacy-Safe Analytics Utility


### PR DESCRIPTION
## Summary

Closes #932 and closes #933

---

## Backend — #932: Platform fee accounting and reporting

### Schema
- New `PlatformFeeEvent` model in `prisma/schema.prisma` with migration `20260729000001_add_platform_fee_event`
- Stores: `tradeId` (unique), `tradeAmountUsdc`, `feeUsdc` (1%), `collectedAt`, `ledgerSequence`

### Service (`feeAccounting.service.ts`)
- `recordFee(tx, tradeId, amount, ledger)` — idempotent, runs inside the existing event-handler transaction
- `listFees({ dateFrom, dateTo, page, limit })` — paginated list with optional date range
- `aggregateFees({ dateFrom, dateTo })` — total fees collected + trade count
- `exportCsv({ dateFrom, dateTo })` — BOM-prefixed CSV via json2csv

### Event hooks (`eventHandlers.ts`)
Fee recording is called in `handleFundsReleased` and `handleDisputeResolved` — the two paths that mark a trade COMPLETED.

### Routes (`/fees`, admin-only)
| Method | Path | Description |
|--------|------|-------------|
| GET | `/fees` | Paginated JSON list or CSV download (`?format=csv`) |
| GET | `/fees/summary` | Aggregated totals (totalFeesUsdc, totalTrades) |

Both routes require `authMiddleware` + `adminMiddleware` (ADMIN_STELLAR_PUBKEYS). Query params: `dateFrom`, `dateTo` (ISO 8601). `/fees` also accepts `page`, `limit`, `format`.

### Tests
- `src/__tests__/feeAccounting.service.test.ts` — 12 tests (fee calculation, idempotency, pagination, aggregation, CSV)
- `src/__tests__/fees.routes.test.ts` — 12 tests (401/403 auth gates, JSON list, CSV download, summary, date filters)

---

## Frontend — #933: Privacy-first analytics instrumentation

### `src/lib/analytics.ts`
- `isAnalyticsOptedOut()` / `setAnalyticsOptOut(optOut)` — localStorage-backed opt-out (`amana_analytics_opt_out`)
- `publishEvent()` now checks opt-out before every dispatch
- New trade lifecycle helpers (status labels and route names only — no PII):
  - `trackPageView(page)`
  - `trackTradeCreationStep(step, metadata?)`
  - `trackTradeStatusChange(toStatus, metadata?)`
  - `trackDisputeEvent(action, metadata?)`

### `AnalyticsProvider.tsx`
Exposes all new functions plus `isOptedOut` and `setOptOut` through the existing React context.

### `settings/page.tsx`
New **Privacy & Analytics** section with:
- Toggle to enable/disable usage analytics (persisted to localStorage, hydrated after mount)
- Inline disclosure panel listing exactly what is and is not collected

### `frontend/docs/analytics.md`
Full documentation: event table, PII guarantees, provider config, opt-out UI + programmatic API, usage examples, architecture overview.

### Tests
- `src/lib/__tests__/analytics.test.ts` — 15 tests (scrubProperties PII redaction, opt-out persistence, publishEvent suppression, dispatch verification for all 4 lifecycle helpers)

---

## What was tested
- Backend: **24 tests passing** (12 service unit + 12 route integration)
- Frontend: **15 tests passing**
- Prisma client regenerated from updated schema

closes #932 
closes #933 